### PR TITLE
chore: remove volumes from docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,10 +3,6 @@ services:
   # Define the service, which is used in pipeline.yml
   baseui:
     build: .
-    volumes:
-      # Mount the current source directory (if not copied in Dockerfile)
-      - .:/baseui
-      - /baseui/node_modules/
     environment:
       # Pass through any necessary environment variables
       - CODECOV_TOKEN


### PR DESCRIPTION
These volumes are occasionally leveraged for Dockerfile layer caching, but are not needed for BaseUI as we add all necessary files within the Dockerfile. Remove the mounts to reduce unnecessary config.