### PR TITLE
chore: shared enzyme setup and snapshot testing

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  rootDir: 'src',
+  setupFiles: ['<rootDir>/utils/test-setup.js'],
+  testEnvironment: 'jsdom',
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  snapshotSerializers: ['enzyme-to-json/serializer'],
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,11 @@
   "name": "baseui",
   "version": "0.0.1",
   "description": "React implementation of uber design components platform.",
-  "keywords": ["react", "uber", "base-ui"],
+  "keywords": [
+    "react",
+    "uber",
+    "base-ui"
+  ],
   "author": "",
   "license": "MIT",
   "bugs": {
@@ -46,6 +50,7 @@
     "babel-preset-stage-1": "^6.24.1",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future",
+    "enzyme-to-json": "^3.3.4",
     "eslint": "^4.18.2",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-uber-universal-stage-3": "^1.0.0-rc.7",

--- a/src/button/__snapshots__/index.test.js.snap
+++ b/src/button/__snapshots__/index.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<Button /> 1`] = `
+<button
+  onClick={[Function]}
+>
+  it is a button!
+</button>
+`;

--- a/src/button/index.test.js
+++ b/src/button/index.test.js
@@ -1,14 +1,11 @@
 // @flow
-
 import React from 'react';
-import Enzyme, {shallow} from 'enzyme';
-import Adapter from 'enzyme-adapter-react-16';
+import {shallow} from 'enzyme';
 
 import Button from './index';
-
-Enzyme.configure({adapter: new Adapter()});
 
 test('<Button />', () => {
   const wrapper = shallow(<Button onClick={() => {}} />);
   expect(wrapper.text()).toBe('it is a button!');
+  expect(wrapper).toMatchSnapshot();
 });

--- a/src/utils/test-setup.js
+++ b/src/utils/test-setup.js
@@ -1,0 +1,4 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+
+Enzyme.configure({adapter: new Adapter()});

--- a/yarn.lock
+++ b/yarn.lock
@@ -3178,6 +3178,12 @@ enzyme-adapter-utils@^1.3.0:
     object.assign "^4.0.4"
     prop-types "^15.6.0"
 
+enzyme-to-json@^3.3.4:
+  version "3.3.4"
+  resolved "https://registry.yarnpkg.com/enzyme-to-json/-/enzyme-to-json-3.3.4.tgz#67c6040e931182f183418af2eb9f4323258aa77f"
+  dependencies:
+    lodash "^4.17.4"
+
 enzyme@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/enzyme/-/enzyme-3.3.0.tgz#0971abd167f2d4bf3f5bd508229e1c4b6dc50479"


### PR DESCRIPTION
Moves the enzyme adapter setup into a place where it can be shared between all tests, also adds support for snapshot testing.