### PR TITLE
chore: update enzyme context workaround

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM uber/web-base-image:1.0.4
+FROM uber/web-base-image:1.0.6
 
 WORKDIR /baseui
 
@@ -11,5 +11,5 @@ RUN yarn --ignore-scripts
 COPY . .
 
 # Perform any build steps if you want binaries inside of the image
-RUN yarn build && patch -p1 < ./node_modules/enzyme-context-patch/patches/enzyme-adapter-react-16+1.1.1.patch
+RUN yarn build
 RUN yarn build-storybook

--- a/package.json
+++ b/package.json
@@ -45,8 +45,7 @@
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-1": "^6.24.1",
     "enzyme": "^3.3.0",
-    "enzyme-adapter-react-16": "^1.1.1",
-    "enzyme-context-patch": "^0.0.7",
+    "enzyme-adapter-react-16": "npm:enzyme-react-adapter-future",
     "eslint": "^4.18.2",
     "eslint-config-airbnb": "^16.1.0",
     "eslint-config-uber-universal-stage-3": "^1.0.0-rc.7",
@@ -79,7 +78,7 @@
     "react-dom": ">= 16.4.0 < 17"
   },
   "engines": {
-    "node": "8.11.1",
+    "node": "^8.11.0",
     "npm": "6.0.0",
     "yarn": ">=1.5.1"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3158,13 +3158,13 @@ entities@^1.1.1, entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
-enzyme-adapter-react-16@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.1.1.tgz#a8f4278b47e082fbca14f5bfb1ee50ee650717b4"
+"enzyme-adapter-react-16@npm:enzyme-react-adapter-future":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz#f0c102f098086a0ad0270bbdaf9da5113297dc05"
   dependencies:
     enzyme-adapter-utils "^1.3.0"
     lodash "^4.17.4"
-    object.assign "^4.0.4"
+    object.assign "^4.1.0"
     object.values "^1.0.4"
     prop-types "^15.6.0"
     react-reconciler "^0.7.0"
@@ -3177,10 +3177,6 @@ enzyme-adapter-utils@^1.3.0:
     lodash "^4.17.4"
     object.assign "^4.0.4"
     prop-types "^15.6.0"
-
-enzyme-context-patch@^0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/enzyme-context-patch/-/enzyme-context-patch-0.0.7.tgz#24559e8ed25e83ced33bfc72fe7e1678a5d90a28"
 
 enzyme@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
Enzyme still hasn't released a fix for the context API, but we have a new workaround in the adapter that will persist after package installation. This also results in one less package needed in package.json and can be easily reverted once a version is released.