### PR TITLE
chore: update all components to new overrides api

### DIFF
--- a/rfcs/checkbox.md
+++ b/rfcs/checkbox.md
@@ -25,7 +25,7 @@
   Sets control into isError state. Default is `false`
 * `isIndeterminate: boolean`:
   Indeterminate control value. checked is ignored.
-* `components: {Root: (props: {[string]: any}) => React$Node, Checkmark: (props: {[string]: any}) => React$Node, Label: (props: {[string]: any}) => React$Node, , Input: (props: {[string]: any}) => React$Node}`
+* `overrides: {Root: (props: {[string]: any}) => React$Node, Checkmark: (props: {[string]: any}) => React$Node, Label: (props: {[string]: any}) => React$Node, , Input: (props: {[string]: any}) => React$Node}`
   * `Label` to render. Optional.
   * Custom `Checkmark` (exact control). If used, most of handlers may not work.
   * `Root` wrapper element for the whole checkbox control to apply styles
@@ -115,7 +115,7 @@ export default () => {
           return (
             <CustomCheckbox
               {...childrenProps}
-              components={{
+              overrides={{
                 Label: <CustomLabel>Click me</CustomLabel>,
                 Checkmark: props => <CustomCheckmark {...props} />,
               }}

--- a/rfcs/input-component.md
+++ b/rfcs/input-component.md
@@ -38,7 +38,7 @@
 ### Input component API
 
 * All properties of the BaseInput except `adjoined`
-* `override: {Label, Root, StartEnhancer, InputContainer, Input, Before, After, EndEnhancer, Caption}` - Optional
+* `overrides: {Label, Root, StartEnhancer, InputContainer, Input, Before, After, EndEnhancer, Caption}` - Optional
   * `Label: ReactComponent` - Optional
   * `Root: ReactComponent` - Optional
   * `StartEnhancer: ReactComponent` - Optional
@@ -60,7 +60,7 @@
 
 ### BaseInput component API
 
-* `override: {InputContainer, Input, Before, After}` - Optional
+* `overrides: {InputContainer, Input, Before, After}` - Optional
   * `InputContainer: ReactComponent` - ReqOptionaluired
   * `Input: ReactComponent` - Optional
   * `Before: ReactComponent` - Optional
@@ -124,8 +124,8 @@ const RootWithStyle = withStyle(StyledRoot, props => {
 export default () => {
   return (
     <div>
-      <Input override={{Root: RootWithProps}} />
-      <Input override={{Root: RootWithStyle}} />
+      <Input overrides={{Root: RootWithProps}} />
+      <Input overrides={{Root: RootWithStyle}} />
     </div>
   );
 };

--- a/rfcs/popover-component.md
+++ b/rfcs/popover-component.md
@@ -121,7 +121,7 @@ export default () => {
       <Popover
         placement="topLeft"
         content={popoverContent}
-        components={{
+        overrides={{
           Body: CustomPopoverBody,
         }}
       >
@@ -195,7 +195,7 @@ const PopoverContent = ({close}) => (
 );
 
 export default () => (
-  <StatefulPopover components={{Content: PopoverContent}}>
+  <StatefulPopover overrides={{Content: PopoverContent}}>
     <Button>Share</Button>
   </StatefulPopover>
 )

--- a/rfcs/tooltip-component.md
+++ b/rfcs/tooltip-component.md
@@ -38,7 +38,11 @@ const BigOlTooltip = withStyle(StyledTooltip, {
 export default () => (
   <Tooltip
     content="Lorem ipsum dolor sit amet..."
-    components={{Tooltip: BigOlTooltip}}
+    overrides={{
+      Tooltip: {
+        style: {width: '500px'},
+      },
+    }}
   >
     <span>Hover me!</span>
   </Tooltip>

--- a/src/components/checkbox/checkbox.js
+++ b/src/components/checkbox/checkbox.js
@@ -1,5 +1,6 @@
 // @flow
 import React from 'react';
+import {getComponent, getOverrideProps} from '../../helpers/overrides';
 import type {PropsT, DefaultPropsT, StatelessStateT} from './types';
 import {
   Checkmark as StyledCheckmark,
@@ -10,7 +11,7 @@ import {
 
 class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
   static defaultProps: DefaultPropsT = {
-    components: {},
+    overrides: {},
     checked: false,
     disabled: false,
     autoFocus: false,
@@ -60,7 +61,7 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
 
   render() {
     const {
-      components,
+      overrides = {},
       onChange,
       labelPlacement,
       label,
@@ -71,12 +72,19 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
       checked,
       required,
     } = this.props;
+
     const {
-      Root = StyledRoot,
-      Checkmark = StyledCheckmark,
-      Label = StyledLabel,
-      Input = StyledInput,
-    } = components;
+      Root: RootOverride,
+      Checkmark: CheckmarkOverride,
+      Label: LabelOverride,
+      Input: InputOverride,
+    } = overrides;
+
+    const Root = getComponent(RootOverride, StyledRoot);
+    const Checkmark = getComponent(CheckmarkOverride, StyledCheckmark);
+    const Label = getComponent(LabelOverride, StyledLabel);
+    const Input = getComponent(InputOverride, StyledInput);
+
     const events = {
       onChange,
       onMouseEnter: this.onMouseEnter,
@@ -94,14 +102,27 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
       $disabled: disabled,
     };
     const labelComp = (
-      <Label $labelPlacement={labelPlacement} {...sharedProps} {...events}>
+      <Label
+        $labelPlacement={labelPlacement}
+        {...sharedProps}
+        {...events}
+        {...getOverrideProps(LabelOverride)}
+      >
         {label}
       </Label>
     );
     return (
-      <Root $labelPlacement={labelPlacement} {...sharedProps}>
+      <Root
+        $labelPlacement={labelPlacement}
+        {...sharedProps}
+        {...getOverrideProps(RootOverride)}
+      >
         {(labelPlacement === 'top' || labelPlacement === 'left') && labelComp}
-        <Checkmark checked={checked} {...sharedProps} />
+        <Checkmark
+          checked={checked}
+          {...sharedProps}
+          {...getOverrideProps(CheckmarkOverride)}
+        />
         <Input
           required={required}
           aria-invalid={isError || null}
@@ -111,6 +132,7 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
           $ref={inputRef}
           {...sharedProps}
           {...events}
+          {...getOverrideProps(InputOverride)}
         />
         {(labelPlacement === 'bottom' || labelPlacement === 'right') &&
           labelComp}

--- a/src/components/checkbox/checkbox.test.js
+++ b/src/components/checkbox/checkbox.test.js
@@ -14,13 +14,13 @@ describe('Stateless checkbox', function() {
   let wrapper,
     events = {};
   let allProps: any = {},
-    components,
+    overrides,
     isError,
     mockFn;
 
   beforeEach(function() {
     mockFn = jest.fn();
-    components = {
+    overrides = {
       Root: StyledRoot,
       Checkmark: StyledCheckmark,
       Label: StyledLabel,
@@ -31,7 +31,7 @@ describe('Stateless checkbox', function() {
       onChange: mockFn,
     };
     allProps = {
-      components,
+      overrides,
       ...events,
       labelPlacement: 'left',
       label: 'some',
@@ -53,7 +53,7 @@ describe('Stateless checkbox', function() {
     'should send props to %s',
     subcomponent => {
       const mockComp: any = jest.fn(() => <div>{subcomponent}</div>);
-      components[subcomponent] = mockComp;
+      overrides[subcomponent] = mockComp;
       wrapper = mount(<StatelessCheckbox {...allProps} />);
       const instance = wrapper.instance();
       const sharedProps = {
@@ -107,7 +107,7 @@ describe('Stateless checkbox', function() {
 
   test('should show label text in label', function() {
     const mockComp = jest.fn(() => <div>test</div>);
-    components.Label = mockComp;
+    overrides.Label = mockComp;
     allProps.label = 'super-puper label';
     wrapper = mount(<StatelessCheckbox {...allProps} />);
     expect(mockComp.mock.calls[0][0].children).toEqual(allProps.label);
@@ -117,7 +117,7 @@ describe('Stateless checkbox', function() {
     'should place label according to dock to %s',
     (labelPlacement, index) => {
       const mockComp = jest.fn(() => <div>test</div>);
-      components.Root = mockComp;
+      overrides.Root = mockComp;
       allProps.label = 'super-puper label';
       allProps.labelPlacement = labelPlacement;
       wrapper = mount(<StatelessCheckbox {...allProps} />);

--- a/src/components/checkbox/stateful-checkbox.js
+++ b/src/components/checkbox/stateful-checkbox.js
@@ -8,12 +8,9 @@ import type {PropsT, StatefulCheckboxPropsT} from './types';
 // Styled elements
 
 const StatefulCheckbox = function(props: StatefulCheckboxPropsT) {
-  const {components} = props;
   return (
     <StatefulContainer {...props}>
-      {(childrenProps: PropsT) => (
-        <Checkbox {...childrenProps} components={components} />
-      )}
+      {(childrenProps: PropsT) => <Checkbox {...childrenProps} />}
     </StatefulContainer>
   );
 };

--- a/src/components/checkbox/stateful-checkbox.test.js
+++ b/src/components/checkbox/stateful-checkbox.test.js
@@ -23,7 +23,7 @@ describe('Stateful checkbox', function() {
       StyledInput,
       StatefulCheckbox,
     } = require('./index');
-    allProps.components = {
+    allProps.overrides = {
       Root: StyledRoot,
       Label: StyledLabel,
       Checkmark: StyledCheckmark,
@@ -31,8 +31,8 @@ describe('Stateful checkbox', function() {
     };
     const checkbox: any = require('./checkbox');
     wrapper = mount(<StatefulCheckbox {...allProps} />);
-    const {components} = checkbox.mock.calls[0][0];
-    expect(components).toEqual({
+    const {overrides} = checkbox.mock.calls[0][0];
+    expect(overrides).toEqual({
       Root: StyledRoot,
       Checkmark: StyledCheckmark,
       Label: StyledLabel,
@@ -50,7 +50,7 @@ describe('Stateful checkbox', function() {
     const checkbox: any = require('./checkbox');
     wrapper = mount(<StatefulCheckbox {...allProps} />);
     // eslint-disable-next-line no-unused-vars
-    const {components, ...rest} = checkbox.mock.calls[1][0];
+    const {overrides, ...rest} = checkbox.mock.calls[1][0];
     expect(rest).toMatchObject({
       someProp: 'some other props',
       checked: false,

--- a/src/components/checkbox/stories.js
+++ b/src/components/checkbox/stories.js
@@ -53,12 +53,6 @@ class GroupList extends React.Component<{}, {checkboxes: Array<boolean>}> {
     return (
       <div>
         <StatelessCheckbox
-          components={{
-            Root: StyledRoot,
-            Label: StyledLabel,
-            Checkmark: StyledCheckmark,
-            Input: StyledInput,
-          }}
           onChange={e => {
             const checkboxes = [e.target.checked, e.target.checked];
             this.setState({checkboxes});
@@ -70,7 +64,7 @@ class GroupList extends React.Component<{}, {checkboxes: Array<boolean>}> {
         <div style={{padding: 30}}>
           <div>
             <StatelessCheckbox
-              components={{
+              overrides={{
                 Root: StyledRoot,
                 Label: StyledLabel,
                 Checkmark: StyledCheckmark,
@@ -86,12 +80,6 @@ class GroupList extends React.Component<{}, {checkboxes: Array<boolean>}> {
             />
           </div>
           <StatelessCheckbox
-            components={{
-              Root: StyledRoot,
-              Label: StyledLabel,
-              Checkmark: StyledCheckmark,
-              Input: StyledInput,
-            }}
             checked={checkboxes[1]}
             onChange={e => {
               const newCheckboxes = checkboxes.slice();
@@ -148,7 +136,7 @@ storiesOf('Checkbox', module)
     return (
       <Checkbox
         onChange={onChange}
-        components={{
+        overrides={{
           Root: withStyle(StyledRoot, () => {
             return {
               border: `1px solid green`,
@@ -197,7 +185,7 @@ storiesOf('Checkbox', module)
     return (
       <Checkbox
         onChange={onChange}
-        components={{
+        overrides={{
           Label: customLabel,
           Checkmark: customCheckmark,
         }}
@@ -214,7 +202,7 @@ storiesOf('Checkbox', module)
     return (
       <Checkbox
         onChange={onChange}
-        components={{
+        overrides={{
           Root: RootWithProps,
         }}
         label="With a custom 'data-value' attr on the Root"

--- a/src/components/checkbox/types.js
+++ b/src/components/checkbox/types.js
@@ -1,21 +1,15 @@
 // @flow
 
 import * as React from 'react';
+import type {OverrideT} from '../../helpers/overrides';
 
 export type LabelPlacementT = 'top' | 'right' | 'bottom' | 'left';
 
-export type ComponentsT = {
-  Checkmark?: React.ComponentType<*>,
-  Label?: React.ComponentType<*>,
-  Root?: React.ComponentType<*>,
-  Input?: React.ComponentType<*>,
-};
-
-export type RequiredComponentsT = {
-  Checkmark?: React.ComponentType<*>,
-  Label?: React.ComponentType<*>,
-  Root?: React.ComponentType<*>,
-  Input?: React.ComponentType<*>,
+export type OverridesT = {
+  Checkmark?: OverrideT<*>,
+  Label?: OverrideT<*>,
+  Root?: OverrideT<*>,
+  Input?: OverrideT<*>,
 };
 
 export type DefaultPropsT = {
@@ -35,7 +29,7 @@ export type DefaultPropsT = {
 };
 
 export type PropsT = {
-  components: RequiredComponentsT,
+  overrides?: OverridesT,
   checked?: boolean,
   disabled?: boolean,
   required?: boolean,
@@ -82,7 +76,7 @@ export type DefaultStatefulPropsT = {
 };
 
 export type StatefulContainerPropsT = {
-  components?: ComponentsT,
+  overrides?: OverridesT,
   children?: (*) => React.Node,
   initialState?: StateT,
   stateReducer: StateReducerT,
@@ -95,7 +89,7 @@ export type StatefulContainerPropsT = {
 };
 
 export type StatefulCheckboxPropsT = {
-  components?: ComponentsT,
+  overrides?: OverridesT,
   children?: React.ComponentType<*>,
   initialState?: StateT,
   autoFocus?: boolean,

--- a/src/components/input/__tests__/__snapshots__/stateful-input.test.js.snap
+++ b/src/components/input/__tests__/__snapshots__/stateful-input.test.js.snap
@@ -12,7 +12,7 @@ exports[`StatefulInput - basic render: renders <Input/> as a child 1`] = `
   onBlur={[Function]}
   onChange={[Function]}
   onFocus={[Function]}
-  override={
+  overrides={
     Object {
       "Input": [Function],
     }
@@ -30,7 +30,7 @@ exports[`StatefulInput - basic render: renders <StatefulContainer/> 1`] = `
   initialState={Object {}}
   label="Label"
   onChange={[MockFunction]}
-  override={
+  overrides={
     Object {
       "Input": [Function],
     }

--- a/src/components/input/__tests__/__snapshots__/utils.test.js.snap
+++ b/src/components/input/__tests__/__snapshots__/utils.test.js.snap
@@ -1,18 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Utils - getComponentProps: returns correct object when override has props and styles 1`] = `
-Object {
-  "$style": Object {
-    "color": "blue",
-  },
-  "propName": "propsValue",
-}
-`;
-
-exports[`Utils - getComponentProps: returns empty object when no overrides 1`] = `Object {}`;
-
-exports[`Utils - getComponentProps: returns empty object when override is a component 1`] = `Object {}`;
-
 exports[`Utils - getSharedProps: getSharedProps returns correct object 1`] = `
 Object {
   "$adjoined": "none",

--- a/src/components/input/__tests__/base-input.test.js
+++ b/src/components/input/__tests__/base-input.test.js
@@ -10,7 +10,7 @@ test('BaseInput - basic functionality', () => {
     onFocus: jest.fn(),
     onBlur: jest.fn(),
     onChange: jest.fn(),
-    override: {
+    overrides: {
       Before: jest.fn().mockImplementation(() => <span />),
       After: jest.fn().mockImplementation(() => <span />),
     },
@@ -28,11 +28,11 @@ test('BaseInput - basic functionality', () => {
   expect(renderedInput.props().onFocus).toEqual(wrapper.instance().onFocus);
   expect(renderedInput.props().onBlur).toEqual(wrapper.instance().onBlur);
 
-  const renderedBefore = wrapper.find(props.override.Before);
+  const renderedBefore = wrapper.find(props.overrides.Before);
   expect(renderedBefore).toHaveLength(1);
   expect(renderedBefore.props()).toMatchSnapshot('Before gets correct props');
 
-  const renderedAfter = wrapper.find(props.override.After);
+  const renderedAfter = wrapper.find(props.overrides.After);
   expect(renderedAfter).toHaveLength(1);
   expect(renderedAfter.props()).toMatchSnapshot('After gets correct props');
 
@@ -53,12 +53,12 @@ test('BaseInput - basic functionality', () => {
   // Correct props passed when error state
   wrapper.setProps({error: true});
 
-  const updatedBefore = wrapper.find(props.override.Before);
+  const updatedBefore = wrapper.find(props.overrides.Before);
   expect(updatedBefore.props()).toMatchSnapshot(
     'Before gets correct error prop',
   );
 
-  const updatedAfter = wrapper.find(props.override.After);
+  const updatedAfter = wrapper.find(props.overrides.After);
   expect(updatedAfter.props()).toMatchSnapshot('After gets correct error prop');
 });
 

--- a/src/components/input/__tests__/stateful-input.test.js
+++ b/src/components/input/__tests__/stateful-input.test.js
@@ -8,7 +8,7 @@ test('StatefulInput - basic render', () => {
     onChange: jest.fn(),
     label: 'Label',
     caption: 'Caption',
-    override: {
+    overrides: {
       Input: function CustomInput(props) {
         return (
           <span>

--- a/src/components/input/__tests__/utils.test.js
+++ b/src/components/input/__tests__/utils.test.js
@@ -1,5 +1,5 @@
 // @flow
-import {getSharedProps, getComponent, getComponentProps} from '../utils';
+import {getSharedProps} from '../utils';
 import {ADJOINED, SIZE} from '../index';
 
 test('Utils - getSharedProps', () => {
@@ -23,37 +23,5 @@ test('Utils - getSharedProps', () => {
   // $FlowFixMe
   expect(getSharedProps(props, state)).toMatchSnapshot(
     'getSharedProps returns correct object',
-  );
-});
-
-test('Utils - getComponent', () => {
-  const DefaultComponent = jest.fn();
-  const CustomComponent = jest.fn();
-  expect(getComponent(null, DefaultComponent)).toEqual(DefaultComponent);
-  // $FlowFixMe
-  expect(getComponent(CustomComponent, DefaultComponent)).toEqual(
-    CustomComponent,
-  );
-  // $FlowFixMe
-  expect(getComponent({component: CustomComponent}, DefaultComponent)).toEqual(
-    CustomComponent,
-  );
-});
-
-test('Utils - getComponentProps', () => {
-  const CustomComponent = jest.fn();
-  const override = {
-    props: {propName: 'propsValue'},
-    style: {color: 'blue'},
-  };
-  expect(getComponentProps(null)).toMatchSnapshot(
-    'returns empty object when no overrides',
-  );
-  // $FlowFixMe
-  expect(getComponentProps(CustomComponent)).toMatchSnapshot(
-    'returns empty object when override is a component',
-  );
-  expect(getComponentProps(override)).toMatchSnapshot(
-    'returns correct object when override has props and styles',
   );
 });

--- a/src/components/input/base-input.js
+++ b/src/components/input/base-input.js
@@ -1,9 +1,10 @@
 // @flow
 import * as React from 'react';
-import type {BaseInputPropsT, InternalStateT} from './types';
 import getBuiId from '../../utils/get-bui-id';
+import {getComponent, getOverrideProps} from '../../helpers/overrides';
+import type {BaseInputPropsT, InternalStateT} from './types';
+import {getSharedProps} from './utils';
 import {ADJOINED, SIZE} from './constants';
-import {getSharedProps, getComponent, getComponentProps} from './utils';
 import {
   InputContainer as StyledInputContainer,
   Input as StyledInput,
@@ -20,7 +21,7 @@ class BaseInput extends React.Component<BaseInputPropsT, InternalStateT> {
     onBlur: () => {},
     onChange: () => {},
     onFocus: () => {},
-    override: {},
+    overrides: {},
     placeholder: '',
     required: false,
     size: SIZE.default,
@@ -78,7 +79,7 @@ class BaseInput extends React.Component<BaseInputPropsT, InternalStateT> {
 
   render() {
     const {
-      override: {
+      overrides: {
         InputContainer: InputContainerOverride,
         Input: InputOverride,
         Before: BeforeOverride,
@@ -98,22 +99,22 @@ class BaseInput extends React.Component<BaseInputPropsT, InternalStateT> {
 
     return (
       <InputContainer
-        {...getComponentProps(InputContainerOverride)}
+        {...getOverrideProps(InputContainerOverride)}
         {...sharedProps}
       >
         <span>
           <i />
         </span>
         {Before ? (
-          <Before {...getComponentProps(BeforeOverride)} {...sharedProps} />
+          <Before {...getOverrideProps(BeforeOverride)} {...sharedProps} />
         ) : null}
         <Input
-          {...getComponentProps(InputOverride)}
+          {...getOverrideProps(InputOverride)}
           {...this.getInputProps()}
           {...sharedProps}
         />
         {After ? (
-          <After {...getComponentProps(AfterOverride)} {...sharedProps} />
+          <After {...getOverrideProps(AfterOverride)} {...sharedProps} />
         ) : null}
       </InputContainer>
     );

--- a/src/components/input/input.js
+++ b/src/components/input/input.js
@@ -1,8 +1,9 @@
 // @flow
 import * as React from 'react';
-import type {InputPropsT, InternalStateT, AdjoinedT} from './types';
-import {getSharedProps, getComponent, getComponentProps} from './utils';
 import getBuiId from '../../utils/get-bui-id';
+import {getComponent, getOverrideProps} from '../../helpers/overrides';
+import type {InputPropsT, InternalStateT, AdjoinedT} from './types';
+import {getSharedProps} from './utils';
 import BaseInput from './base-input';
 import {
   Label as StyledLabel,
@@ -20,7 +21,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
     error: false,
     onBlur: () => {},
     onFocus: () => {},
-    override: {},
+    overrides: {},
     required: false,
     size: 'default',
     label: null,
@@ -56,7 +57,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
       StartEnhancer: StartEnhancerOverride,
       EndEnhancer: EndEnhancerOverride,
       Caption: CaptionOverride,
-    } = this.props.override;
+    } = this.props.overrides;
 
     const Label = getComponent(LabelOverride, StyledLabel);
     const Root = getComponent(RootOverride, StyledRoot);
@@ -75,17 +76,17 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
       <React.Fragment>
         {label && (
           <Label
-            {...getComponentProps(LabelOverride)}
+            {...getOverrideProps(LabelOverride)}
             {...sharedProps}
             htmlFor={this.props.id}
           >
             {typeof label === 'function' ? label(sharedProps) : label}
           </Label>
         )}
-        <Root {...getComponentProps(RootOverride)} {...sharedProps}>
+        <Root {...getOverrideProps(RootOverride)} {...sharedProps}>
           {startEnhancer && (
             <StartEnhancer
-              {...getComponentProps(StartEnhancerOverride)}
+              {...getOverrideProps(StartEnhancerOverride)}
               {...sharedProps}
               $position={ENHANCER_POSITION.start}
             >
@@ -102,7 +103,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
           />
           {endEnhancer && (
             <EndEnhancer
-              {...getComponentProps(EndEnhancerOverride)}
+              {...getOverrideProps(EndEnhancerOverride)}
               {...sharedProps}
               $position={ENHANCER_POSITION.end}
             >
@@ -113,7 +114,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
           )}
         </Root>
         {(caption || error) && (
-          <Caption {...getComponentProps(CaptionOverride)} {...sharedProps}>
+          <Caption {...getOverrideProps(CaptionOverride)} {...sharedProps}>
             {error && typeof error !== 'boolean'
               ? typeof error === 'function' ? error(sharedProps) : error
               : typeof caption === 'function' ? caption(sharedProps) : caption}

--- a/src/components/input/stories.js
+++ b/src/components/input/stories.js
@@ -339,7 +339,7 @@ storiesOf('Input', module)
       <React.Fragment>
         <Input
           label="Input with a Before component"
-          override={{
+          overrides={{
             Before: function Before(props) {
               return <InputIcon {...props} $position="left" />;
             },
@@ -348,7 +348,7 @@ storiesOf('Input', module)
         />
         <Input
           label="Input with an After component"
-          override={{
+          overrides={{
             After: function After(props) {
               return <InputIcon {...props} $position="right" />;
             },
@@ -363,12 +363,12 @@ storiesOf('Input', module)
       <React.Fragment>
         <Input
           label="Input with style overrides"
-          override={{InputContainer: RootWithStyle}}
+          overrides={{InputContainer: RootWithStyle}}
           placeholder="With style overrides on the Root element"
         />
         <Input
           label="Input with extra props"
-          override={{
+          overrides={{
             Input: InputWithProps,
             Label: LabelWithProps,
           }}
@@ -382,7 +382,7 @@ storiesOf('Input', module)
       <React.Fragment>
         <Input
           label="Input with custom label"
-          override={{
+          overrides={{
             Label: CustomLabel,
           }}
           placeholder="Placeholder"

--- a/src/components/input/types.js
+++ b/src/components/input/types.js
@@ -1,5 +1,6 @@
 // @flow
 import * as React from 'react';
+import type {OverrideT} from '../../helpers/overrides';
 import {STATE_CHANGE_TYPE, ADJOINED, SIZE} from './constants';
 
 // function withEnhancedTypes<Props, Component: React.ComponentType<Props>>(
@@ -31,28 +32,20 @@ export type StateReducerT = (
 
 export type PropsT = mixed;
 
-export type ComponentOverridesT =
-  | {
-      component?: ?React.ComponentType<PropsT>,
-      props?: ?{},
-      style?: ?{},
-    }
-  | React.ComponentType<PropsT>;
-
 export type BaseInputComponentsT = {
-  InputContainer?: ComponentOverridesT,
-  Input?: ComponentOverridesT,
+  InputContainer?: OverrideT<PropsT>,
+  Input?: OverrideT<PropsT>,
   // TODO: Next two seems like shouldn't be in components prop
-  Before?: ComponentOverridesT,
-  After?: ComponentOverridesT,
+  Before?: OverrideT<PropsT>,
+  After?: OverrideT<PropsT>,
 };
 
 export type InputComponentsT = BaseInputComponentsT & {
-  Root?: ComponentOverridesT,
-  Label?: ComponentOverridesT,
-  StartEnhancer?: ComponentOverridesT,
-  EndEnhancer?: ComponentOverridesT,
-  Caption?: ComponentOverridesT,
+  Root?: OverrideT<PropsT>,
+  Label?: OverrideT<PropsT>,
+  StartEnhancer?: OverrideT<PropsT>,
+  EndEnhancer?: OverrideT<PropsT>,
+  Caption?: OverrideT<PropsT>,
 };
 
 export type BaseInputPropsT = {
@@ -65,7 +58,7 @@ export type BaseInputPropsT = {
   onBlur: (e: SyntheticEvent<HTMLInputElement>) => void,
   onChange: (e: SyntheticEvent<HTMLInputElement>) => void,
   onFocus: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
-  override: BaseInputComponentsT,
+  overrides: BaseInputComponentsT,
   placeholder: string,
   required: boolean,
   size: SizeT,
@@ -75,7 +68,7 @@ export type BaseInputPropsT = {
 
 export type InputPropsT = {
   ...BaseInputPropsT,
-  override: InputComponentsT,
+  overrides: InputComponentsT,
   label: ?(React.Node | ((props: PropsT) => React.Node)),
   caption: ?(React.Node | ((props: PropsT) => React.Node)),
   startEnhancer: ?(React.Node | ((props: PropsT) => React.Node)),
@@ -92,7 +85,7 @@ export type StatefulContainerPropsT = {
 };
 
 type OmitPropsT = {
-  override: InputComponentsT,
+  overrides: InputComponentsT,
   children: ?(props: PropsT) => React.Node,
 };
 
@@ -102,5 +95,5 @@ type StInputPropsDiffT = $Diff<FullStPropsT, OmitPropsT>;
 
 export type StatefulInputPropsT = {
   ...StInputPropsDiffT,
-  override?: InputComponentsT,
+  overrides?: InputComponentsT,
 };

--- a/src/components/input/utils.js
+++ b/src/components/input/utils.js
@@ -1,11 +1,5 @@
 // @flow
-import type {
-  InputPropsT,
-  BaseInputPropsT,
-  InternalStateT,
-  ComponentOverridesT,
-  PropsT,
-} from './types';
+import type {InputPropsT, BaseInputPropsT, InternalStateT} from './types';
 
 export function getSharedProps(
   props: BaseInputPropsT | InputPropsT,
@@ -21,26 +15,4 @@ export function getSharedProps(
     $size: size,
     $required: required,
   };
-}
-
-export function getComponent(
-  override: ?ComponentOverridesT,
-  defaultComponent: React.ComponentType<PropsT>,
-): React.ComponentType<PropsT> {
-  if (override && typeof override === 'object') {
-    return override.component || defaultComponent;
-  }
-  return override || defaultComponent;
-}
-
-export function getComponentProps(override: ?ComponentOverridesT) {
-  if (override && typeof override === 'object') {
-    return {
-      // $FlowFixMe
-      ...override.props,
-      // $FlowFixMe
-      $style: override.style,
-    };
-  }
-  return {};
 }

--- a/src/components/popover/__tests__/__snapshots__/stateful-container.test.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/stateful-container.test.js.snap
@@ -4,9 +4,6 @@ exports[`StatefulPopoverContainer basic render: function-as-child called with co
 Array [
   Object {
     "accessibilityType": "menu",
-    "components": Object {
-      "Body": [Function],
-    },
     "content": [Function],
     "isOpen": true,
     "onBlur": [Function],
@@ -17,6 +14,9 @@ Array [
     "onMouseEnterDelay": 100,
     "onMouseLeave": [Function],
     "onMouseLeaveDelay": 200,
+    "overrides": Object {
+      "Body": [Function],
+    },
     "placement": "topLeft",
     "showArrow": true,
     "triggerType": "hover",

--- a/src/components/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
+++ b/src/components/popover/__tests__/__snapshots__/stateful-popover.test.js.snap
@@ -3,11 +3,6 @@
 exports[`StatefulPopover basic render: renders <Popover/> as child to container 1`] = `
 <Popover
   accessibilityType="menu"
-  components={
-    Object {
-      "Body": [Function],
-    }
-  }
   content={[Function]}
   isOpen={true}
   onBlur={[Function]}
@@ -18,6 +13,11 @@ exports[`StatefulPopover basic render: renders <Popover/> as child to container 
   onMouseEnterDelay={100}
   onMouseLeave={[Function]}
   onMouseLeaveDelay={200}
+  overrides={
+    Object {
+      "Body": [Function],
+    }
+  }
   placement="topLeft"
   showArrow={true}
   triggerType="hover"
@@ -31,11 +31,6 @@ exports[`StatefulPopover basic render: renders <Popover/> as child to container 
 exports[`StatefulPopover basic render: renders <StatefulContainer/> 1`] = `
 <StatefulContainer
   accessibilityType="menu"
-  components={
-    Object {
-      "Body": [Function],
-    }
-  }
   content={[MockFunction]}
   dismissOnClickOutside={true}
   dismissOnEsc={true}
@@ -48,6 +43,11 @@ exports[`StatefulPopover basic render: renders <StatefulContainer/> 1`] = `
   onMouseEnterDelay={100}
   onMouseLeaveDelay={200}
   onOpen={[MockFunction]}
+  overrides={
+    Object {
+      "Body": [Function],
+    }
+  }
   placement="topLeft"
   showArrow={true}
   stateReducer={[MockFunction]}

--- a/src/components/popover/__tests__/popover.test.js
+++ b/src/components/popover/__tests__/popover.test.js
@@ -225,7 +225,7 @@ describe('Popover', () => {
   });
 
   test('component overrides', () => {
-    const components = {
+    const overrides = {
       Arrow: jest.fn().mockImplementation(() => <div />),
       Body: jest.fn().mockImplementation(({children}) => <div>{children}</div>),
       Inner: jest
@@ -237,7 +237,7 @@ describe('Popover', () => {
       // $FlowFixMe - Flow is complaining about jest mock args
       <Popover
         isOpen
-        components={components}
+        overrides={overrides}
         showArrow
         triggerType={TRIGGER_TYPE.hover}
       >
@@ -252,19 +252,19 @@ describe('Popover', () => {
       return shallowCopy;
     }
 
-    const body = wrapper.find(components.Body);
+    const body = wrapper.find(overrides.Body);
     expect(body).toHaveLength(1);
     expect(withoutChildren(body.props())).toMatchSnapshot(
       'custom popover body has correct props',
     );
 
-    const arrow = wrapper.find(components.Arrow);
+    const arrow = wrapper.find(overrides.Arrow);
     expect(arrow).toHaveLength(1);
     expect(withoutChildren(arrow.props())).toMatchSnapshot(
       'custom popover arrow has correct props',
     );
 
-    const inner = wrapper.find(components.Inner);
+    const inner = wrapper.find(overrides.Inner);
     expect(inner).toHaveLength(1);
     expect(withoutChildren(inner.props())).toMatchSnapshot(
       'custom popover inner has correct props',

--- a/src/components/popover/__tests__/stateful-container.test.js
+++ b/src/components/popover/__tests__/stateful-container.test.js
@@ -12,7 +12,7 @@ import type {PopoverPropsWithoutChildrenT} from '../types';
 describe('StatefulPopoverContainer', () => {
   test('basic render', () => {
     const props = {
-      components: {
+      overrides: {
         Body: function CustomBody() {
           return <span />;
         },

--- a/src/components/popover/__tests__/stateful-popover.test.js
+++ b/src/components/popover/__tests__/stateful-popover.test.js
@@ -5,11 +5,13 @@ import {StatefulPopover, PLACEMENT, TRIGGER_TYPE} from '../index';
 
 describe('StatefulPopover', () => {
   test('basic render', () => {
+    function CustomBody() {
+      return <span />;
+    }
+
     const props = {
-      components: {
-        Body: function CustomBody() {
-          return <span />;
-        },
+      overrides: {
+        Body: CustomBody,
       },
       content: jest.fn(),
       initialState: {

--- a/src/components/popover/__tests__/styled-components.test.js
+++ b/src/components/popover/__tests__/styled-components.test.js
@@ -83,7 +83,7 @@ describe('Popover styled components', () => {
     );
   });
 
-  test('StyledPadding - override', () => {
+  test('StyledPadding - style override', () => {
     const component = shallow(
       <StyledPadding $style={{padding: '21px', color: 'red'}}>
         <div />

--- a/src/components/popover/default-props.js
+++ b/src/components/popover/default-props.js
@@ -4,7 +4,7 @@ import type {BasePopoverPropsT} from './types';
 
 const baseDefaultProps: $Shape<BasePopoverPropsT> = {
   accessibilityType: ACCESSIBILITY_TYPE.menu,
-  components: {},
+  overrides: {},
   onMouseEnterDelay: 200,
   onMouseLeaveDelay: 200,
   placement: PLACEMENT.auto,

--- a/src/components/popover/examples.js
+++ b/src/components/popover/examples.js
@@ -1,7 +1,6 @@
 // @flow
 import React from 'react';
 import {boolean, number} from '@storybook/addon-knobs';
-import {withStyleDeep} from 'styletron-react-core';
 
 import {styled} from '../../styles';
 import {
@@ -10,9 +9,6 @@ import {
   Popover,
   StatefulPopover,
   StyledPadding as StyledPopoverPadding,
-  StyledArrow,
-  StyledBody,
-  StyledInner,
 } from './index';
 
 function popoverContent() {
@@ -319,30 +315,30 @@ export default [
       const hue = number('Color', 100, {range: true, min: 0, max: 360});
       const hsl = `hsl(${hue}, 40%, 40%)`;
 
-      const CustomBody = withStyleDeep(StyledBody, {
-        backgroundColor: hsl,
-        borderRadius: 0,
-      });
-
-      const CustomInner = withStyleDeep(StyledInner, {
-        backgroundColor: hsl,
-        borderRadius: 0,
-        color: '#fff',
-      });
-
-      const CustomArrow = withStyleDeep(StyledArrow, {
-        backgroundColor: hsl,
-      });
-
       return (
         <Centered>
           <StatefulPopover
             initialState={{isOpen: true}}
             showArrow
-            components={{
-              Arrow: CustomArrow,
-              Body: CustomBody,
-              Inner: CustomInner,
+            overrides={{
+              Arrow: {
+                style: {
+                  backgroundColor: hsl,
+                },
+              },
+              Body: {
+                style: {
+                  backgroundColor: hsl,
+                  borderRadius: 0,
+                },
+              },
+              Inner: {
+                style: {
+                  backgroundColor: hsl,
+                  borderRadius: 0,
+                  color: '#fff',
+                },
+              },
             }}
             content={popoverContent}
           >

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -4,6 +4,7 @@ import * as React from 'react';
 import ReactDOM from 'react-dom';
 import document from 'global/document';
 import Popper from 'popper.js';
+import {getComponent, getOverrideProps} from '../../helpers/overrides';
 import isBrowser from '../../utils/is-browser';
 import getBuiId from '../../utils/get-bui-id';
 import {ACCESSIBILITY_TYPE, PLACEMENT, TRIGGER_TYPE} from './constants';
@@ -412,12 +413,17 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
   }
 
   renderPopover() {
-    const {showArrow, components = {}, content} = this.props;
+    const {showArrow, overrides = {}, content} = this.props;
+
     const {
-      Arrow = StyledArrow,
-      Body = StyledBody,
-      Inner = StyledInner,
-    } = components;
+      Arrow: ArrowOverride,
+      Body: BodyOverride,
+      Inner: InnerOverride,
+    } = overrides;
+
+    const Arrow = getComponent(ArrowOverride, StyledArrow);
+    const Body = getComponent(BodyOverride, StyledBody);
+    const Inner = getComponent(InnerOverride, StyledInner);
 
     const sharedProps = this.getSharedProps();
     const bodyProps = this.getPopoverBodyProps();
@@ -428,11 +434,21 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
         $ref={this.popperRef}
         {...bodyProps}
         {...sharedProps}
+        {...getOverrideProps(BodyOverride)}
       >
         {showArrow ? (
-          <Arrow key="popover-arrow" $ref={this.arrowRef} {...sharedProps} />
+          <Arrow
+            key="popover-arrow"
+            $ref={this.arrowRef}
+            {...sharedProps}
+            {...getOverrideProps(ArrowOverride)}
+          />
         ) : null}
-        <Inner key="popover-inner" {...sharedProps}>
+        <Inner
+          key="popover-inner"
+          {...sharedProps}
+          {...getOverrideProps(InnerOverride)}
+        >
           {typeof content === 'function' ? content() : content}
         </Inner>
       </Body>

--- a/src/components/popover/stateful-container.js
+++ b/src/components/popover/stateful-container.js
@@ -108,7 +108,7 @@ class StatefulContainer extends React.Component<
       accessibilityType,
       dismissOnClickOutside,
       dismissOnEsc,
-      components,
+      overrides,
       onMouseEnterDelay,
       onMouseLeaveDelay,
       placement,
@@ -119,7 +119,7 @@ class StatefulContainer extends React.Component<
     const popoverProps: PopoverPropsWithoutChildrenT = {
       accessibilityType,
       isOpen: this.state.isOpen,
-      components,
+      overrides,
       content: this.renderContent,
       onMouseEnterDelay,
       onMouseLeaveDelay,

--- a/src/components/popover/types.js
+++ b/src/components/popover/types.js
@@ -1,13 +1,14 @@
 // @flow
 /* eslint-disable flowtype/generic-spacing */
 import * as React from 'react';
+import type {ThemeT} from '../../styles/types';
+import type {OverrideT} from '../../helpers/overrides';
 import {
   ACCESSIBILITY_TYPE,
   PLACEMENT,
   STATE_CHANGE_TYPE,
   TRIGGER_TYPE,
 } from './constants';
-import type {ThemeT} from '../../styles/types';
 
 export type PopoverPlacementT = $Keys<typeof PLACEMENT>;
 
@@ -33,11 +34,11 @@ export type StatefulContentRenderPropT = ({
   close: () => void,
 }) => React.Node;
 
-export type ComponentsPropT = {|
-  Body?: React.ComponentType<*> | React.StatelessFunctionalComponent<*>,
-  Arrow?: React.ComponentType<*> | React.StatelessFunctionalComponent<*>,
-  Inner?: React.ComponentType<*> | React.StatelessFunctionalComponent<*>,
-|};
+export type OverridesT = {
+  Body?: OverrideT<SharedStylePropsT>,
+  Arrow?: OverrideT<SharedStylePropsT>,
+  Inner?: OverrideT<SharedStylePropsT>,
+};
 
 // Basically React.Node minus React.Portal and Iterable
 export type ChildT =
@@ -54,7 +55,7 @@ export type ChildrenT = React.ChildrenArray<ChildT>;
 // Props shared by all flavors of popover
 export type BasePopoverPropsT = {
   accessibilityType?: AccessibilityTypeT,
-  components?: ComponentsPropT,
+  overrides?: OverridesT,
   id?: string,
   onMouseEnterDelay?: number,
   onMouseLeaveDelay?: number,

--- a/src/helpers/__tests__/__snapshots__/overrides.test.js.snap
+++ b/src/helpers/__tests__/__snapshots__/overrides.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Helpers - Overrides - getOverrideProps: returns correct object when override has props and styles 1`] = `
+Object {
+  "$style": Object {
+    "color": "blue",
+  },
+  "propName": "propsValue",
+}
+`;
+
+exports[`Helpers - Overrides - getOverrideProps: returns empty object when no overrides 1`] = `Object {}`;
+
+exports[`Helpers - Overrides - getOverrideProps: returns empty object when override is a component 1`] = `Object {}`;

--- a/src/helpers/__tests__/overrides.test.js
+++ b/src/helpers/__tests__/overrides.test.js
@@ -1,0 +1,34 @@
+// @flow
+import {getComponent, getOverrideProps} from '../overrides';
+
+test('Helpers - Overrides - getComponent', () => {
+  const DefaultComponent = jest.fn();
+  const CustomComponent = jest.fn();
+  expect(getComponent(null, DefaultComponent)).toEqual(DefaultComponent);
+  // $FlowFixMe
+  expect(getComponent(CustomComponent, DefaultComponent)).toEqual(
+    CustomComponent,
+  );
+  // $FlowFixMe
+  expect(getComponent({component: CustomComponent}, DefaultComponent)).toEqual(
+    CustomComponent,
+  );
+});
+
+test('Helpers - Overrides - getOverrideProps', () => {
+  const CustomComponent = jest.fn();
+  const override = {
+    props: {propName: 'propsValue'},
+    style: {color: 'blue'},
+  };
+  expect(getOverrideProps(null)).toMatchSnapshot(
+    'returns empty object when no overrides',
+  );
+  // $FlowFixMe
+  expect(getOverrideProps(CustomComponent)).toMatchSnapshot(
+    'returns empty object when override is a component',
+  );
+  expect(getOverrideProps(override)).toMatchSnapshot(
+    'returns correct object when override has props and styles',
+  );
+});

--- a/src/helpers/overrides.js
+++ b/src/helpers/overrides.js
@@ -1,0 +1,31 @@
+// @flow
+
+export type OverrideT<T> =
+  | {
+      component?: ?React.ComponentType<T>,
+      props?: ?{},
+      style?: ?{},
+    }
+  | React.ComponentType<T>;
+
+export function getComponent<T>(
+  override: ?OverrideT<T>,
+  defaultComponent: React.ComponentType<T>,
+): React.ComponentType<T> {
+  if (override && typeof override === 'object') {
+    return override.component || defaultComponent;
+  }
+  return override || defaultComponent;
+}
+
+export function getOverrideProps<T>(override: ?OverrideT<T>) {
+  if (override && typeof override === 'object') {
+    return {
+      // $FlowFixMe
+      ...override.props,
+      // $FlowFixMe
+      $style: override.style,
+    };
+  }
+  return {};
+}


### PR DESCRIPTION
Following #44, updates Checkbox and Popover to use the new `overrides` API (Input was already supports it).

Also took some of @nadiia's helpers like `getComponent`, `getComponentProps` and centralized them so they can be reused.