### PR TITLE
fix(dist): add files to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
     "url": "https://github.com/uber-web/baseui/issues"
   },
   "homepage": "https://github.com/uber-web/baseui#readme",
-  "main": "dist/index.js",
-  "jsnext:main": "dist/index.es.js",
-  "module": "dist/index.es.js",
+  "main": "dist/baseui.es.js",
+  "jsnext:main": "dist/baseui.es.js",
+  "module": "dist/baseui.es.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/uber-web/baseui.git"
@@ -105,5 +105,6 @@
     "node": ">=8.11.0",
     "npm": ">=5.6.0",
     "yarn": ">=1.5.1"
-  }
+  },
+  "files": ["dist"]
 }


### PR DESCRIPTION
As per

> Publishes a package to the registry so that it can be installed by name. All files in the package directory are included if no local .gitignore or .npmignore file exists. - https://docs.npmjs.com/cli/publish

And 

> Files included with the "package.json#files" field cannot be excluded through .npmignore or .gitignore. https://docs.npmjs.com/files/package.json#files