### PR TITLE
test: Flow definitions

### DIFF
--- a/src/components/popover/styled-components.js
+++ b/src/components/popover/styled-components.js
@@ -27,17 +27,18 @@ export function getBodyStyles(props: SharedStylePropsT) {
     top: 0,
     left: 0,
     zIndex: 1050,
-    backgroundColor: $theme.colors.background,
-    borderRadius: $theme.borders.useRoundedCorners
-      ? $theme.borders.radius300
-      : '0px',
-    boxShadow: $theme.lighting.shadow600,
+    backgroundColor: $theme && $theme.colors.background,
+    borderRadius:
+      $theme && $theme.borders.useRoundedCorners
+        ? $theme.borders.radius300
+        : '0px',
+    boxShadow: $theme && $theme.lighting.shadow600,
 
     transitionProperty: 'opacity,transform',
     transitionDuration: $isAnimating ? '0.1s' : '0s',
     transitionTimingFunction: $isOpen
-      ? $theme.animation.easeOutCurve
-      : $theme.animation.easeInCurve,
+      ? $theme && $theme.animation.easeOutCurve
+      : $theme && $theme.animation.easeInCurve,
     opacity: $isAnimating && $isOpen ? 1 : 0,
     transform:
       $isAnimating && $isOpen
@@ -55,8 +56,8 @@ export const Body = styled('div', getBodyStyles);
 export function getArrowStyles(props: SharedStylePropsT) {
   const {$arrowOffset, $placement, $theme} = props;
   return {
-    backgroundColor: $theme.colors.background,
-    boxShadow: $theme.lighting.shadow600,
+    backgroundColor: $theme && $theme.colors.background,
+    boxShadow: $theme && $theme.lighting.shadow600,
     width: `${ARROW_WIDTH}px`,
     height: `${ARROW_WIDTH}px`,
     transform: 'rotate(45deg)',
@@ -76,10 +77,11 @@ export const Arrow = styled('div', getArrowStyles);
  */
 export function getInnerStyles({$theme}: SharedStylePropsT) {
   return {
-    backgroundColor: $theme.colors.background,
-    borderRadius: $theme.borders.useRoundedCorners
-      ? $theme.borders.radius300
-      : '0px',
+    backgroundColor: $theme && $theme.colors.background,
+    borderRadius:
+      $theme && $theme.borders.useRoundedCorners
+        ? $theme && $theme.borders.radius300
+        : '0px',
     position: 'relative',
     zIndex: 2, // Above "Arrow"
   };

--- a/src/components/popover/types.js
+++ b/src/components/popover/types.js
@@ -150,7 +150,8 @@ export type SharedStylePropsArgT = {
 };
 
 export type SharedStylePropsT = SharedStylePropsArgT & {
-  $theme: ThemeT,
+  $theme?: ThemeT,
+  children?: React.Node,
 };
 
 export type AnchorPropsT = {

--- a/src/components/tooltip/__tests__/tooltip.test.js
+++ b/src/components/tooltip/__tests__/tooltip.test.js
@@ -31,7 +31,7 @@ describe('Tooltip', () => {
         Body: {
           component: function CustomBody(props) {
             // eslint-disable-next-line react/prop-types
-            return <div>{props.children}</div>;
+            return <div>{props && props.children}</div>;
           },
           style: {width: '300px'},
         },

--- a/src/helpers/__tests__/overrides.test.js
+++ b/src/helpers/__tests__/overrides.test.js
@@ -45,8 +45,6 @@ test('Helpers - Overrides - getOverrideProps', () => {
 
 test('Helpers - Overrides - toObjectOverride', () => {
   const CustomComponent = getMockComponent();
-  expect(toObjectOverride()).toBeUndefined();
-  expect(toObjectOverride(null)).toBe(null);
   expect(toObjectOverride(CustomComponent)).toEqual({
     component: CustomComponent,
   });

--- a/src/helpers/overrides.js
+++ b/src/helpers/overrides.js
@@ -1,5 +1,7 @@
 // @flow
 
+import * as React from 'react';
+
 export type OverrideT<T> =
   | {
       component?: ?React.ComponentType<T>,
@@ -17,9 +19,20 @@ export function getComponent<T>(
   defaultComponent: React.ComponentType<T>,
 ): React.ComponentType<T> {
   if (override && typeof override === 'object') {
-    return override.component || defaultComponent;
+    if (
+      typeof override.component === 'object' &&
+      (override.component instanceof React.StatelessFunctionalComponent ||
+        override.component instanceof React.Component)
+    ) {
+      return override.component;
+    }
+  } else if (
+    override instanceof React.StatelessFunctionalComponent ||
+    override instanceof React.Component
+  ) {
+    return override;
   }
-  return override || defaultComponent;
+  return defaultComponent;
 }
 
 export function getOverrideProps<T>(override: ?OverrideT<T>) {


### PR DESCRIPTION
This is going to fail there is 12 more flow errors to fix.
All of them are related to usage of `getComponent`. 

@nadiia , @schnerd 
[Sometimes](https://github.com/uber-web/baseui/blob/master/src/components/input/base-input.js#L97) it is called with `null` as second argument - if  this appropriate usage of`getComponent` function? if so we need to update typing of it.

Sometimes styletron adds to confusion - I will look into those cases. 