### PR TITLE
fix: change input's background in an error unfocused state

### DIFF
--- a/src/components/input/styled-components.js
+++ b/src/components/input/styled-components.js
@@ -142,7 +142,9 @@ export const getInputContainerStyles = (props: SharedPropsT) => {
     width: '100%',
     backgroundColor: $disabled
       ? colors.mono300
-      : $isFocused || $error ? colors.mono100 : colors.mono200,
+      : $isFocused
+        ? colors.mono100
+        : $error ? colors.negative50 : colors.mono200,
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: $disabled


### PR DESCRIPTION
Resolves #86 