### PR TITLE
Optimize Docker services to leverage layer caching

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -9,7 +9,6 @@ steps:
     plugins:
       'docker-compose':
         build:
-          - chrome-standalone
           - e2e-test-chrome
           - e2e-server
           - e2e-server-healthy


### PR DESCRIPTION
This optimizes building to build all of the necessary e2e containers on a single builder node. This allows us to leverage previous docker layer caching which should make the subsequent images nearly instant.

Test times are down to 2 minutes with this change, which is better than the ~5 minutes we are seeing in master CI currently. Additional optimizations may be possible, but it will be quite an investment. Recommend taking another look after open sourcing.

![image](https://user-images.githubusercontent.com/122602/43929468-f9821fea-9be9-11e8-9590-2468f135e5c2.png)
