### PR TITLE
docs(rfc): add template for component rfcs

### DIFF
--- a/rfcs/templates/component.md
+++ b/rfcs/templates/component.md
@@ -1,0 +1,58 @@
+# Foo Component
+
+Delete this line and any sections, exports, props, etc below where applicable.
+
+### Exports
+
+* `Foo`
+* `StatefulFoo`
+* `StatefulContainer`
+* `StyledRoot`
+* `StyledBody`
+* `CONSTANT`
+
+### <Foo/> API
+
+* `prop: type` - Optional|Required
+  Description of prop
+* `prop: type` - Optional|Required
+  Description of prop
+* `prop: type` - Optional|Required
+  Description of prop
+
+### <StatefulFoo/> API
+
+* `prop: type` - Optional|Required
+  Description of prop
+* `prop: type` - Optional|Required
+  Description of prop
+* `prop: type` - Optional|Required
+  Description of prop
+
+### Presentational components props API
+
+These properties are passed to every presentational (styled) component that is exported:
+
+* `$prop: type`
+* `$prop: type`
+* `$prop: type`
+
+### Usage
+
+Basic usage:
+
+```javascript
+import * as React from 'react';
+import {Foo} from 'baseui/foo';
+
+export default () => <Foo prop={true} />;
+```
+
+### Dependencies
+
+Does this component depend on any 3rd party packages or other internal components?
+
+### Accessibility
+
+How can this component be used via keyboard controls?
+What are the accessibility best practices for this component (aria-\*, role, etc.)


### PR DESCRIPTION
Seemed useful to have a template for this (should encourage folks to think about accessibility concerns, etc)