### PR TITLE
[RFC] Modal Component

### DIFF
--- a/rfcs/modal-component.md
+++ b/rfcs/modal-component.md
@@ -2,69 +2,69 @@
 
 ### Exports
 
-* `Modal`
-* `ModalHeader`
-* `ModalBody`
-* `ModalFooter`
-* `StyledRoot`
-* `StyledBackdrop`
-* `StyledDialog`
-* `StyledDialogInner`
-* `StyledHeader`
-* `StyledBody`
-* `StyledFooter`
-* `StyledFooterAction`
-* `StyledClose`
-* `SIZE`
-* `ROLE`
+- `Modal`
+- `ModalHeader`
+- `ModalBody`
+- `ModalFooter`
+- `StyledRoot`
+- `StyledBackdrop`
+- `StyledDialog`
+- `StyledDialogInner`
+- `StyledHeader`
+- `StyledBody`
+- `StyledFooter`
+- `StyledFooterAction`
+- `StyledClose`
+- `SIZE`
+- `ROLE`
 
 ### <Modal/> API
 
-* `children: React.node | ({close: fn}) => React.node` - Required
+- `children: React.node | ({close: fn}) => React.node` - Required
   Modal content. The children-as-function API may be preferable for performance reasons (wont render until opened) and also gives users access to a `close()` callback that they can add to buttons
-* `isOpen: boolean` - Required
+- `isOpen: boolean` - Required
   Controls whether the modal is visible or not
-* `closeable: boolean` - Optional, Defaults to `true`
+- `closeable: boolean` - Optional, Defaults to `true`
   Whether the modal should be closeable by the user (either via escape, backdrop click, etc). You can set this to `false` if your modal has an action that the user _must_ take before closing.
-* `onClose: function` - Optional
-  A callback that is invoked when the modal will close
-* `size: SIZE.{small|medium|large|full|cover|auto}|string|number`, Defaults to SIZE.default
+- `onClose: (source: CloseSource) => void` - Optional
+  A callback that is invoked when the modal will close. Callback is passed a constant identifying what triggered the close.
+- `size: SIZE.{small|medium|large|full|cover|auto}|string|number`, Defaults to SIZE.default
   Controls the size of the modal (primarily width). Can be a SIZE constant or css `width` property value.
-* `aria-labelledby: string` - Optional, Default to ''
+- `aria-labelledby: string` - Optional, Default to ''
   If specified, will be passed to the dialog element
-* `aria-describedby: string` - Optional, Defaults to ''
+- `aria-describedby: string` - Optional, Defaults to ''
   If specified, will be passed to the dialog element
-* `aria-label: string` - Optional, Defaults to ''
+- `aria-label: string` - Optional, Defaults to ''
   If specified, will be passed to the dialog element (described the modal for screen readers)
-* `id: string` - Optional, Defaults to ''
+- `id: string` - Optional, Defaults to ''
   If specified, will be passed to the dialog element
-* `role: 'dialog'|'alertdialog'|string` - Optional, Defaults to 'dialog'
+- `role: 'dialog'|'alertdialog'|string` - Optional, Defaults to 'dialog'
   Which accessibility role this modal should have
-* `mountNode: HTMLElement | React.Ref` - Optional, Defaults to document.body
+- `mountNode: HTMLElement | React.Ref` - Optional, Defaults to document.body
   Where to mount the modal
-* `overrides: {Root, Backdrop, Dialog, DialogInner, Close}` - Optional
+- `overrides: {Root, Backdrop, Dialog, DialogInner, Close}` - Optional
   Overrides for presentational components. See "Presentational Components Props API" below.
-  * `[ComponentName]: ReactComponent | {props: {}, style: {}, component: ReactComponent}` - Optional
+  - `[ComponentName]: ReactComponent | {props: {}, style: {}, component: ReactComponent}` - Optional
 
 ### <ModalHeader/> API
 
 ModalHeader is just a styled component with spacing / typography
 
-* `$style: () => {} | {}` - Optional
+- `$style: () => {} | {}` - Optional
   Style overrides object or function
 
 ### <ModalBody/> API
 
 ModalBody is just a styled component with the correct spacing
 
-* `$style: () => {} | {}` - Optional
+- `$style: () => {} | {}` - Optional
   Style overrides object or function
 
 ### <ModalFooter/> API
 
 ModalBody is just a styled component with spacing and top border
 
-* `$style: () => {} | {}` - Optional
+- `$style: () => {} | {}` - Optional
   Style overrides object or function
 
 ### <ModalButton/> API
@@ -74,22 +74,26 @@ See <Button/> docs for available props and usage.
 
 ### SIZE Constant
 
-* `compact` - 400px width
-* `default` - 550px width
-* `full` - Span full viewport, minus some margin
-* `auto` - Based on content width
+- `compact` - 400px width
+- `default` - 550px width
+- `full` - Span full viewport, minus some margin
+- `auto` - Based on content width
 
-^ Open to ideas here. Too many options?
+### CLOSE_SOURCE Constant
+
+- `close_button`
+- `escape`
+- `backdrop`
 
 ### Presentational Components Props API
 
 Next properties are passed to every presentational (styled) component
 
-* `$isOpen: boolean`
-* `$size: string|number`
-* `$role: string`
-* `$closeable: boolean`
-* `$theme: theme`
+- `$isOpen: boolean`
+- `$size: string|number`
+- `$role: string`
+- `$closeable: boolean`
+- `$theme: theme`
 
 More props likely TBA as development continues
 
@@ -136,34 +140,30 @@ class App extends React.Component {
 
 ### Key Design Decisions
 
-* Modal content will not render server side. This is because portals don't exist server-side, and realistically your page shouldn't be loading with a modal open.
+- Modal content will not render server side. This is because portals don't exist server-side, and realistically your page shouldn't be loading with a modal open.
 
 ### Accesibility
 
 Good read: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
 
-* Upon opening, first focusable item in modal will receive focus (form input, footer button, etc)
-* Dialog element will `aria-modal="true"`
-* Explicitly expose props for role, aria-labeledby, aria-describedby, id, to encourage good a11y practices
-* `Tab` key will move between focusable items (form inputs, footer buttons, etc). According to best practices, tabbing past the last focusable item should loop back to the first focusable item.
-* `Escape` key will close the modal
-* Click on backdrop (anywhere outside dialog) will hide modal
-* Background will not be scrollable while modal is open (position: fixed)
-* Focus should ideally be transitioned back to last focused element upon closing
+- Upon opening, first focusable item in modal will receive focus (form input, footer button, etc)
+- Dialog element will `aria-modal="true"`
+- Explicitly expose props for role, aria-labeledby, aria-describedby, id, to encourage good a11y practices
+- `Tab` key will move between focusable items (form inputs, footer buttons, etc). According to best practices, tabbing past the last focusable item should loop back to the first focusable item.
+- `Escape` key will close the modal
+- Click on backdrop (anywhere outside dialog) will hide modal
+- Background will not be scrollable while modal is open (position: fixed)
+- Focus should ideally be transitioned back to last focused element upon closing
 
 ### Possible Future Props
 
 The following props could be useful in the future but are low priority for V1
 
-* `onBackdropClick: function` - Callback handler for when backdrop is clicked specifically
-* `backdrop: boolean` - Set to false to not show a transparent backdrop
-* `backdropCloseable: boolean` - Set to false if click on backdrop should not close modal
-* `onEscapeKey: function` - Callback handler for when escape key is hit
-* `escakeKeyCloseable: boolean` - Set to false to disable escape key closing modal
-* `onOpenComplete: function` - handler after opening (after animation, etc)
-* `onCloseComplete: function` - handler after closing (after animation, etc)
-* `autofocus: boolean` - Set to false if modal shouldn't autofocus on its content
-* `enforceFocus: boolean` - Set to false if we should force focus to stay in modal
-* `usePortal: boolean` - Set to false to not use a portal, and just mount as direct child
-* `disableRestoreFocus: boolean` - Set to false to not restore focus to previous element on close
-* `keepMounted` - Keep children in DOM but not visible (could be good for SEO)
+- `backdrop: boolean` - Set to false to not show a transparent backdrop
+- `onOpenComplete: function` - handler after opening (after animation, etc)
+- `onCloseComplete: function` - handler after closing (after animation, etc)
+- `autofocus: boolean` - Set to false if modal shouldn't autofocus on its content
+- `enforceFocus: boolean` - Set to false if we should force focus to stay in modal
+- `usePortal: boolean` - Set to false to not use a portal, and just mount as direct child
+- `disableRestoreFocus: boolean` - Set to false to not restore focus to previous element on close
+- `keepMounted` - Keep children in DOM but not visible (could be good for SEO)

--- a/rfcs/modal-component.md
+++ b/rfcs/modal-component.md
@@ -1,0 +1,154 @@
+# Modal Component
+
+### Exports
+
+* `Modal`
+* `ModalHeader`
+* `ModalBody`
+* `ModalFooter`
+* `StyledRoot`
+* `StyledBackdrop`
+* `StyledDialog`
+* `StyledDialogInner`
+* `StyledHeader`
+* `StyledBody`
+* `StyledFooter`
+* `StyledFooterAction`
+* `StyledClose`
+* `SIZE`
+* `ROLE`
+
+### <Modal/> API
+
+* `children: React.node | ({close: fn}) => React.node` - Required
+  Modal content. The children-as-function API may be preferable for performance reasons (wont render until opened) and also gives users access to a `close()` callback that they can add to buttons
+* `isOpen: boolean` - Required
+  Controls whether the modal is visible or not
+* `closable: boolean` - Optional, Defaults to `true`
+  Whether the modal should be closable by the user (either via escape, backdrop click, etc). You can set this to `false` if your modal has an action that the user _must_ take before closing.
+* `onClose: function` - Optional
+  A callback that is invoked when the modal will close
+* `size: SIZE.{small|medium|large|full|cover|auto}|string|number`, Defaults to SIZE.default
+  Controls the size of the modal (primarily width). Can be a SIZE constant or css `width` property value.
+* `aria-labelledby: string` - Optional, Default to ''
+  If specified, will be passed to the dialog element
+* `aria-describedby: string` - Optional, Defaults to ''
+  If specified, will be passed to the dialog element
+* `aria-label: string` - Optional, Defaults to ''
+  If specified, will be passed to the dialog element (described the modal for screen readers)
+* `id: string` - Optional, Defaults to ''
+  If specified, will be passed to the dialog element
+* `role: 'dialog'|'alertdialog'|string` - Optional, Defaults to 'dialog'
+  Which accessibility role this modal should have
+* `mountNode: HTMLElement` - Optional, Defaults to document.body
+  Where to mount the modal
+* `overrides: {Root, Backdrop, Dialog, DialogInner, Close}` - Optional
+  Overrides for presentational components. See "Presentational Components Props API" below.
+  * `[ComponentName]: ReactComponent | {props: {}, style: {}, component: ReactComponent}` - Optional
+
+### <ModalHeader/> API
+
+TBD
+
+### <ModalBody/> API
+
+TBD
+
+### <ModalFooter/> API
+
+TBD
+
+### SIZE Constant
+
+* `small` - 400px width
+* `medium` - 550px width
+* `large` - 800px width
+* `full` - Span full viewport, minus some margin
+* `cover` - Span full viewport, no margin
+* `auto` - Based on content width
+
+^ Open to ideas here. Too many options?
+
+### Presentational Components Props API
+
+Next properties are passed to every presentational (styled) component
+
+* `$isOpen: boolean`
+* `$size: string|number`
+* `$role: string`
+* `$closable: boolean`
+* `$theme: theme`
+
+More props likely TBA as development continues
+
+### Usage
+
+Basic usage:
+
+```javascript
+import * as React from 'react';
+import {Modal, SIZE} from 'baseui/modal';
+
+class App extends React.Component {
+  state = {
+    open: true
+  };
+  render() {
+    return (
+      <div>
+        <Button onClick={() => this.setState({open: true})}>Open</Button>
+        <Modal
+          isOpen={this.state.open}
+          close={() => this.setState({open: false})}
+        >
+          {({close}) => (
+            <>
+              <ModalTitle>Whatsup!</ModalTitle>
+              <ModalBody>This is a modal</ModalBody>
+              <ModalFooter>
+                <Button type=”tertiary” onClick={close}>Close</Button>
+                <Button type=”primary” onClick={this.submit}>Let’s Go</Button>
+              </ModalFooter>
+            </>
+          )}
+        </Modal>
+      </div>
+
+    );
+  }
+}
+```
+
+### Key Design Decisions
+
+* Modal content will not render server side. This is because portals don't exist server-side, and realistically your page shouldn't be loading with a modal open.
+
+### Accesibility
+
+Good read: https://www.w3.org/TR/wai-aria-practices/examples/dialog-modal/dialog.html
+
+* Upon opening, first focusable item in modal will receive focus (form input, footer button, etc)
+* Dialog element will `aria-modal="true"`
+* Explicitly expose props for role, aria-labeledby, aria-describedby, id, to encourage good a11y practices
+* `Tab` key will move between focusable items (form inputs, footer buttons, etc). According to best practices, tabbing past the last focusable item should loop back to the first focusable item.
+* `Escape` key will close the modal
+* Click on backdrop (anywhere outside dialog) will hide modal
+* Background will not be scrollable while modal is open (position: fixed)
+* Focus should ideally be transitioned back to last focused element upon closing
+
+### Possible Future Props
+
+The following props could be useful in the future but are low priority for V1
+
+* `onBackdropClick: function` - Callback handler for when backdrop is clicked specifically
+* `backdrop: boolean` - Set to false to not show a transparent backdrop
+* `backdropCloseable: boolean` - Set to false if click on backdrop should not close modal
+* `onEscapeKey: function` - Callback handler for when escape key is hit
+* `escakeKeyCloseable: boolean` - Set to false to disable escape key closing modal
+* `onOpenComplete: function` - handler after opening (after animation, etc)
+* `onCloseComplete: function` - handler after closing (after animation, etc)
+* `autofocus: boolean` - Set to false if modal shouldn't autofocus on its content
+* `enforceFocus: boolean` - Set to false if we should force focus to stay in modal
+* `usePortal: boolean` - Set to false to not use a portal, and just mount as direct child
+* `disableRestoreFocus: boolean` - Set to false to not restore focus to previous element on close
+* `keepMounted` - Keep children in DOM but not visible (could be good for SEO)

--- a/rfcs/modal-component.md
+++ b/rfcs/modal-component.md
@@ -24,8 +24,8 @@
   Modal content. The children-as-function API may be preferable for performance reasons (wont render until opened) and also gives users access to a `close()` callback that they can add to buttons
 * `isOpen: boolean` - Required
   Controls whether the modal is visible or not
-* `closable: boolean` - Optional, Defaults to `true`
-  Whether the modal should be closable by the user (either via escape, backdrop click, etc). You can set this to `false` if your modal has an action that the user _must_ take before closing.
+* `closeable: boolean` - Optional, Defaults to `true`
+  Whether the modal should be closeable by the user (either via escape, backdrop click, etc). You can set this to `false` if your modal has an action that the user _must_ take before closing.
 * `onClose: function` - Optional
   A callback that is invoked when the modal will close
 * `size: SIZE.{small|medium|large|full|cover|auto}|string|number`, Defaults to SIZE.default
@@ -40,7 +40,7 @@
   If specified, will be passed to the dialog element
 * `role: 'dialog'|'alertdialog'|string` - Optional, Defaults to 'dialog'
   Which accessibility role this modal should have
-* `mountNode: HTMLElement` - Optional, Defaults to document.body
+* `mountNode: HTMLElement | React.Ref` - Optional, Defaults to document.body
   Where to mount the modal
 * `overrides: {Root, Backdrop, Dialog, DialogInner, Close}` - Optional
   Overrides for presentational components. See "Presentational Components Props API" below.
@@ -48,23 +48,35 @@
 
 ### <ModalHeader/> API
 
-TBD
+ModalHeader is just a styled component with spacing / typography
+
+* `$style: () => {} | {}` - Optional
+  Style overrides object or function
 
 ### <ModalBody/> API
 
-TBD
+ModalBody is just a styled component with the correct spacing
+
+* `$style: () => {} | {}` - Optional
+  Style overrides object or function
 
 ### <ModalFooter/> API
 
-TBD
+ModalBody is just a styled component with spacing and top border
+
+* `$style: () => {} | {}` - Optional
+  Style overrides object or function
+
+### <ModalButton/> API
+
+ModalButton is just a normal BaseUI button with margin already applied
+See <Button/> docs for available props and usage.
 
 ### SIZE Constant
 
-* `small` - 400px width
-* `medium` - 550px width
-* `large` - 800px width
+* `compact` - 400px width
+* `default` - 550px width
 * `full` - Span full viewport, minus some margin
-* `cover` - Span full viewport, no margin
 * `auto` - Based on content width
 
 ^ Open to ideas here. Too many options?
@@ -76,7 +88,7 @@ Next properties are passed to every presentational (styled) component
 * `$isOpen: boolean`
 * `$size: string|number`
 * `$role: string`
-* `$closable: boolean`
+* `$closeable: boolean`
 * `$theme: theme`
 
 More props likely TBA as development continues
@@ -91,7 +103,7 @@ import {Modal, SIZE} from 'baseui/modal';
 
 class App extends React.Component {
   state = {
-    open: true
+    open: true,
   };
   render() {
     return (
@@ -103,17 +115,20 @@ class App extends React.Component {
         >
           {({close}) => (
             <>
-              <ModalTitle>Whatsup!</ModalTitle>
+              <ModalHeader>Whatsup!</ModalHeader>
               <ModalBody>This is a modal</ModalBody>
               <ModalFooter>
-                <Button type=”tertiary” onClick={close}>Close</Button>
-                <Button type=”primary” onClick={this.submit}>Let’s Go</Button>
+                <ModalButton kind="tertiary" onClick={close}>
+                  Close
+                </ModalButton>
+                <ModalButton kind="primary" onClick={this.submit}>
+                  Let’s Go
+                </ModalButton>
               </ModalFooter>
             </>
           )}
         </Modal>
       </div>
-
     );
   }
 }


### PR DESCRIPTION
RFC for modal component (Click "Files changed" above). Attempts to take all the best API design bits from other modals on the market (material-ui, antd, palantir, etc), as well as accessibility best practices.

Two other lingering topics that I'd appreciate your feedback on:

### 1. Opinionated Header/Footer

People can render whatever arbitrary content they want, but we also want to make it easy to create a beautiful standard modal. After some thought, I think one of the two following APIs would be best:

#### Option A: Top-level title/actions props
```js
<Modal
  isOpen={this.state.open}
  title="Hello world!" // string|React.node
  actions={[{
    // Actions are mapped to `<Button>` instances, essentially same props
    type: 'secondary'
    label: 'Close'
    onClick: this.handleClose
  }, {
    type: 'primary'
    label: 'Close'
    onClick: this.handleSubmit
    isLoading: this.state.isSubmitting
  }]}
>
  Lorem ipsum dolor sit amet
</Modal>
```

#### Option B: Use exported ModalHeader, ModalBody, ModalFooter components.
```js
<Modal isOpen={this.state.open}>
  <ModalHeader>Hello world!</ModalHeader>
  <ModalBody>Lorem ipsum dolor sit amet</ModalBody>
  {/* ModalFooter can take same actions array as Option A */}
  <ModalFooter actions={[{
    type: 'secondary'
    label: 'Close'
    onClick: this.handleClose
  }, /*  more buttons */ ]} />
  {/* Or you can just pass children if you only want spacing/border styling */}
  <ModalFooter>
    My custom footer content
  </ModalFooter>
</Modal>
```

Whichever option we choose, I think the `actions` array is nice because it prevents you from needing to do all the margin between buttons, and right-alignment yourself.

### 2. `Modal.method()` Imperative API

[Antd has a pretty innovative alternate modal API](https://ant.design/components/modal/#Modal.method()) for quickly rendering modals in a callback handler. Here's what it looks like:

```js
handleSubmit() {
  this._modal = Modal.confirm({
    // Mostly same props as <Modal/>
    title: 'Are you sure delete this task?',
    content: 'Some descriptions',
    okType: 'danger',
    onOk() { console.log('OK'); },
    onCancel() { console.log('Cancel') },
  });
  // Sometime later...
 this._modal.destroy();
}
```

Internally, it just attaches a new react root to the page with a modal inside of it.

In my opinion, this imperative API actually better matches the mental model of modals compared to the declarative approach of always having a `<Modal/>` in your render() method and controlling `isOpen`. 

I think we should offer this utility API **in addition to** the default `<Modal/>` API, but curious to see if anyone has strong opinions against that.