### PR TITLE
chore(overrides): export mergeOverrides helper

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -25,3 +25,4 @@ THE SOFTWARE.
 export {styled, ThemeProvider} from './styles';
 export {LightTheme} from './themes';
 export {withProps} from './helpers';
+export {mergeOverrides} from './helpers/overrides';


### PR DESCRIPTION
I anticipate people may want to create their own wrappers around baseui components with specific overrides, while still allowing consumers of _their_ component to pass in further overrides:

```js
// SpecialAutocomplete.js
import {mergeOverrides} from '@uber/baseui';
import {Autocomplete} from '@uber/baseui/autocomplete';

const autocompleteOverrides = {
  Root: {
    style: {
      borderColor: 'red',
    }
  },
};

export function SpecialAutocomplete(props) {
  const overrides = mergeOverrides(autocompleteOverrides, props.overrides);
  return <Autocomplete {...props} overrides={overrides} />;
}

// App.js
<SpecialAutocomplete overrides={{Root: {props: {className: 'foo'}}}} />
```

In order to allow this we need to export `mergeOverrides`.

To be clear, mergeOverrides currently only does a shallow merge – so if a user passes in `props` overrides for a component, they would replace any `props` overrides in the interim component. But even the current behavior is helpful, and we could evolve this over time though to more intelligently merge things during a major version bump.