### PR TITLE
fix(popover): fix behavior when opening and closing quickly

### DIFF
--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -85,6 +85,8 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
   componentDidUpdate(prevProps: PopoverPropsT) {
     if (this.props.isOpen !== prevProps.isOpen) {
       if (this.props.isOpen) {
+        // Clear any existing timers (like previous animateOutCompleteTimer)
+        this.clearTimers();
         // Opening
         this.initializePopper();
         this.addDomEvents();


### PR DESCRIPTION
Fixes an issue that happened with opening an closing popovers really quickly.

The issue is that when the popover closes, we still want to leave it in the DOM for a couple hundred milliseconds so it can animate out. To make that work, we do a setTimeout for a few hundred milliseconds into the future, when we'll remove the popover from the DOM. But this causes an issue if the popover is immediately opened again before that timeout fires. To fix that, we clear any existing timers when opening.