### PR TITLE
docs(readme): remove styled() from default example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,22 +17,13 @@ npm install @uber/baseui
 ```
 
 ```javascript
-import {LightTheme, ThemeProvider, styled} from '@uber/baseui';
+import {LightTheme, ThemeProvider} from '@uber/baseui';
 import {StatefulInput} from '@uber/baseui/input';
-
-const Centered = styled('div', {
-  display: 'flex',
-  justifyContent: 'center',
-  alignItems: 'center',
-  height: '100%',
-});
 
 export default function Hello() {
   return (
     <ThemeProvider theme={LightTheme}>
-      <Centered>
-        <StatefulInput />
-      </Centered>
+      <StatefulInput />
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
I don't know if we want to promote using `styled` from baseui (at least in the primary setup example). I think it could create confusion about when to use `styled` from `fusion-plugin-styletron-react` vs `styletron-react` vs `baseui`. 

It seems like generally we'd want to encourage people to use the one they directly depend upon in their app. The only time it might make sense to use `styled` from baseui is if you:
1. need baseui theme values (though they could wire these up to their own styled impl)
2. are passing a new styled component through overrides and want to maintain it's ability to accept style override objects through `$style`. 

We could probably document these use cases in a more advanced guide though.

Curious to hear others thoughts about this though. @rtsao @nadiia @abmai @gergelyke