### PR TITLE
refactor(buildkite): use worker and builder queues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -5,6 +5,8 @@ steps:
       'docker-compose':
         build: baseui
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+    agents:
+      queue: builders
   - name: ':docker: :package: e2e'
     plugins:
       'docker-compose':
@@ -13,6 +15,8 @@ steps:
           - e2e-server
           - e2e-server-healthy
         image-repository: 027047743804.dkr.ecr.us-east-2.amazonaws.com/uber
+    agents:
+      queue: builders
   # Wait until all images are built.
   # This way we can download the built image from a registry instead of building each for each test task.
   - wait
@@ -22,16 +26,22 @@ steps:
     plugins:
       'docker-compose':
         run: baseui
+    agents:
+      queue: workers
   - name: ':flowtype:'
     command: yarn flow check
     plugins:
       'docker-compose':
         run: baseui
+    agents:
+      queue: workers
   - name: ':jest:'
     command: yarn unit-test
     plugins:
       'docker-compose':
         run: baseui
+    agents:
+      queue: workers
   - name: ':selenium: :chromium:'
     command: yarn test-e2e
     plugins:
@@ -41,3 +51,5 @@ steps:
           - e2e-test-chrome
           - e2e-server
           - e2e-server-healthy
+    agents:
+      queue: workers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # BASE UI
 
-[![Build status](https://badge.buildkite.com/4c46e1f96d71ca1eaab3236c90a8ff4d218eb818e412ba1cf9.svg?branch=master)](https://buildkite.com/uber/baseui)
+[![Build status](https://badge.buildkite.com/92a7500cd98f619621c4801833d8b358c2fd79efc9b98f1b98.svg)](https://buildkite.com/uberopensource/baseui)
 
 `baseui` is a design system comprised of modern, responsive, living components.
 


### PR DESCRIPTION
In an effort to move to the buildkite org `uberopensource`, we have to assign queues to build steps.