### PR TITLE
Radio option should be disabled if the group or itself is disabled

### DIFF
--- a/src/components/radio/radiogroup.js
+++ b/src/components/radio/radiogroup.js
@@ -98,6 +98,7 @@ class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
           return React.cloneElement(child, {
             ...childrenProps,
             checked: this.props.value === child.props.value,
+            disabled: this.props.disabled || child.props.disabled,
           });
         })}
       </StyledRadioGroupRoot>


### PR DESCRIPTION
It is not possible to disable an option in a `RadioGroup`, this change correctly disables a radio option if the `RadioGroup` is disabled or itself is disabled.

