### PR TITLE
chore(flow): set up types for cup globals

### DIFF
--- a/flow-typed/globals.js
+++ b/flow-typed/globals.js
@@ -1,0 +1,28 @@
+/*
+MIT License
+
+Copyright (c) 2018 Uber Technologies, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+// @flow
+
+declare var __NODE__: boolean;
+declare var __BROWSER__: boolean;
+declare var __DEV__: boolean;

--- a/src/components/menu/stateful-container.js
+++ b/src/components/menu/stateful-container.js
@@ -30,7 +30,6 @@ export default class MenuStatefulContainer extends React.Component<
   state: StatefulContainerStateT = {...this.props.initialState};
 
   componentDidMount() {
-    // $FlowFixMe
     if (__BROWSER__) {
       // TODO: perhaps only bind event listener on focus
       document.addEventListener('keydown', this.onKeyDown);
@@ -38,7 +37,6 @@ export default class MenuStatefulContainer extends React.Component<
   }
 
   componentWillUnmount() {
-    // $FlowFixMe
     if (__BROWSER__) {
       document.removeEventListener('keydown', this.onKeyDown);
     }

--- a/src/components/popover/popover.js
+++ b/src/components/popover/popover.js
@@ -266,7 +266,6 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
   };
 
   addDomEvents() {
-    // $FlowFixMe
     if (__BROWSER__) {
       document.addEventListener('mousedown', this.onDocumentClick);
       document.addEventListener('keyup', this.onKeyPress);
@@ -274,7 +273,6 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
   }
 
   removeDomEvents() {
-    // $FlowFixMe
     if (__BROWSER__) {
       document.removeEventListener('mousedown', this.onDocumentClick);
       document.removeEventListener('keyup', this.onKeyPress);
@@ -483,7 +481,6 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
     const rendered = [this.renderAnchor()];
 
     // Only render popover on the browser (portals aren't supported server-side)
-    // $FlowFixMe
     if (__BROWSER__) {
       if (this.props.isOpen || this.state.isAnimating) {
         rendered.push(


### PR DESCRIPTION
Same thing that exists in fusion:
https://github.com/fusionjs/fusion-core/blob/master/flow-typed/globals.js

Prevents us from needing $FlowFixMe comments around these.