### PR TITLE
feat: extend styled function to use withStyleDeep

### DIFF
--- a/src/styles/__tests__/styled.test.js
+++ b/src/styles/__tests__/styled.test.js
@@ -99,3 +99,31 @@ test('styled override prop', () => {
 
   wrapper.unmount();
 });
+
+test('styled override styled component', () => {
+  const StyledBase = styled('div', {
+    color: 'red',
+  });
+  const StyledBaseOverride = styled(StyledBase, {
+    color: 'blue',
+  });
+  const TestComponent = withStyletronProvider(() => (
+    <div>
+      <StyledBase />
+      <StyledBaseOverride />
+    </div>
+  ));
+
+  const wrapper = mount(<TestComponent />);
+
+  const base = wrapper.find(StyledBase).getDOMNode();
+  expect(base.classList).toHaveLength(1);
+  const redColorClass = base.classList.item(0);
+
+  // BaseOverride should not have red color class
+  const override = wrapper.find(StyledBaseOverride).getDOMNode();
+  expect(override.classList).toHaveLength(1);
+  expect(override.classList).not.toContain(redColorClass);
+
+  wrapper.unmount();
+});

--- a/src/styles/styled.js
+++ b/src/styles/styled.js
@@ -42,11 +42,14 @@ const baseStyled = createStyled({wrapper, getInitialStyle, driver});
 // TODO: Need a flow expert to help remove this 'any' type
 // eslint-disable-next-line flowtype/no-weak-types
 export default function styledWrapper(...args: any) {
+  // If user is trying to style a styled component
+  // use withStyleDeep, otherwise use baseStyled
+  const styleFn = typeof args[0] === 'function' ? withStyleDeep : baseStyled;
   // Also allow passing deep style overrides via $style prop
   // Ex: <StyledDiv $style={{color: 'red'}} />
   // Issue for supporting this natively in styletron:
   // https://github.com/rtsao/styletron/issues/221
-  return withStyleDeep(baseStyled(...args), (props: {$style?: ?{}}) => {
+  return withStyleDeep(styleFn(...args), (props: {$style?: ?{}}) => {
     const {$style} = props;
     if (typeof $style === 'function') {
       return $style(props);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

#### Patch: Bug Fix?

This allows this behavior to work as expected

```js
import {styled} from 'baseui';

const Base = styled('div', {color: 'red'});
const BaseBlue = styled(Base, {color: 'blue'});
```

#### Tests Added + Pass?

Yes

#### License

MIT

<!-- Describe your changes below in as much detail as possible -->
