### PR TITLE
fix(menu): only polyfill smoothscroll in browser env

### DIFF
--- a/src/menu/utils.js
+++ b/src/menu/utils.js
@@ -8,7 +8,9 @@ LICENSE file in the root directory of this source tree.
 /* eslint-disable import/prefer-default-export */
 import smoothscroll from 'smoothscroll-polyfill';
 
-smoothscroll.polyfill();
+if (__BROWSER__) {
+  smoothscroll.polyfill();
+}
 
 /**
  * Given a props object and a mapper dictionary of prop keys, we will prepend


### PR DESCRIPTION
Fix for an issue reported by @nudge:
```
ReferenceError: window is not defined
    at Object.polyfill (/Users/davidng/Uber/src/riderpayments/web-payments-experience-2/node_modules/smoothscroll-polyfill/dist/smoothscroll.js:8:13)
    at Object.<anonymous> (/Users/davidng/Uber/src/riderpayments/web-payments-experience-2/node_modules/baseui/menu/utils.js:18:32)
7:33 AM
```
> i think because the smoothscroll polyfill is being called regardless of browser/backend inside menu/utils.js

Wrapping this call in a `__BROWSER__` should do the trick.