### PR TITLE
fix(button): set default shape to default

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -67,5 +67,5 @@ Button.defaultProps = {
   overrides: {},
   size: SIZE.default,
   kind: KIND.primary,
-  shape: SHAPE.square,
+  shape: SHAPE.default,
 };

--- a/src/button/examples.js
+++ b/src/button/examples.js
@@ -73,7 +73,7 @@ export default {
           <Button disabled={true}>Disabled</Button>
         </ButtonRow>
         <ButtonRow>
-          <Button>
+          <Button shape={SHAPE.square}>
             <CloudComponent />
           </Button>
         </ButtonRow>


### PR DESCRIPTION
### Button Component

Properly set default button shape to `default`. This is what was causing the weird padding we were seeing, @schnerd

#### Preview

Default
![image](https://user-images.githubusercontent.com/2263443/45259910-20643980-b38d-11e8-8e22-d09e79b5015a.png)

Compact
![image](https://user-images.githubusercontent.com/2263443/45259912-26f2b100-b38d-11e8-8a8f-a3abfae66f90.png)
