### PR TITLE
fix(button): add focus style in-lieu of outline

### DIFF
--- a/src/button/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/button/__tests__/__snapshots__/styled-components.test.js.snap
@@ -10,6 +10,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
   },
@@ -47,6 +50,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
@@ -86,6 +92,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
   },
@@ -123,6 +132,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
@@ -162,6 +174,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
   },
@@ -199,6 +214,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono200",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono200",
@@ -238,6 +256,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
   },
@@ -275,6 +296,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
@@ -314,6 +338,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
   },
@@ -351,6 +378,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
@@ -390,6 +420,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
   },
@@ -427,6 +460,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary500",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary500",
@@ -466,6 +502,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
   },
@@ -503,6 +542,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
@@ -542,6 +584,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
   },
@@ -579,6 +624,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
@@ -618,6 +666,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
   },
@@ -655,6 +706,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.primary100",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.primary100",
@@ -694,6 +748,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
@@ -731,6 +788,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",
@@ -770,6 +830,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
@@ -807,6 +870,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",
@@ -846,6 +912,9 @@ Object {
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
   },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
+  },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
@@ -883,6 +952,9 @@ Object {
     "backgroundColor": "$theme.colors.mono300",
     "color": "$theme.colors.mono600",
     "cursor": "not-allowed",
+  },
+  ":focus:enabled": Object {
+    "backgroundColor": "$theme.colors.mono400",
   },
   ":hover:enabled": Object {
     "backgroundColor": "$theme.colors.mono400",

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -73,6 +73,9 @@ function getStyleForKind({$theme, $kind}) {
         ':hover:enabled': {
           backgroundColor: $theme.colors.primary500,
         },
+        ':focus:enabled': {
+          backgroundColor: $theme.colors.primary500,
+        },
         ':active:enabled': {
           backgroundColor: $theme.colors.primary600,
         },
@@ -82,6 +85,9 @@ function getStyleForKind({$theme, $kind}) {
         color: $theme.colors.primary,
         backgroundColor: $theme.colors.primary50,
         ':hover:enabled': {
+          backgroundColor: $theme.colors.primary100,
+        },
+        ':focus:enabled': {
           backgroundColor: $theme.colors.primary100,
         },
         ':active:enabled': {
@@ -95,6 +101,9 @@ function getStyleForKind({$theme, $kind}) {
         ':hover:enabled': {
           backgroundColor: $theme.colors.mono400,
         },
+        ':focus:enabled': {
+          backgroundColor: $theme.colors.mono400,
+        },
         ':active:enabled': {
           backgroundColor: $theme.colors.mono500,
         },
@@ -104,6 +113,9 @@ function getStyleForKind({$theme, $kind}) {
         color: $theme.colors.primary,
         backgroundColor: 'transparent',
         ':hover:enabled': {
+          backgroundColor: $theme.colors.mono200,
+        },
+        ':focus:enabled': {
           backgroundColor: $theme.colors.mono200,
         },
         ':active:enabled': {


### PR DESCRIPTION
### Button Component

Adding `:focus:enabled` styling so that keyboard users will know which button is focused when tabbing through.

Seems to be in line with what antd and material-ui are doing. I'm using our `hover` style here because we don't have a separate styling for `focus`. @nguyensomniac can you take a look?

#### Preview

[Live Preview](https://deploy-preview-216--baseui.netlify.com/)