### PR TITLE
feat(pagination): initial implementation with Select integration (part 4 WIP)

### DIFF
--- a/src/pagination/select.js
+++ b/src/pagination/select.js
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import * as React from 'react';
+import {Select as DefaultSelect, TYPE} from '../select';
+import {StyledListItem} from '../menu';
+import {SelectInput, SelectTag} from './styled-components';
+import type {SelectMenuItemT} from './types';
+
+const noop = () => {};
+
+const getOptionLabel = item => item.label;
+
+// This is used internally only, not meant to be exported
+
+export default function Select({
+  currentPage,
+  options,
+  ...restProps
+}: {
+  currentPage: number,
+  options: Array<SelectMenuItemT>,
+}) {
+  return (
+    <DefaultSelect
+      // Required to re-initialize Select component so that selectedOptions work
+      key={currentPage}
+      options={options}
+      selectedOptions={[options[currentPage - 1]]}
+      rows={5}
+      type={TYPE.select}
+      getOptionLabel={getOptionLabel}
+      overrides={{
+        Input: SelectInput,
+        Tag: SelectTag,
+        DropDownItem: StyledListItem,
+      }}
+      // None of these props should be required
+      filterOption={() => false}
+      filterable={false}
+      multiple={false}
+      error={false}
+      textValue={''}
+      onBlur={noop}
+      onFocus={noop}
+      onMouseEnter={noop}
+      onMouseLeave={noop}
+      onMouseDown={noop}
+      onMouseUp={noop}
+      {...restProps}
+    />
+  );
+}

--- a/src/pagination/styled-components.js
+++ b/src/pagination/styled-components.js
@@ -8,6 +8,8 @@ LICENSE file in the root directory of this source tree.
 import {styled} from '../styles';
 import {StyledList} from '../menu';
 import {StyledBaseButton} from '../button';
+import {StyledInput} from '../input';
+import {StyledTag} from '../select';
 
 export const Root = styled('div', {
   display: 'flex',
@@ -22,8 +24,10 @@ export const MaxLabel = styled('span', ({$theme}) => ({
 
 export const DropdownContainer = styled('div', ({$theme}) => ({
   position: 'relative',
+  cursor: 'pointer',
   marginLeft: $theme.sizing.scale600,
   marginRight: $theme.sizing.scale300,
+  minWidth: `calc(${$theme.sizing.scale1600} + ${$theme.sizing.scale400})`,
 }));
 
 export const DropdownMenu = styled(StyledList, ({$theme}) => ({
@@ -38,5 +42,17 @@ export const DropdownMenu = styled(StyledList, ({$theme}) => ({
 
 export const DropdownButton = styled(StyledBaseButton, ({$theme}) => ({
   color: $theme.colors.black,
-  minWidth: `calc(${$theme.sizing.scale1600} + ${$theme.sizing.scale400})`,
+}));
+
+// The following are meant to be used internallt and not exported to external customers
+
+export const SelectInput = styled(StyledInput, {display: 'none'});
+export const SelectTag = styled(StyledTag, ({$theme}) => ({
+  ...$theme.typography.font300,
+  color: $theme.colors.black,
+  // Hacking to get around not being able to override borders
+  paddingTop: `calc(${$theme.sizing.scale300} - 1px)`,
+  paddingBottom: `calc(${$theme.sizing.scale300} - 1px)`,
+  paddingLeft: `calc(${$theme.sizing.scale600} - 1px)`,
+  paddingRight: `calc(${$theme.sizing.scale600} - 1px)`,
 }));

--- a/src/pagination/types.js
+++ b/src/pagination/types.js
@@ -8,6 +8,12 @@ LICENSE file in the root directory of this source tree.
 import type {OverrideT} from '../helpers/overrides';
 import {STATE_CHANGE_TYPE} from './constants';
 
+export type SelectMenuItemT = {
+  id: string,
+  label: number,
+  disabled?: boolean,
+};
+
 export type StateReducerFnT = (
   changeType: $Keys<typeof STATE_CHANGE_TYPE>,
   changes: StatefulContainerStateT,
@@ -19,9 +25,8 @@ export type OverridesT = {
   PrevButton?: OverrideT<*>,
   NextButton?: OverrideT<*>,
   MaxLabel?: OverrideT<*>,
+  Select?: OverrideT<*>,
   DropdownContainer?: OverrideT<*>,
-  DropdownButton?: OverrideT<*>,
-  DropdownMenu?: OverrideT<*>,
 };
 
 export type PaginationPropsT = {

--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -128,7 +128,7 @@ export const SearchIcon = styled('img', props => {
 });
 
 export const DropDown = styled(MenuList, ({$theme, $isOpen, $type, $rows}) => ({
-  height: $rows ? parseInt($theme.sizing.scale600) * $rows + 'px' : null,
+  height: $rows ? `calc(${$theme.sizing.scale900} * ${$rows})` : null,
   overflowY: $rows ? 'scroll' : null,
   display: !$isOpen ? 'none' : null,
   top: $type === TYPE.select ? $theme.sizing.scale600 : null,


### PR DESCRIPTION
### Pagination Component

This is a WIP PR to integrate with our `Select` component. I think I got it as far as I could with our current implementations. There will be changes needed to `Select` to integrate further. We are pretty close though!!

Comparing with the Live Preview from the previous part 3 (no integration): [Ideal State](https://deploy-preview-214--baseui.netlify.com/?selectedKind=Pagination&selectedStory=Stateful%20Pagination&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

This is the current state of the integration: [Current State](https://deploy-preview-227--baseui.netlify.com/?selectedKind=Pagination&selectedStory=Stateful%20Pagination&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

Suggestions (from my perspective) on how to get to the ideal state and some open questions:

* How do we get the hover effect on the drop-down button?
* Should we separate `Select` and `Autocomplete` into 2 internal components, so that the logic does not have to overlap between the two?
* Instead of overriding sub-components of `Menu`, we should allow full override of the entire `Menu` component. This way the drop-down look and feel is entirely up to the user to modify if they want.

Some other issues that I observed:

* `Root` is rendered twice (at least for Select mode). Once in the main `render()` function and another by the `InputComponent`. This caused some confusion when I tried to override `Root`.
* `InputContainer` isn't overridable in Select mode, but it is when in Search/Autocomplete mode. This also caused some confusion for me.

Would love some suggestions and insight here as I continue to work on the integration!