### PR TITLE
fix(select): remove DefaultPropsT

### DIFF
--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -17,6 +17,7 @@ exports[`Stateless select should render component in search mode and false for m
   options={Array []}
   overrides={Object {}}
   selectedOptions={Array []}
+  textValue=""
   type="search"
 >
   <MockStyledComponent>
@@ -48,6 +49,7 @@ exports[`Stateless select should render component in search mode and false for m
         required={false}
         size="default"
         startEnhancer={null}
+        value=""
       >
         <MockStyledComponent
           $disabled={false}
@@ -219,6 +221,7 @@ exports[`Stateless select should render component in search mode and true for mu
   options={Array []}
   overrides={Object {}}
   selectedOptions={Array []}
+  textValue=""
   type="search"
 >
   <MockStyledComponent>
@@ -250,6 +253,7 @@ exports[`Stateless select should render component in search mode and true for mu
         required={false}
         size="default"
         startEnhancer={null}
+        value=""
       >
         <MockStyledComponent
           $disabled={false}
@@ -421,6 +425,7 @@ exports[`Stateless select should render component in select mode and false for m
   options={Array []}
   overrides={Object {}}
   selectedOptions={Array []}
+  textValue=""
   type="select"
 >
   <MockStyledComponent>
@@ -602,6 +607,7 @@ exports[`Stateless select should render component in select mode and true for mu
   options={Array []}
   overrides={Object {}}
   selectedOptions={Array []}
+  textValue=""
   type="select"
 >
   <MockStyledComponent>

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -20,7 +20,6 @@ import {Input as InputComponent} from '../input';
 import {ICON, TYPE, STATE_CHANGE_TYPE} from './constants';
 import SelectDropDown from './dropdown';
 import type {
-  DefaultPropsT,
   LabelT,
   OptionT,
   PropsT,
@@ -30,7 +29,7 @@ import type {
 import {getOverride} from '../helpers/overrides';
 
 class Select extends React.Component<PropsT, StatelessStateT> {
-  static defaultProps: DefaultPropsT = {
+  static defaultProps = {
     overrides: {},
     selectedOptions: [],
     options: [],
@@ -44,6 +43,8 @@ class Select extends React.Component<PropsT, StatelessStateT> {
     error: false,
     autoFocus: false,
     filterable: false,
+    multiple: false,
+    textValue: '',
     filterOption: (option: OptionT, query: string) => {
       return (
         typeof option.label === 'string' &&

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -45,20 +45,6 @@ export type OverridesDropDownT = {
   DropDownItem?: OverrideT<*>,
 };
 
-export type DefaultPropsT = {
-  overrides?: OverridesT,
-  options?: Array<OptionT>,
-  error: boolean,
-  autoFocus: boolean,
-  onChange: (e: SyntheticEvent<HTMLInputElement>, params: ParamsT) => void,
-  onMouseEnter: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onMouseLeave: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onMouseDown: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onMouseUp: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onFocus: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onBlur: (e: SyntheticEvent<HTMLInputElement>) => void,
-};
-
 export type PropsT = {
   options: Array<OptionT>,
   overrides?: OverridesT,
@@ -67,7 +53,7 @@ export type PropsT = {
   textValue: string,
   multiple: boolean,
   error: boolean,
-  autoFocus?: boolean,
+  autoFocus: boolean,
   type?: string,
   filterable: boolean,
   filterOption: (OptionT, string) => boolean,


### PR DESCRIPTION
### Select Component

According to discussions here: https://github.com/uber-web/baseui/pull/227#pullrequestreview-154460579

`defaultProps` will properly marked "required" props from `PropsT` as optional so we do not need the additional typing.