### PR TITLE
docs: update stories to use new button component

### DIFF
--- a/src/modal/examples.js
+++ b/src/modal/examples.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 /* global document */
 import * as React from 'react';
 import {select as selectKnob} from '@storybook/addon-knobs';
-import {Button} from '../popover/examples';
+import {Button} from '../button';
 import {Input} from '../input';
 
 import {styled} from '../styles';

--- a/src/popover/examples.js
+++ b/src/popover/examples.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 import {boolean, number} from '@storybook/addon-knobs';
 
+import {Button} from '../button';
 import {styled} from '../styles';
 import {
   PLACEMENT,
@@ -27,29 +28,6 @@ function popoverContent() {
     </StyledPopoverPadding>
   );
 }
-
-// TODO replace with real button when its available
-export const Button = styled('button', ({$theme}) => ({
-  padding: `${$theme.sizing.scale200} ${$theme.sizing.scale400}`,
-  fontWeight: 'bold',
-  backgroundColor: $theme.colors.buttonPrimaryFill,
-  borderRadius: '3px',
-  border: 'none',
-  color: '#fff',
-  cursor: 'pointer',
-  transitionProperty: 'background-color',
-  transitionDuration: '0.2s',
-  fontSize: '14px',
-  ':hover': {
-    backgroundColor: $theme.colors.buttonPrimaryHover,
-  },
-  ':focus': {
-    backgroundColor: $theme.colors.buttonPrimaryHover,
-  },
-  ':active': {
-    backgroundColor: $theme.colors.buttonPrimaryActive,
-  },
-}));
 
 const Centered = styled('div', {
   position: 'relative',

--- a/src/tooltip/examples.js
+++ b/src/tooltip/examples.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import React from 'react';
 import {styled} from '../styles';
-import {Button} from '../popover/examples';
+import {Button} from '../button';
 import {StatefulTooltip, TRIGGER_TYPE, PLACEMENT} from './index';
 
 const Centered = styled('div', {


### PR DESCRIPTION
I've been using a fake button for the popover/tooltip/modal stories – updating these to use the new Button component.