### PR TITLE
feat(testing): integrate saucelabs

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -47,5 +47,10 @@ steps:
     plugins:
       'docker-compose':
         run: e2e-test
+        pull:
+          - e2e-server
+          - e2e-server-healthy
+          - sauce-tunnel
+          - sauce-tunnel-healthy
     agents:
       queue: workers

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -42,14 +42,10 @@ steps:
         run: baseui
     agents:
       queue: workers
-  - name: ':selenium: :chromium:'
+  - name: ':saucelabs: :selenium:'
     command: yarn e2e:test
     plugins:
       'docker-compose':
-        run: e2e-test-chrome
-        pull:
-          - e2e-test-chrome
-          - e2e-server
-          - e2e-server-healthy
+        run: e2e-test
     agents:
       queue: workers

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,4 +5,3 @@ storybook-static
 coverage
 docs
 webpack.e2e.config.js
-src/e2e-test-utils.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -5,3 +5,4 @@ storybook-static
 coverage
 docs
 webpack.e2e.config.js
+src/e2e-test-utils.js

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,15 @@
+# Testing
+
+## Running end to end tests locally
+
+Build the assets & start serving them using:
+
+```sh
+yarn e2e:build && yarn e2e:serve
+```
+
+In a new terminal window start the tests using:
+
+```sh
+yarn e2e:test
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,47 @@
 version: '2.1'
 services:
-  chrome-standalone:
-    image: selenium/standalone-chrome:latest@sha256:b3cd083132dc390a9f623223b45db66a44b043c2ba1e962b85a2004f67bc0831
-    network_mode: 'host'
+  # so tests can run against localhost
+  sauce-tunnel:
+    image: henrrich/docker-sauce-connect:latest@sha256:9921657d1a3db8832f868ab25491363756abae52025a8d5af888aadc42ed31e9
     restart: always
+    expose:
+      - 4445
     ports:
-      - '4444:4444'
+      - 4445
+    network_mode: 'host'
+    command:
+      [
+        '-u',
+        '${SAUCE_USERNAME}',
+        '-k',
+        '${SAUCE_ACCESS_KEY}',
+        '-i',
+        '${BUILDKITE_BUILD_NUMBER}',
+        '-p',
+      ]
+    environment:
+      - SAUCE_USERNAME
+      - SAUCE_ACCESS_KEY
+      - BUILDKITE_BUILD_NUMBER
+    healthcheck:
+      test:
+        [
+          'CMD-SHELL',
+          'grep -R "Sauce Connect is up" /tmp/sc-${BUILDKITE_BUILD_NUMBER}.log || exit 1',
+        ]
+      interval: 5s
+      timeout: 5m
+      retries: 10
 
+  # docker-compose run does not wait on healthchecks, so proxy using this service
+  sauce-tunnel-healthy:
+    build: .
+    network_mode: 'host'
+    depends_on:
+      sauce-tunnel:
+        condition: service_healthy
+
+  # this spins up a server that serves the html/js/css for the e2e tests
   e2e-server:
     build: .
     command: node e2e/serve.js
@@ -14,7 +49,6 @@ services:
       - 8080
     ports:
       - '8080:8080'
-    # network_mode: "host"
     healthcheck:
       test:
         [
@@ -25,6 +59,7 @@ services:
       timeout: 10s
       retries: 5
 
+  # tests if the e2e-server is ready to serve traffic
   e2e-server-healthy:
     build: .
     network_mode: 'host'
@@ -32,13 +67,13 @@ services:
       e2e-server:
         condition: service_healthy
 
-  e2e-test-chrome:
+  # running the e2e tests in ci
+  e2e-test:
     build: .
     network_mode: 'host'
     depends_on:
-      - chrome-standalone
       - e2e-server-healthy
-    command: yarn e2e:test
+      - sauce-tunnel-healthy
     environment:
       - CODECOV_TOKEN
       - CI=true
@@ -49,7 +84,9 @@ services:
       - BUILDKITE_BUILD_URL
       - BUILDKITE_PROJECT_SLUG
       - BUILDKITE_COMMIT
-      - SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub
+      - SAUCE_USERNAME
+      - SAUCE_ACCESS_KEY
+      - SELENIUM_REMOTE_URL=http://localhost:4445/wd/hub
 
   baseui:
     build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,32 @@
 version: '2.1'
 services:
+  # to run selenium with chrome locally
+  chrome-standalone:
+    image: selenium/standalone-chrome:latest@sha256:b3cd083132dc390a9f623223b45db66a44b043c2ba1e962b85a2004f67bc0831
+    network_mode: 'host'
+    restart: always
+    ports:
+      - '4444:4444'
+
+  e2e-test-chrome:
+    build: .
+    network_mode: 'host'
+    depends_on:
+      - chrome-standalone
+      - e2e-server-healthy
+    command: yarn e2e:test
+    environment:
+      - CODECOV_TOKEN
+      - CI=true
+      - BUILDKITE
+      - BUILDKITE_BRANCH
+      - BUILDKITE_BUILD_NUMBER
+      - BUILDKITE_JOB_ID
+      - BUILDKITE_BUILD_URL
+      - BUILDKITE_PROJECT_SLUG
+      - BUILDKITE_COMMIT
+      - SELENIUM_REMOTE_URL=http://localhost:4444/wd/hub
+
   # so tests can run against localhost
   sauce-tunnel:
     image: henrrich/docker-sauce-connect:latest@sha256:9921657d1a3db8832f868ab25491363756abae52025a8d5af888aadc42ed31e9
@@ -86,7 +113,6 @@ services:
       - BUILDKITE_COMMIT
       - SAUCE_USERNAME
       - SAUCE_ACCESS_KEY
-      - SELENIUM_REMOTE_URL=http://localhost:4445/wd/hub
 
   baseui:
     build: .

--- a/jest-e2e.config.js
+++ b/jest-e2e.config.js
@@ -3,7 +3,7 @@
 
 module.exports = {
   rootDir: 'src',
-  setupFiles: ['<rootDir>/e2e-test.setup.js'],
+  setupTestFrameworkScriptFile: '<rootDir>/e2e-test.setup.js',
   testMatch: ['**/e2e.js'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/', '/dist/'],

--- a/src/checkbox/e2e.js
+++ b/src/checkbox/e2e.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import e2e from '../utils/e2e-test-utils';
+import e2e from '../e2e-test-utils';
 
 const {run, By, goToUrl, runBrowserAccecibilityTest, getElement} = e2e;
 import {suite, tests} from './examples';

--- a/src/e2e-test-utils.js
+++ b/src/e2e-test-utils.js
@@ -4,7 +4,6 @@ Copyright (c) 2018 Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
-// @flow
 import * as webdriver from 'selenium-webdriver';
 import AxeBuilder from 'axe-webdriverjs';
 
@@ -16,11 +15,7 @@ let currentDriver;
 
 const location = 'http://localhost:8080';
 
-const goToUrl = async function(
-  driver: webdriver$WebDriver,
-  suite: string,
-  test: string,
-) {
+const goToUrl = async function(driver, suite, test) {
   const url = location + `/?suite=${suite}&test=${test}`;
   await driver.get(url);
   let errors = await driver
@@ -35,16 +30,17 @@ const goToUrl = async function(
   await new Promise(resolve => resolve());
 };
 
-const run = function(
-  testSuite: (driver: webdriver$WebDriver, browser: string) => void,
-) {
+const run = function(testSuite) {
   browsers.forEach(browser => {
     if (!activeDrivers[browser]) {
-      const browserMethod = webdriver.Capabilities[browser];
-      const caps = browserMethod();
+      const capabilities = {
+        browserName: browser,
+        username: process.env.SAUCE_USERNAME,
+        accessKey: process.env.SAUCE_ACCESS_KEY,
+      };
       activeDrivers[browser] = new webdriver.Builder()
         .forBrowser(browser)
-        .withCapabilities(caps)
+        .withCapabilities(capabilities)
         .build();
     }
     afterAll(async function() {
@@ -56,8 +52,8 @@ const run = function(
 };
 
 const runBrowserAccecibilityTest = async function(
-  driver: webdriver$WebDriver,
-  rootSelector: string = 'body',
+  driver,
+  rootSelector = 'body',
 ) {
   const builder = AxeBuilder(driver).include(rootSelector);
   const results = await builder.analyze();
@@ -67,10 +63,7 @@ const runBrowserAccecibilityTest = async function(
   }
 };
 
-const getElement = async function(
-  parent: webdriver$WebElement | webdriver$WebDriver,
-  css: string,
-) {
+const getElement = async function(parent, css) {
   return await parent.findElement(By.css(css));
 };
 

--- a/src/e2e-test-utils.js
+++ b/src/e2e-test-utils.js
@@ -4,6 +4,8 @@ Copyright (c) 2018 Uber Technologies, Inc.
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+/* eslint-disable */
+/* no-flow */
 import * as webdriver from 'selenium-webdriver';
 import AxeBuilder from 'axe-webdriverjs';
 
@@ -14,6 +16,9 @@ const activeDrivers = {};
 let currentDriver;
 
 const location = 'http://localhost:8080';
+const JOB_IDENTIFIER = process.env.BUILDKITE_BUILD_NUMBER;
+const SAUCE_USERNAME = process.env.SAUCE_USERNAME;
+const SAUCE_ACCESS_KEY = process.env.SAUCE_ACCESS_KEY;
 
 const goToUrl = async function(driver, suite, test) {
   const url = location + `/?suite=${suite}&test=${test}`;
@@ -35,12 +40,18 @@ const run = function(testSuite) {
     if (!activeDrivers[browser]) {
       const capabilities = {
         browserName: browser,
-        username: process.env.SAUCE_USERNAME,
-        accessKey: process.env.SAUCE_ACCESS_KEY,
+        username: SAUCE_USERNAME,
+        accessKey: SAUCE_ACCESS_KEY,
+        tunnelIdentifier: JOB_IDENTIFIER,
       };
       activeDrivers[browser] = new webdriver.Builder()
         .forBrowser(browser)
         .withCapabilities(capabilities)
+        .usingServer(
+          `http://${capabilities.username}:${
+            capabilities.accessKey
+          }@ondemand.saucelabs.com:80/wd/hub`,
+        )
         .build();
     }
     afterAll(async function() {

--- a/src/e2e-test.setup.js
+++ b/src/e2e-test.setup.js
@@ -9,4 +9,4 @@ import 'babel-polyfill';
 import 'chromedriver';
 import 'geckodriver';
 
-jest.setTimeout(5000);
+jest.setTimeout(20000);

--- a/src/modal/e2e.js
+++ b/src/modal/e2e.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 
 import * as webdriver from 'selenium-webdriver';
-import e2e from '../utils/e2e-test-utils';
+import e2e from '../e2e-test-utils';
 import {suite, examples} from './examples';
 
 const {run, goToUrl} = e2e;


### PR DESCRIPTION
This initial PR just integrates Sauce Labs with the project, but does not address a few important things, that will be covered in follow up PRs:

* run tests in different browsers
* proper instructions on running Sauce Labs tests from local dev envs
* migrating over to Nightwatch
* link sauce lab builds to PRs
* "thank you" to sauce labs in the README

https://saucelabs.com/beta/tests/b14ca805d1174333bb8949c5a2715389/commands