### PR TITLE
fix(overrides): propose new interface for getOverrideObject

### DIFF
--- a/src/helpers/__tests__/overrides.test.js
+++ b/src/helpers/__tests__/overrides.test.js
@@ -12,7 +12,7 @@ import {
   toObjectOverride,
   mergeOverrides,
   mergeOverride,
-  getOverrideObject,
+  getOverrides,
 } from '../overrides';
 
 function getMockComponent<T>(): React.ComponentType<T> {
@@ -137,22 +137,22 @@ describe('Helpers - Overrides', () => {
     });
   });
 
-  test('getOverrideObject', () => {
+  test('getOverrides', () => {
     const DefaultComponent = getMockComponent();
     const OverrideComponent = getMockComponent();
 
-    expect(getOverrideObject(null, DefaultComponent)).toEqual({
-      component: DefaultComponent,
-      props: {},
-    });
+    expect(getOverrides(null, DefaultComponent)).toEqual([
+      DefaultComponent,
+      {},
+    ]);
 
-    expect(getOverrideObject(OverrideComponent, DefaultComponent)).toEqual({
-      component: OverrideComponent,
-      props: {},
-    });
+    expect(getOverrides(OverrideComponent, DefaultComponent)).toEqual([
+      OverrideComponent,
+      {},
+    ]);
 
     expect(
-      getOverrideObject(
+      getOverrides(
         {
           component: OverrideComponent,
           props: {
@@ -164,14 +164,14 @@ describe('Helpers - Overrides', () => {
         },
         DefaultComponent,
       ),
-    ).toEqual({
-      component: OverrideComponent,
-      props: {
+    ).toEqual([
+      OverrideComponent,
+      {
         custom: 'prop',
         $style: {
           cursor: 'pointer',
         },
       },
-    });
+    ]);
   });
 });

--- a/src/helpers/overrides.js
+++ b/src/helpers/overrides.js
@@ -75,18 +75,15 @@ export function toObjectOverride<T>(
 }
 
 /**
- * Get a convenient override object that will always have {component, props}
+ * Get a convenient override array that will always have [component, props]
  */
-export function getOverrideObject<T>(
+export function getOverrides<T>(
   override: ?OverrideT<T>,
   defaultComponent: React.ComponentType<T>,
-): {
-  component: React.ComponentType<T>,
-  props: {},
-} {
+): [React.ComponentType<T>, {}] {
   const component = getOverride(override) || defaultComponent;
   const props = getOverrideProps(override);
-  return {component, props};
+  return [component, props];
 }
 
 /**

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -19,7 +19,7 @@ import {
   DropdownButton as StyledDropdownButton,
 } from './styled-components';
 import {ArrowLeft, ArrowRight, ArrowDown} from './icons';
-import {getOverrideObject} from '../helpers/overrides';
+import {getOverrides} from '../helpers/overrides';
 import type {PaginationPropsT, PaginationStateT} from './types';
 
 type MenuItemT = {
@@ -99,34 +99,31 @@ export default class Pagination extends React.PureComponent<
     const {overrides = {}, currentPage, labels, numPages} = this.props;
     const {isMenuOpen} = this.state;
 
-    const {component: Root, props: rootProps} = getOverrideObject(
-      overrides.Root,
-      StyledRoot,
-    );
-    const {component: PrevButton, props: prevButtonProps} = getOverrideObject(
+    const [Root, rootProps] = getOverrides(overrides.Root, StyledRoot);
+    const [PrevButton, prevButtonProps] = getOverrides(
       overrides.PrevButton,
       StyledBaseButton,
     );
-    const {component: NextButton, props: nextButtonProps} = getOverrideObject(
+    const [NextButton, nextButtonProps] = getOverrides(
       overrides.NextButton,
       StyledBaseButton,
     );
-    const {component: MaxLabel, props: maxLabelProps} = getOverrideObject(
+    const [MaxLabel, maxLabelProps] = getOverrides(
       overrides.MaxLabel,
       StyledMaxLabel,
     );
-    const {
-      component: DropdownContainer,
-      props: dropdownContainerProps,
-    } = getOverrideObject(overrides.DropdownContainer, StyledDropdownContainer);
-    const {
-      component: DropdownButton,
-      props: dropdownButtonProps,
-    } = getOverrideObject(overrides.DropdownButton, StyledDropdownButton);
-    const {
-      component: DropdownMenu,
-      props: dropdownMenuProps,
-    } = getOverrideObject(overrides.DropdownMenu, Menu);
+    const [DropdownContainer, dropdownContainerProps] = getOverrides(
+      overrides.DropdownContainer,
+      StyledDropdownContainer,
+    );
+    const [DropdownButton, dropdownButtonProps] = getOverrides(
+      overrides.DropdownButton,
+      StyledDropdownButton,
+    );
+    const [DropdownMenu, dropdownMenuProps] = getOverrides(
+      overrides.DropdownMenu,
+      Menu,
+    );
 
     const options = this.getMenuOptions(numPages);
 


### PR DESCRIPTION
Wanted to get feedback on this before I make further changes. Right now, using `getOverrideObject` is cumbersome because of the redundant `component` and `props` destructuring. I want to change the return value to an array, which really simplifies that.

I don't see any drawback in this approach, plus it's an internal helper we use. We get the convenience with less code. I modified `pagination.js` to show an example of how it's used. Thoughts?