### PR TITLE
fix(e2e): add retry logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "e2e:build": "webpack --config webpack.e2e.config.js --mode=production",
     "e2e:serve": "static-server e2e/dist --port 8080",
     "e2e:test": "nightwatch --filter e2e.js",
-    "e2e:test:ci": "nightwatch --filter e2e.js --env chrome-mac,chrome-windows,iPhone-X",
+    "e2e:test:ci": "nightwatch --filter e2e.js --env chrome-mac,chrome-windows,iPhone-X --retries 2",
     "prepublish": "npm run build",
     "license": "license-check-and-add"
   },


### PR DESCRIPTION
Sometimes the sauce lab connection from buildkite to suacelab seems flaky. It causes tests to fail sometimes - this will try any failed tests cases up to two more times.