### PR TITLE
rfc(input) Propsed changes to flow typing for SyntheticEvent

### DIFF
--- a/rfcs/input-component.md
+++ b/rfcs/input-component.md
@@ -73,8 +73,12 @@ export default () => {
   * `nextState` - a new state value to be set
   * `currentState` - current state value
   * `stateToSet` - a return value that the state will be updated with
-* `onChange: (e: SyntheticEvent<HTMLInputElement>) => void` - Optional
+* `onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void` - Optional
   onChange event handler.
+* `onBlur: (e: SyntheticFocusEvent<HTMLInputElement>) => void` - Optional
+  onBlur event handler.
+* `onFocus: (e: SyntheticFocusEvent<HTMLInputElement>) => void` - Optional
+  onFocus event handler.
 
 ## Input component API
 
@@ -125,11 +129,11 @@ export default () => {
   Defines styles for inputs that are grouped with other controls.
 * `size: 'default' | 'compact'`
   Defines the size of an input control.
-* `onChange: Function` - Optional
+* `onChange: SyntheticInputEvent` - Optional
   onChange event handler.
-* `onFocus: Function` - Optional
+* `onFocus: SyntheticFocusEvent` - Optional
   onFocus event handler.
-* `onBlur: Function` - Optional
+* `onBlur: SyntheticFocusEvent` - Optional
   onBlur event handler.
 
 ## Presentational components props API


### PR DESCRIPTION
It's more accurate to use [`SyntheticFocusEvent`](https://github.com/facebook/flow/blob/v0.82.0/lib/react-dom.js#L170) and [`SyntheticInputEvent`](https://github.com/facebook/flow/blob/v0.82.0/lib/react-dom.js#L170) instead of the generic `SyntheticEvent` for `onBlur`/`onFocus` and `onChange` respectively, they have more properties such as `relatedTarget`.

If this RFC is approved, I'll open another PR to include this work for `input`.

Other components are also using `SyntheticEvent`, if it makes sense, I'll include the RFC changes all in here.