### PR TITLE
feat(toast): add toaster component (part 1)

### DIFF
--- a/rfcs/toast-component.md
+++ b/rfcs/toast-component.md
@@ -80,16 +80,19 @@ export default () => {
   `onMouseLeave: function` - Optional
   A callback function called when the notification's Body element gets a `mouseleave` event
 * `overrides: {Body, Svg}` - Optional
-  Overrides for presentational components. See "Presentational Components Props API" below.
+  Overrides for presentational components. See "Presentational Components Props API" below
   * `[ComponentName]: ReactComponent | {props: {}, style: {}, component: ReactComponent}` - Optional
 * `autoHideDuration: number` - Optional. Defaults to 0
   The number of milliseconds to wait before automatically dismissing a notification. This behavior is disabled when the value is set to 0
 
-## Presentational components props API
+## Toast Presentational components props API
 
-These properties are passed to every presentational (styled) component that is exported:
+These properties are passed to every Toast's presentational (styled) component that is exported:
 
-* `$kind: type`
+* `$kind: KindTypeT`
+* `$closeable: boolean`,
+* `$isHidden: boolean`,
+* `$isAnimating: boolean`,
 * `$theme: theme`
 
 ## KIND Constant
@@ -98,6 +101,52 @@ These properties are passed to every presentational (styled) component that is e
 * `positive` - Generally used as a confirmation of a succesful action or operation  
 * `warning` - Generally used for messages with an warning context
 * `negative` - Generally used as a notification of an error happened as a result of an action or operation
+
+## `Toaster` API
+
+* `placement: 'inline' | 'topLeft' | 'top' | 'topRight' | 'bottomRight' | 'bottom' | 'bottomLeft'` - Optional. Defaults to 'top'
+  Position of a toast notification ontainer relative to the browser window
+* `usePortal: boolean` - Optional. Defaults to `true`
+  Defines if the portal is used to append a container to the `body` element. In both cases the container is positioned `fixed`
+* `overrides: {Root, ToastBody, ToastCloseIcon}` - Optional
+  Overrides for presentational components. See "Presentational Components Props API" below.
+  * `[ComponentName]: ReactComponent | {props: {}, style: {}, component: ReactComponent}` - Optional
+* `autoHideDuration: number` - Optional. Defaults to 0
+  The number of milliseconds to wait before automatically dismissing a notification. This behavior is disabled when the value is set to 0
+
+## Toaster Presentational components props API
+
+These properties are passed to every presentational (styled) component of a Toaster:
+
+* `$placement: PlacementTypeT`
+
+## PLACEMENT Constant
+
+* `topLeft` - defines position of toasts relative to the browser window
+* `top` - defines position of toasts relative to the browser window
+* `topRight` - defines position of toasts relative to the browser window
+* `bottomRight` - defines position of toasts relative to the browser window
+* `bottom` - defines position of toasts relative to the browser window
+* `bottomLeft` - defines position of toasts relative to the browser window
+
+## toaster API
+
+* `create: (props?: $Shape<ToasterPropsT>): React.Node => {}`
+  Creates a Toaster container component. There is only one `toaster` can be created on a page.
+* `show: (children: React.Node, props: $Shape<ToastPropsT>): ?React.Key => {}`
+  Creates a Toast and renders it in the Toaster container. `toaster.show()` can only be called on the client side. `toaster.create()` must be called first and the Toaster must be mounted before any `toaster.show()` call
+* `info: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {}`
+  Creates a `KIND.info` type Toast and renders it in the Toaster container. `toaster.info()` can only be called on the client side. `toaster.create()` must be called first and the Toaster must be mounted before any `toaster.info()` call
+* `positive: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {}`
+  Creates a `KIND.positive` type Toast and renders it in the Toaster container. `toaster.positive()` can only be called on the client side. `toaster.create()` must be called first and the Toaster must be mounted before any `toaster.positive()` call
+* `warning: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {}`
+  Creates a `KIND.warning` type Toast and renders it in the Toaster container. `toaster.warning()` can only be called on the client side. `toaster.create()` must be called first and the Toaster must be mounted before any `toaster.warning()` call
+* `negative: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {}`
+  Creates a `KIND.negative` type Toast and renders it in the Toaster container. `toaster.negative()` can only be called on the client side. `toaster.create()` must be called first and the Toaster must be mounted before any `toaster.negative()` call
+* `update: (key: React.Key, props: $Shape<ToastPropsT>): void => {}`
+  Updated an earlier created Toast.
+* `clear: (key?: React.Key): void => {}`,
+  Dismissed a specific Toast or clears all rendered toasts if no toast key is passed.
 
 ## Dependencies
 
@@ -108,4 +157,3 @@ These properties are passed to every presentational (styled) component that is e
 * Toast notification container element will have `role="alert"` set on it
 * When multiple alerts are displayed and positioned relative to the browser window they won't overlap but displayed in a column way, latest notifications are displayed at the initial position of a chosen placement
 * When a notification is set to be dissmissed automatically after a provided `autoHideDuration` time hovering or focusing the notification will prevend the notification from disappearing and reset the timeout to the initial `autoHideDuration` value
-* Think about handling a case where the number of notifications is more than a screen can fit, possible solution is to have the notifications that overflow hidden (older notifications) or have the column of notifications scrollable

--- a/src/toast/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/toast/__tests__/__snapshots__/styled-components.test.js.snap
@@ -18,8 +18,9 @@ Object {
   "paddingLeft": "$theme.sizing.scale600",
   "paddingRight": "$theme.sizing.scale600",
   "paddingTop": "$theme.sizing.scale600",
+  "pointerEvents": "auto",
   "transitionDuration": "$theme.animation.timing100",
-  "transitionProperty": "opacity, height",
+  "transitionProperty": "all",
   "transitionTimingFunction": "$theme.animation.easeInOutCurve",
   "width": "288px",
 }

--- a/src/toast/__tests__/toaster.test.js
+++ b/src/toast/__tests__/toaster.test.js
@@ -1,0 +1,361 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {mount} from 'enzyme';
+import {
+  KIND,
+  PLACEMENT,
+  toaster,
+  Toaster,
+  Toast,
+  StyledRoot,
+  StyledBody,
+  StyledCloseIcon,
+} from '../index';
+
+// Mock React 16 portals
+const originalCreatePortal = ReactDOM.createPortal;
+
+jest.useFakeTimers();
+
+describe('toaster', () => {
+  let wrapper;
+
+  beforeAll(() => {
+    // $FlowFixMe
+    ReactDOM.createPortal = jest.fn(children => (
+      <div is-portal="true" key="portal">
+        {children}
+      </div>
+    ));
+  });
+
+  afterEach(() => {
+    ReactDOM.createPortal.mockClear();
+    wrapper && wrapper.unmount();
+  });
+
+  afterAll(() => {
+    // $FlowFixMe
+    ReactDOM.createPortal = originalCreatePortal;
+  });
+
+  test('toaster.create', () => {
+    wrapper = mount(toaster.create());
+    const renderedToaster = wrapper.find(Toaster).first();
+    expect(renderedToaster.instance().state.isMounted).toBe(true);
+    expect(renderedToaster.instance().state.toasts.length).toEqual(0);
+    expect(wrapper.find(StyledRoot).first()).toExist();
+  });
+
+  describe('toaster.create props', () => {
+    test.each(
+      Object.keys(PLACEMENT).map(pl => {
+        return [pl];
+      }),
+    )(
+      '%s placement is passed to the Toaster and StyledRoot component',
+      placement => {
+        const props = {placement};
+        wrapper = mount(toaster.create(props));
+        expect(
+          wrapper
+            .find(Toaster)
+            .first()
+            .props().placement,
+        ).toEqual(placement);
+        expect(
+          wrapper
+            .find(StyledRoot)
+            .first()
+            .props().$placement,
+        ).toEqual(placement);
+      },
+    );
+
+    test('portal is created when usePortal is set to true', () => {
+      wrapper = mount(toaster.create());
+      expect(
+        wrapper
+          .find(Toaster)
+          .first()
+          .props().usePortal,
+      ).toBe(true);
+      expect(ReactDOM.createPortal).toHaveBeenCalled();
+    });
+
+    test('portal is not created when usePortal is set to false', () => {
+      wrapper = mount(toaster.create({usePortal: false}));
+      expect(
+        wrapper
+          .find(Toaster)
+          .first()
+          .props().usePortal,
+      ).toBe(false);
+      expect(ReactDOM.createPortal).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('toaster overrides', () => {
+    test('Inner components override', () => {
+      const overrides = {
+        Root: jest
+          .fn()
+          .mockImplementation(({children}) => <div>{children}</div>),
+        ToastBody: jest
+          .fn()
+          .mockImplementation(({children}) => <div>{children}</div>),
+        ToastCloseIcon: jest
+          .fn()
+          .mockImplementation(({children}) => <svg>{children}</svg>),
+      };
+      // $FlowFixMe
+      wrapper = mount(toaster.create({overrides}));
+      const renderedToaster = wrapper.find(Toaster).first();
+      toaster.getRef = jest.fn().mockReturnValue(renderedToaster.instance());
+      toaster.show('Toast message');
+      wrapper.update();
+
+      Object.keys(overrides).forEach(name => {
+        expect(wrapper.find(overrides[name]).first()).toExist();
+      });
+    });
+
+    test('Inner components props and styles overrides', () => {
+      const overrides = {
+        Root: {
+          props: {'data-attr': 'root'},
+          style: {borderColor: 'skyblue'},
+        },
+        ToastBody: {
+          props: {'data-attr': 'body'},
+          style: {backgroundColor: 'skyblue'},
+        },
+        ToastCloseIcon: {
+          props: {'data-attr': 'closeIcon'},
+          style: {color: 'blue'},
+        },
+      };
+      const components = {
+        Root: StyledRoot,
+        ToastBody: StyledBody,
+        ToastCloseIcon: StyledCloseIcon,
+      };
+      wrapper = mount(toaster.create({overrides}));
+
+      const renderedToaster = wrapper.find(Toaster).first();
+      toaster.getRef = jest.fn().mockReturnValue(renderedToaster.instance());
+      toaster.show('Toast message');
+      wrapper.update();
+
+      Object.keys(overrides).forEach(name => {
+        const passedProps = wrapper
+          .find(components[name])
+          .first()
+          .props();
+        expect(passedProps['data-attr']).toEqual(
+          overrides[name].props['data-attr'],
+        );
+        expect(passedProps.$style).toEqual(overrides[name].style);
+      });
+    });
+  });
+
+  describe('toaster methods', () => {
+    let renderedToaster;
+
+    beforeEach(() => {
+      wrapper = mount(toaster.create());
+      renderedToaster = wrapper.find(Toaster).first();
+      toaster.getRef = jest.fn().mockReturnValue(renderedToaster.instance());
+    });
+
+    test('toaster[show | update | clear]', () => {
+      let toastCounter = 0;
+      const toasterInstance = renderedToaster.instance();
+
+      // test toast is updated
+      function getKey() {
+        return `test-toast-${toastCounter++}`;
+      }
+      const MockNode1 = jest.fn().mockImplementation(() => 'Toast 1');
+      const MockNode2 = jest.fn().mockImplementation(() => 'Toast 2');
+      const props1 = {key: getKey(), children: <MockNode1 />};
+      const props2 = {key: getKey(), children: <MockNode2 />};
+
+      const showSpy = jest.spyOn(toasterInstance, 'show');
+
+      // add the first Toast
+      const toastKey1: any = toaster.show(props1.children, {key: props1.key});
+      jest.runAllTimers();
+
+      expect(showSpy).toHaveBeenCalledTimes(1);
+      expect(showSpy).toHaveBeenCalledWith(props1);
+      expect(toasterInstance.state.toasts.length).toEqual(1);
+      expect(toasterInstance.state.toasts[0]).toMatchObject(props1);
+
+      // verify that first Toast is rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(1);
+      expect(wrapper.find(StyledBody).length).toEqual(1);
+      expect(wrapper.find(MockNode1).length).toEqual(1);
+
+      // add the second Toast
+      toaster.show(props2.children, {key: props2.key});
+      jest.runAllTimers();
+
+      expect(showSpy).toHaveBeenCalledTimes(2);
+      expect(showSpy).toHaveBeenLastCalledWith(props2);
+      expect(toasterInstance.state.toasts.length).toEqual(2);
+      expect(toasterInstance.state.toasts[1]).toMatchObject(props2);
+
+      // verify that second Toast is rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(2);
+      expect(wrapper.find(StyledBody).length).toEqual(2);
+      expect(wrapper.find(MockNode2).length).toEqual(1);
+
+      // test toast is updated
+      const updateSpy = jest.spyOn(toasterInstance, 'update');
+
+      const MockNode3 = jest.fn().mockImplementation(() => 'Toast updated');
+      const updatedProps = {
+        children: <MockNode3 />,
+        kind: KIND.positive,
+      };
+
+      toaster.update(toastKey1, updatedProps);
+      jest.runAllTimers();
+
+      expect(updateSpy).toHaveBeenCalled();
+      expect(updateSpy).toHaveBeenCalledWith(toastKey1, updatedProps);
+      expect(toasterInstance.state.toasts.length).toEqual(2);
+      expect(toasterInstance.state.toasts[0]).toMatchObject({
+        ...props1,
+        ...updatedProps,
+      });
+      expect(toasterInstance.state.toasts[1]).toMatchObject(props2);
+
+      // verify that updated children are rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(2);
+      expect(wrapper.find(StyledBody).length).toEqual(2);
+      expect(wrapper.find(MockNode1).length).toEqual(0);
+      expect(wrapper.find(MockNode3).length).toEqual(1);
+
+      // test toast is cleared
+      const clearSpy = jest.spyOn(toasterInstance, 'clear');
+
+      toaster.clear(toastKey1);
+      jest.runAllTimers();
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(clearSpy).toHaveBeenCalledWith(toastKey1);
+      expect(toasterInstance.state.toasts.length).toEqual(1);
+
+      // verify that dismissed toast is not rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(1);
+      expect(wrapper.find(StyledBody).length).toEqual(1);
+      expect(wrapper.find(MockNode3).length).toEqual(0);
+      expect(wrapper.find(MockNode2).length).toEqual(1);
+    });
+
+    test('info, positive, warning, negative methods and clear all', () => {
+      const toasterInstance = renderedToaster.instance();
+      let counter = 0;
+      ['info', 'positive', 'warning', 'negative'].forEach(method => {
+        const children = `${method} toast`;
+        toaster[method](children);
+        counter++;
+        const toastsLength = toasterInstance.state.toasts.length;
+        expect(toastsLength).toEqual(counter);
+        expect(toasterInstance.state.toasts[toastsLength - 1]).toMatchObject({
+          key: `toast-${counter - 1}`,
+          children,
+          kind: KIND[method],
+        });
+      });
+
+      // verify all toasts rendered
+      jest.runAllTimers();
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(4);
+      // verify oldest toasts are rendered last in the tree
+      expect(
+        wrapper
+          .find(Toast)
+          .last()
+          .props(),
+      ).toMatchObject({
+        kind: KIND.info,
+      });
+
+      // verify all toasts are cleared
+      const clearSpy = jest.spyOn(toasterInstance, 'clear');
+
+      toaster.clear();
+      jest.runAllTimers();
+
+      expect(clearSpy).toHaveBeenCalled();
+      expect(clearSpy).toHaveBeenCalledWith(undefined);
+
+      // verify no toasts are rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(0);
+    });
+
+    test('onClose toast handler is called', () => {
+      const onClose = jest.fn();
+      const toastKey = toaster.show('Toast message', {onClose});
+
+      // verify the toast is rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(1);
+
+      // verify the toast is cleared
+      toaster.clear(toastKey);
+      jest.runAllTimers();
+
+      // verify the onClose toast handler is called
+      expect(onClose).toHaveBeenCalled();
+
+      // verify no toasts are rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(0);
+    });
+
+    test('toast is cleared and onClose is called when it is dissmissed by a user', () => {
+      const toasterInstance = renderedToaster.instance();
+      const onClose = jest.fn();
+      toaster.show('Toast message', {onClose});
+
+      // verify the toast is rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(1);
+      const closeButton = wrapper.find(StyledCloseIcon).first();
+      expect(closeButton).toExist();
+
+      // verify the toast is cleared
+      closeButton.simulate('click');
+      jest.runAllTimers();
+
+      // verify the toast is removed from the list
+      expect(toasterInstance.state.toasts.length).toEqual(0);
+
+      // verify the onClose toast handler is called
+      expect(onClose).toHaveBeenCalled();
+
+      // verify no toasts are rendered
+      wrapper.update();
+      expect(wrapper.find(Toast).length).toEqual(0);
+    });
+  });
+});

--- a/src/toast/constants.js
+++ b/src/toast/constants.js
@@ -13,7 +13,6 @@ export const KIND = {
 };
 
 export const PLACEMENT = {
-  inline: 'inline',
   topLeft: 'topLeft',
   top: 'top',
   topRight: 'topRight',

--- a/src/toast/examples-list.js
+++ b/src/toast/examples-list.js
@@ -3,6 +3,7 @@
 
 module.exports = {
   SIMPLE_EXAMPLE: 'Toast notifications',
-  DISMISSABLE_EXAMPLE: 'Auto dismissable toasts',
+  TOASTER_EXAMPLE: 'Toaster example',
+  TOASTER_ADVANCED_EXAMPLE: "Toaster's update and clear example",
   OVERRIDES_EXAMPLE: 'Toasts with overrides',
 };

--- a/src/toast/examples.js
+++ b/src/toast/examples.js
@@ -7,8 +7,9 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import * as React from 'react';
 import {styled} from '../styles';
-import {Toast, KIND} from './index';
+import {Toast, toaster, KIND, PLACEMENT} from './index';
 import {Button, KIND as ButtonKind, SIZE} from '../button';
+import type {ToastPropsT} from './types';
 
 import examples from './examples-list';
 
@@ -41,51 +42,29 @@ const getBtnStyle = color => ({$theme}) => {
   };
 };
 
-class NotificationExample extends React.Component<{}, {toasts: []}> {
-  state = {
-    toasts: [],
-  };
-  toastId = 0;
-
+class ToasterExample extends React.Component<{}, {toasts: []}> {
   getToastProps(props) {
-    const toastId = this.toastId++;
     return {
-      key: toastId,
-      autoHideDuration: 4000,
-      onClose: this.getOnCloseHandler(toastId),
+      onClose: () => {
+        // eslint-disable-next-line no-console
+        console.log('Toast dismissed');
+      },
+      autoHideDuration: 5000,
       children: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
       ...props,
     };
   }
 
   add = props => () => {
-    const toastProps = this.getToastProps(props);
-    this.setState(state => {
-      const toasts = [...state.toasts];
-      toasts.unshift(toastProps);
-      return {toasts};
-    });
+    // $FlowFixMe
+    const toastProps: ToastPropsT = this.getToastProps(props);
+    toaster.show(toastProps);
   };
 
   addInfo = this.add({});
   addPositive = this.add({kind: KIND.positive});
   addWarning = this.add({kind: KIND.warning});
   addNegative = this.add({kind: KIND.negative});
-
-  dismiss = (key: number) => {
-    this.setState(({toasts}) => ({
-      // $FlowFixMe
-      toasts: toasts.filter(t => {
-        return !(t.key === key);
-      }),
-    }));
-  };
-
-  getOnCloseHandler(key) {
-    return () => {
-      this.dismiss(key);
-    };
-  }
 
   render() {
     return (
@@ -124,11 +103,73 @@ class NotificationExample extends React.Component<{}, {toasts: []}> {
         >
           Negative toast
         </Button>
-        <Centered>
-          {this.state.toasts.map((toastOptions, index) => {
-            return <Toast key={index} {...toastOptions} />;
-          })}
-        </Centered>
+      </div>
+    );
+  }
+}
+
+class ToasterAdvancedExample extends React.Component<{}, {cleared: boolean}> {
+  keyToUpdate: React.Key;
+  state = {cleared: false};
+
+  componentDidMount() {
+    this.addNotifications();
+  }
+
+  addNotifications() {
+    toaster.show('Info notification');
+    toaster.show({
+      children: 'Positive notification',
+      kind: KIND.positive,
+    });
+    this.keyToUpdate = toaster.show({
+      children: 'Warning notification',
+      kind: KIND.warning,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Space>
+          <Button
+            onClick={() => {
+              const kind = {
+                '0': KIND.info,
+                '1': KIND.positive,
+                '2': KIND.warning,
+              }[Math.floor(Math.random() * Math.floor(3))];
+              toaster.update(this.keyToUpdate, {
+                kind,
+                children: `Updated ${kind} notification`,
+              });
+            }}
+          >
+            Update to random
+          </Button>
+        </Space>
+        <Space>
+          <Button
+            onClick={() => {
+              toaster.clear();
+              this.setState({cleared: true});
+            }}
+          >
+            Clear all
+          </Button>
+        </Space>
+        {this.state.cleared ? (
+          <Space>
+            <Button
+              onClick={() => {
+                this.addNotifications();
+                this.setState({cleared: false});
+              }}
+            >
+              Add toasts
+            </Button>
+          </Space>
+        ) : null}
       </div>
     );
   }
@@ -166,14 +207,23 @@ export default {
       </Centered>
     );
   },
-  [examples.DISMISSABLE_EXAMPLE]: function Story1() {
+  [examples.TOASTER_EXAMPLE]: function Story2() {
     return (
       <Centered>
-        <NotificationExample />
+        {toaster.create({placement: PLACEMENT.bottomRight})}
+        <ToasterExample />
       </Centered>
     );
   },
-  [examples.OVERRIDES_EXAMPLE]: function Story1() {
+  [examples.TOASTER_ADVANCED_EXAMPLE]: function Story2() {
+    return (
+      <Centered>
+        {toaster.create({placement: PLACEMENT.bottom})}
+        <ToasterAdvancedExample />
+      </Centered>
+    );
+  },
+  [examples.OVERRIDES_EXAMPLE]: function Story3() {
     return (
       <Centered>
         <Toast

--- a/src/toast/examples.js
+++ b/src/toast/examples.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 import {styled} from '../styles';
 import {Toast, toaster, KIND, PLACEMENT} from './index';
 import {Button, KIND as ButtonKind, SIZE} from '../button';
-import type {ToastPropsT, KindTypeT} from './types';
+import type {KindTypeT} from './types';
 
 import examples from './examples-list';
 
@@ -56,8 +56,10 @@ class ToasterExample extends React.Component<{}, {toasts: []}> {
   }
 
   add = (kind: KindTypeT, props) => () => {
-    // $FlowFixMe
-    const {children, ...toastProps}: ToastPropsT = this.getToastProps(props);
+    const {
+      children,
+      ...toastProps
+    }: {children: React.Node} = this.getToastProps(props);
     toaster[kind](children, toastProps);
   };
 
@@ -119,7 +121,6 @@ class ToasterAdvancedExample extends React.Component<{}, {cleared: boolean}> {
   addNotifications() {
     toaster.info('Info notification', {closeable: false});
     toaster.positive(<span>Positive notification</span>);
-    // $FlowFixMe
     this.keyToUpdate = toaster.warning('Warning notification');
   }
 

--- a/src/toast/examples.js
+++ b/src/toast/examples.js
@@ -9,7 +9,7 @@ import * as React from 'react';
 import {styled} from '../styles';
 import {Toast, toaster, KIND, PLACEMENT} from './index';
 import {Button, KIND as ButtonKind, SIZE} from '../button';
-import type {ToastPropsT} from './types';
+import type {ToastPropsT, KindTypeT} from './types';
 
 import examples from './examples-list';
 
@@ -55,16 +55,16 @@ class ToasterExample extends React.Component<{}, {toasts: []}> {
     };
   }
 
-  add = props => () => {
+  add = (kind: KindTypeT, props) => () => {
     // $FlowFixMe
-    const toastProps: ToastPropsT = this.getToastProps(props);
-    toaster.show(toastProps);
+    const {children, ...toastProps}: ToastPropsT = this.getToastProps(props);
+    toaster[kind](children, toastProps);
   };
 
-  addInfo = this.add({});
-  addPositive = this.add({kind: KIND.positive});
-  addWarning = this.add({kind: KIND.warning});
-  addNegative = this.add({kind: KIND.negative});
+  addInfo = this.add(KIND.info);
+  addPositive = this.add(KIND.positive);
+  addWarning = this.add(KIND.warning);
+  addNegative = this.add(KIND.negative);
 
   render() {
     return (
@@ -117,15 +117,10 @@ class ToasterAdvancedExample extends React.Component<{}, {cleared: boolean}> {
   }
 
   addNotifications() {
-    toaster.show('Info notification');
-    toaster.show({
-      children: 'Positive notification',
-      kind: KIND.positive,
-    });
-    this.keyToUpdate = toaster.show({
-      children: 'Warning notification',
-      kind: KIND.warning,
-    });
+    toaster.info('Info notification', {closeable: false});
+    toaster.positive(<span>Positive notification</span>);
+    // $FlowFixMe
+    this.keyToUpdate = toaster.warning('Warning notification');
   }
 
   render() {
@@ -158,18 +153,17 @@ class ToasterAdvancedExample extends React.Component<{}, {cleared: boolean}> {
             Clear all
           </Button>
         </Space>
-        {this.state.cleared ? (
-          <Space>
-            <Button
-              onClick={() => {
-                this.addNotifications();
-                this.setState({cleared: false});
-              }}
-            >
-              Add toasts
-            </Button>
-          </Space>
-        ) : null}
+        <Space>
+          <Button
+            disabled={!this.state.cleared}
+            onClick={() => {
+              this.addNotifications();
+              this.setState({cleared: false});
+            }}
+          >
+            Add toasts
+          </Button>
+        </Space>
       </div>
     );
   }

--- a/src/toast/index.js
+++ b/src/toast/index.js
@@ -5,11 +5,13 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+export {default as toaster, Toaster} from './toaster';
 export {default as Toast} from './toast';
 // Constants
 export {KIND, PLACEMENT} from './constants';
 // Styled elements
 export {
+  Root as StyledRoot,
   Body as StyledBody,
   CloseIconSvg as StyledCloseIcon,
 } from './styled-components';

--- a/src/toast/styled-components.js
+++ b/src/toast/styled-components.js
@@ -7,10 +7,16 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import {styled} from '../styles';
 import {getSvgStyles} from '../icon/styled-components';
-import {KIND} from './constants';
-import type {SharedStylePropsT, KindTypeT} from './types';
+import {KIND, PLACEMENT} from './constants';
+import type {
+  SharedStylePropsT,
+  ToasterSharedStylePropsT,
+  KindTypeT,
+  PlacementTypeT,
+} from './types';
+import type {ThemeT} from '../styles/types';
 
-function getBackgroundColor(kind: KindTypeT, theme) {
+function getBackgroundColor(kind: KindTypeT, theme: ThemeT) {
   return {
     [KIND.info]: theme.colors.primary500,
     [KIND.positive]: theme.colors.positive500,
@@ -19,10 +25,67 @@ function getBackgroundColor(kind: KindTypeT, theme) {
   }[kind];
 }
 
+export function getPlacement(placement: PlacementTypeT) {
+  return {
+    [PLACEMENT.topLeft]: {
+      top: 0,
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
+      flexDirection: 'column',
+    },
+    [PLACEMENT.top]: {
+      top: 0,
+      alignItems: 'center',
+      justifyContent: 'flex-start',
+      flexDirection: 'column',
+    },
+    [PLACEMENT.topRight]: {
+      top: 0,
+      alignItems: 'flex-end',
+      justifyContent: 'flex-start',
+      flexDirection: 'column',
+    },
+    [PLACEMENT.bottomRight]: {
+      bottom: 0,
+      alignItems: 'flex-end',
+      justifyContent: 'flex-end',
+      flexDirection: 'column-reverse',
+    },
+    [PLACEMENT.bottom]: {
+      bottom: 0,
+      alignItems: 'center',
+      justifyContent: 'flex-end',
+      flexDirection: 'column-reverse',
+    },
+    [PLACEMENT.bottomLeft]: {
+      bottom: 0,
+      alignItems: 'flex-start',
+      justifyContent: 'flex-end',
+      flexDirection: 'column-reverse',
+    },
+  }[placement];
+}
+
+/**
+ * Main component container element
+ */
+export const Root = styled('div', (props: ToasterSharedStylePropsT) => {
+  const {$placement} = props;
+  return {
+    pointerEvents: 'none',
+    position: 'fixed',
+    right: 0,
+    left: 0,
+    display: 'flex',
+    ...getPlacement($placement),
+  };
+});
+
 export const Body = styled('div', (props: SharedStylePropsT) => {
   const {$isHidden, $isAnimating, $kind, $theme} = props;
   return {
     ...$theme.typography.font300,
+    pointerEvents: 'auto',
     color: $theme.colors.white,
     height: $isHidden && !$isAnimating ? 0 : 'auto',
     width: '288px',
@@ -39,7 +102,7 @@ export const Body = styled('div', (props: SharedStylePropsT) => {
       : '0px',
     boxShadow: $theme.lighting.shadow600,
     opacity: $isHidden ? 0 : 1,
-    transitionProperty: 'opacity, height',
+    transitionProperty: 'opacity, backgroundColor',
     transitionDuration: $theme.animation.timing100,
     transitionTimingFunction: $theme.animation.easeInOutCurve,
   };

--- a/src/toast/styled-components.js
+++ b/src/toast/styled-components.js
@@ -102,7 +102,7 @@ export const Body = styled('div', (props: SharedStylePropsT) => {
       : '0px',
     boxShadow: $theme.lighting.shadow600,
     opacity: $isHidden ? 0 : 1,
-    transitionProperty: 'opacity, backgroundColor',
+    transitionProperty: 'all',
     transitionDuration: $theme.animation.timing100,
     transitionTimingFunction: $theme.animation.easeInOutCurve,
   };

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -6,12 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import * as React from 'react';
-import {
-  getOverride,
-  getOverrideProps,
-  getOverrides,
-  mergeOverrides,
-} from '../helpers/overrides';
+import {getOverrides, mergeOverrides} from '../helpers/overrides';
 import {Delete as DeleteAltIcon} from '../icon';
 import {
   Body as StyledBody,
@@ -46,7 +41,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
 
   state = {
     isAnimating: false,
-    isHidden: false,
+    isHidden: true,
   };
 
   componentDidMount() {
@@ -76,7 +71,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
   }
 
   animateIn = () => {
-    this.setState({isAnimating: true});
+    this.setState({isHidden: false, isAnimating: true});
   };
 
   animateOut = (callback: () => void = () => {}) => {
@@ -97,25 +92,25 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
 
   onFocus = (e: Event) => {
     this.clearTimeout();
-    this.props.onFocus(e);
+    typeof this.props.onFocus === 'function' && this.props.onFocus(e);
   };
 
   onMouseEnter = (e: Event) => {
     this.clearTimeout();
-    this.props.onMouseEnter(e);
+    typeof this.props.onMouseEnter === 'function' && this.props.onMouseEnter(e);
   };
 
   onBlur = (e: Event) => {
     this.startTimeout();
-    this.props.onBlur(e);
+    typeof this.props.onBlur === 'function' && this.props.onBlur(e);
   };
 
   onMouseLeave = (e: Event) => {
     this.startTimeout();
-    this.props.onMouseLeave(e);
+    typeof this.props.onMouseLeave === 'function' && this.props.onMouseLeave(e);
   };
 
-  getSharedProps(): SharedStylePropsArgT {
+  getSharedProps(): $Shape<SharedStylePropsArgT> {
     const {kind, closeable} = this.props;
     const {isHidden, isAnimating} = this.state;
     return {
@@ -130,15 +125,19 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
     const {children, closeable} = this.props;
     const {isAnimating, isHidden} = this.state;
     const {
+      // $FlowFixMe
       Body: BodyOverride,
+      // $FlowFixMe
       CloseIcon: CloseIconOverride,
     } = this.props.overrides;
 
-    const Body = getOverride(BodyOverride) || StyledBody;
+    // $FlowFixMe
+    const [Body, bodyProps] = getOverrides(BodyOverride, StyledBody);
 
     const [CloseIcon, closeIconProps] = getOverrides(
       // $FlowFixMe
       CloseIconOverride,
+      // $FlowFixMe
       StyledCloseIcon,
     );
 
@@ -158,7 +157,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
         tabIndex={0}
         role="alert"
         {...sharedProps}
-        {...getOverrideProps(BodyOverride)}
+        {...bodyProps}
         // the properties below have to go after overrides
         onBlur={this.onBlur}
         onFocus={this.onFocus}

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -17,7 +17,7 @@ import {
   Body as StyledBody,
   CloseIconSvg as StyledCloseIcon,
 } from './styled-components';
-import {KIND, PLACEMENT} from './constants';
+import {KIND} from './constants';
 
 import type {
   ToastPropsT,
@@ -31,7 +31,6 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
     autoHideDuration: 0,
     closeable: true,
     kind: KIND.info,
-    placement: PLACEMENT.inline,
     // Do we need a separate handler for
     // when a notification dismisses automatically
     onClose: () => {},
@@ -117,11 +116,10 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
   };
 
   getSharedProps(): SharedStylePropsArgT {
-    const {kind, placement, closeable} = this.props;
+    const {kind, closeable} = this.props;
     const {isHidden, isAnimating} = this.state;
     return {
       $kind: kind,
-      $placement: placement,
       $closeable: closeable,
       $isHidden: isHidden,
       $isAnimating: isAnimating,

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -1,0 +1,159 @@
+// @flow
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import {PLACEMENT} from './constants';
+import {Root} from './styled-components';
+import Toast from './toast';
+import type {
+  ToasterPropsT,
+  ToasterStateT,
+  ToastPropsT,
+  ToastPropsAltT,
+} from './types';
+
+let toasterRef: React.Ref<typeof Toaster> = React.createRef();
+
+class ToasterComponent extends React.Component<ToasterPropsT, ToasterStateT> {
+  static defaultProps = {
+    placement: PLACEMENT.top,
+  };
+
+  state = {
+    toasts: [],
+  };
+
+  dismissHandlers = {};
+
+  toastId: number = 0;
+
+  onClose = (key: React.Key) => {
+    delete this.dismissHandlers[key];
+    this.setState(({toasts}) => ({
+      toasts: toasts.filter(t => {
+        return !(t.key === key);
+      }),
+    }));
+  };
+
+  getOnCloseHandler = (key: React.Key, onClose: () => void) => {
+    return () => {
+      this.onClose(key);
+      typeof onClose === 'function' && onClose();
+    };
+  };
+
+  getToastProps = (props: string | ToastPropsT): ToastPropsAltT => {
+    const key: React.Key = props.key || `toast-${this.toastId++}`;
+    if (typeof props === 'string') {
+      return {children: props, key};
+    }
+    return {...props, key};
+  };
+
+  renderToast = (toastProps: ToastPropsT): React.Node => {
+    const {onClose, children, key, ...rest} = toastProps;
+    return (
+      <Toast {...rest} key={key} onClose={this.getOnCloseHandler(key, onClose)}>
+        {({dismiss}) => {
+          this.dismissHandlers[key] = dismiss;
+          return children;
+        }}
+      </Toast>
+    );
+  };
+
+  show = (props: string | ToastPropsT): React.Key => {
+    const toastProps = this.getToastProps(props);
+    this.setState(({toasts}) => {
+      // const newList = [...toasts];
+      toasts.unshift(toastProps);
+      return {toasts};
+    });
+    return toastProps.key;
+  };
+
+  update = (key: React.Key, props: string | ToastPropsT): void => {
+    this.setState(({toasts}) => {
+      toasts.forEach((t, index, arr) => {
+        if (t.key === key) {
+          arr[index] = {...t, ...this.getToastProps(props), key};
+        }
+      });
+      return {
+        toasts,
+      };
+    });
+  };
+
+  dismiss = (key: React.Key) => {
+    if (this.dismissHandlers[key]) {
+      this.dismissHandlers[key]();
+    }
+  };
+
+  clearAll = () => {
+    Object.keys(this.dismissHandlers).forEach(key => {
+      this.dismissHandlers[key]();
+    });
+  };
+
+  clear = (key?: React.Key) => {
+    key === undefined ? this.clearAll() : this.dismiss(key);
+  };
+
+  getSharedProps = () => {
+    const {placement} = this.props;
+    return {
+      $placement: placement,
+    };
+  };
+
+  render = () => {
+    const sharedProps = this.getSharedProps();
+    // Only render on the browser (portals aren't supported server-side)
+    if (__BROWSER__) {
+      return ReactDOM.createPortal(
+        <Root {...sharedProps}>
+          {this.props.children}
+          {this.state.toasts.map(this.renderToast)}
+        </Root>,
+        // $FlowFixMe
+        document.body,
+      );
+    }
+    return null;
+  };
+}
+
+export const Toaster = ToasterComponent;
+
+export default {
+  create: function create(props?: ToasterPropsT): React.Node {
+    return <ToasterComponent {...props} ref={toasterRef} />;
+  },
+  show: (props: string | ToastPropsAltT): ?React.Key => {
+    if (toasterRef.current) {
+      return toasterRef.current.show(props);
+    } else if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.error('No toaster created yet');
+    }
+    return null;
+  },
+  update: (key: React.Key, props: string | ToastPropsAltT): void => {
+    if (toasterRef.current) {
+      toasterRef.current.update(key, props);
+    } else if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.error('No toaster created yet');
+    }
+  },
+  clear: (key?: React.Key): void => {
+    if (toasterRef.current) {
+      toasterRef.current.clear(key);
+    } else if (__DEV__) {
+      // eslint-disable-next-line no-console
+      console.error('No toaster created yet');
+    }
+  },
+};

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -202,25 +202,25 @@ const toaster = {
   info: function(
     children: React.Node,
     props: $Shape<ToastPropsT> = {},
-  ): ?React.Key {
+  ): React.Key {
     return this.show(children, {...props, kind: KIND.info});
   },
   positive: function(
     children: React.Node,
     props: $Shape<ToastPropsT> = {},
-  ): ?React.Key {
+  ): React.Key {
     return this.show(children, {...props, kind: KIND.positive});
   },
   warning: function(
     children: React.Node,
     props: $Shape<ToastPropsT> = {},
-  ): ?React.Key {
+  ): React.Key {
     return this.show(children, {...props, kind: KIND.warning});
   },
   negative: function(
     children: React.Node,
     props: $Shape<ToastPropsT> = {},
-  ): ?React.Key {
+  ): React.Key {
     return this.show(children, {...props, kind: KIND.negative});
   },
   update: function(key: React.Key, props: $Shape<ToastPropsT>): void {

--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -19,6 +19,8 @@ export type SharedStylePropsArgT = {
   $closeable: boolean,
   $isHidden: boolean,
   $isAnimating: boolean,
+  // styled function wrapper related
+  $style?: ?{},
 };
 
 export type SharedStylePropsT = SharedStylePropsArgT & {
@@ -63,24 +65,18 @@ export type ToastPropsT = {
   key: React.Key,
 };
 
-export type ToastPropsAltT = {
-  autoHideDuration?: number,
-  children?: ChildrenT | ComponentRenderPropT,
-  closeable?: boolean,
-  kind?: KindTypeT,
-  onClose?: () => void,
-  onBlur?: (e: Event) => void,
-  onFocus?: (e: Event) => void,
-  onMouseEnter?: (e: Event) => void,
-  onMouseLeave?: (e: Event) => void,
-  overrides?: OverridesT,
-  key?: React.Key,
+export type ToasterOverridesT = {
+  Root?: OverrideT<ToasterSharedStylePropsArgT>,
+  ToastBody?: OverrideT<SharedStylePropsArgT>,
+  ToastCloseIcon?: OverrideT<SharedStylePropsArgT>,
 };
 
 export type ToasterPropsT = {
+  overrides: ToasterOverridesT,
   placement: PlacementTypeT,
-  children?: ?ChildrenT,
+  usePortal: boolean,
 };
 export type ToasterStateT = {
-  toasts: Array<ToastPropsT>,
+  isMounted: boolean,
+  toasts: Array<$Shape<ToastPropsT> & {key: React.Key}>,
 };

--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -16,13 +16,20 @@ export type PlacementTypeT = $Keys<typeof PLACEMENT>;
 
 export type SharedStylePropsArgT = {
   $kind: KindTypeT,
-  $placement: PlacementTypeT,
   $closeable: boolean,
   $isHidden: boolean,
   $isAnimating: boolean,
 };
 
 export type SharedStylePropsT = SharedStylePropsArgT & {
+  $theme: ThemeT,
+};
+
+export type ToasterSharedStylePropsArgT = {
+  $placement: PlacementTypeT,
+};
+
+export type ToasterSharedStylePropsT = ToasterSharedStylePropsArgT & {
   $theme: ThemeT,
 };
 
@@ -47,11 +54,33 @@ export type ToastPropsT = {
   children: ChildrenT | ComponentRenderPropT,
   closeable: boolean,
   kind: KindTypeT,
-  placement: PlacementTypeT,
   onClose: () => void,
   onBlur: (e: Event) => void,
   onFocus: (e: Event) => void,
   onMouseEnter: (e: Event) => void,
   onMouseLeave: (e: Event) => void,
   overrides: OverridesT,
+  key: React.Key,
+};
+
+export type ToastPropsAltT = {
+  autoHideDuration?: number,
+  children?: ChildrenT | ComponentRenderPropT,
+  closeable?: boolean,
+  kind?: KindTypeT,
+  onClose?: () => void,
+  onBlur?: (e: Event) => void,
+  onFocus?: (e: Event) => void,
+  onMouseEnter?: (e: Event) => void,
+  onMouseLeave?: (e: Event) => void,
+  overrides?: OverridesT,
+  key?: React.Key,
+};
+
+export type ToasterPropsT = {
+  placement: PlacementTypeT,
+  children?: ?ChildrenT,
+};
+export type ToasterStateT = {
+  toasts: Array<ToastPropsT>,
 };


### PR DESCRIPTION
API:
```
  create: function create(props?: $Shape<ToasterPropsT>): React.Node {},
  show: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {},
  info: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {},
  positive: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {},
  warning: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {},
  negative: (children: React.Nade, props: $Shape<ToastPropsT>): ?React.Key => {},
  update: (key: React.Key, props: $Shape<ToastPropsT>): void => {},
  clear: (key?: React.Key): void => {},
```

Toaster rendered using portals so it's only rendered on a client side. Therefore any toast can only be added after a component mounted.

[Examples](https://deploy-preview-370--baseui.netlify.com/?selectedKind=Toast&selectedStory=Toaster%20example&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel)

Includes: 
- feat(toast): add toaster tests (#389)