### PR TITLE
fix(select): remove selectedOptions from controlled select state

### DIFF
--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -34,7 +34,7 @@ export type RootRefT = React$ElementRef<*>;
 
 export type OnItemSelectFnT = (
   item: ItemT,
-  event: SyntheticEvent<> | KeyboardEvent,
+  event: SyntheticEvent<HTMLElement> | KeyboardEvent,
 ) => mixed;
 
 export type ProfileOverridesT = {

--- a/src/select/examples.js
+++ b/src/select/examples.js
@@ -9,7 +9,6 @@ LICENSE file in the root directory of this source tree.
 /* eslint-disable no-console*/
 
 import * as React from 'react';
-// Styled elements
 import {StatefulSelect, TYPE} from './index';
 import {STATE_CHANGE_TYPE} from './constants';
 import COLORS from './examples-colors';

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -66,7 +66,10 @@ export type PropsT = {
   getSelectedOptionLabel?: OptionT => React$Node,
   $theme?: *,
   onTextInputChange: (e: SyntheticEvent<HTMLInputElement>) => void,
-  onChange: (e: SyntheticEvent<HTMLInputElement>, params: ParamsT) => void,
+  onChange: (
+    e: SyntheticEvent<HTMLElement> | KeyboardEvent,
+    params: ParamsT,
+  ) => void,
   onMouseEnter: (e: SyntheticEvent<HTMLInputElement>) => void,
   onMouseLeave: (e: SyntheticEvent<HTMLInputElement>) => void,
   onMouseDown: (e: SyntheticEvent<HTMLInputElement>) => void,
@@ -77,7 +80,6 @@ export type PropsT = {
 
 export type StatelessStateT = {
   textValue: string,
-  selectedOptions: Array<OptionT>,
   isDropDownOpen: boolean,
   filteredOptions?: ?Array<OptionT>,
   options: Array<OptionT>,


### PR DESCRIPTION
Fix for #312 

Since `selectedOptions` is the value of the form control, it should _not_ be part of the state. Since `Select` is intended to be a controlled component, it should always reflect the value passed in through props.