### PR TITLE
fix(button): spread args onto onclick handler

### DIFF
--- a/src/button/__tests__/button.test.js
+++ b/src/button/__tests__/button.test.js
@@ -61,7 +61,8 @@ describe('Button Component', () => {
     expect(props.onClick.mock.calls.length).toBe(0);
 
     component.setProps({isLoading: false});
-    component.instance().internalOnClick();
+    component.instance().internalOnClick('arg1');
     expect(props.onClick.mock.calls.length).toBe(1);
+    expect(props.onClick.mock.calls[0][0]).toBe('arg1');
   });
 });

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -27,7 +27,7 @@ export default class Button extends React.Component<ButtonPropsT> {
     if (isLoading) {
       return;
     }
-    onClick && onClick(args);
+    onClick && onClick(...args);
   };
 
   render() {


### PR DESCRIPTION
### Button Component

`onClick` was not called with spreaded args so was receiving an array