### PR TITLE
feat(input): use more accurate Flow types

### DIFF
--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -44,12 +44,12 @@ class BaseInput extends React.Component<BaseInputPropsT, InternalStateT> {
     }
   }
 
-  onFocus = (e: SyntheticEvent<HTMLElement>) => {
+  onFocus = (e: SyntheticFocusEvent<HTMLInputElement>) => {
     this.setState({isFocused: true});
     this.props.onFocus(e);
   };
 
-  onBlur = (e: SyntheticEvent<HTMLElement>) => {
+  onBlur = (e: SyntheticFocusEvent<HTMLInputElement>) => {
     this.setState({isFocused: false});
     this.props.onBlur(e);
   };

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -39,12 +39,12 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
     isFocused: this.props.autoFocus || false,
   };
 
-  onFocus = (e: SyntheticEvent<HTMLElement>) => {
+  onFocus = (e: SyntheticFocusEvent<HTMLInputElement>) => {
     this.setState({isFocused: true});
     this.props.onFocus(e);
   };
 
-  onBlur = (e: SyntheticEvent<HTMLElement>) => {
+  onBlur = (e: SyntheticFocusEvent<HTMLInputElement>) => {
     this.setState({isFocused: false});
     this.props.onBlur(e);
   };

--- a/src/input/stateful-container.js
+++ b/src/input/stateful-container.js
@@ -31,17 +31,17 @@ class StatefulContainer extends React.Component<
     ...this.props.initialState,
   };
 
-  onChange = (e: SyntheticEvent<HTMLElement>) => {
+  onChange = (e: SyntheticInputEvent<HTMLInputElement>) => {
     this.stateReducer(STATE_CHANGE_TYPE.change, e);
     this.props.onChange(e);
   };
 
-  stateReducer = (type: StateTypeT, e: SyntheticEvent<HTMLElement>) => {
+  stateReducer = (type: StateTypeT, e: SyntheticEvent<HTMLInputElement>) => {
     let nextState = {};
     if (
       type === STATE_CHANGE_TYPE.change &&
       // eslint-disable-next-line cup/no-undef
-      e.target instanceof window.HTMLElement
+      e.target instanceof window.HTMLInputElement
     ) {
       nextState = {value: e.target.value};
     }

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -10,8 +10,6 @@ import type {OverrideT} from '../helpers/overrides';
 import type {ThemeT} from '../styles';
 import {STATE_CHANGE_TYPE, ADJOINED, SIZE} from './constants';
 
-type SyntheticEventT = SyntheticEvent<HTMLElement>;
-
 export type AdjoinedT = $Keys<typeof ADJOINED>;
 
 export type SizeT = $Keys<typeof SIZE>;
@@ -65,9 +63,9 @@ export type BaseInputPropsT = {
   id: string,
   name: string,
   inputRef: {current: ?React.ElementRef<'input'>},
-  onBlur: (e: SyntheticEventT) => void,
-  onChange: (e: SyntheticEventT) => void,
-  onFocus: (e: SyntheticEventT) => void,
+  onBlur: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
+  onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
+  onFocus: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
   overrides: BaseInputComponentsT,
   placeholder: string,
   required: boolean,
@@ -82,15 +80,15 @@ export type InputPropsT = {
   overrides: InputComponentsT,
   startEnhancer: ?(React.Node | ((props: PropsT) => React.Node)),
   endEnhancer: ?(React.Node | ((props: PropsT) => React.Node)),
-  onFocus: (e: SyntheticEventT) => void,
-  onBlur: (e: SyntheticEventT) => void,
+  onFocus: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
+  onBlur: (e: SyntheticFocusEvent<HTMLInputElement>) => void,
 };
 
 export type StatefulContainerPropsT = {
   children: (props: PropsT) => React.Node,
   initialState?: StateT,
   stateReducer: StateReducerT,
-  onChange: (e: SyntheticEventT) => void,
+  onChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
 };
 
 type OmitPropsT = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Fixes #381 <!-- remove the (`) quotes to link the issues -->

<!-- Describe your changes below in as much detail as possible -->

These more specific Flow types allow clients to access properties such as event.target.value without needing a runtime check.