### PR TITLE
fix(menu): propagate props for highlight state

### DIFF
--- a/rfcs/select-component.md
+++ b/rfcs/select-component.md
@@ -158,7 +158,7 @@ export default () => {
 * `filterOption?: (option: Object, query: String) => boolean`:
   Custom method to filter whether an option should be displayed in the menu. Defaults to a simple lower-case string match.
 * `getOptionLabel?: (option: Object) => React$Node`:
-  Lets you control what label is rendered for the specified option. The default behavior returns `option.label`.
+  Lets you control what label is rendered for the specified option. Provides all option data and `isHighlighted` property indicating if it is highlighted(but not focused) in dropdown. The default behavior returns `option.label`.
 * `getSelectedOptionLabel?: (option: Object) => React$Node`:
   Lets you control what label is rendered for the selected option. If not specified, defaults to `getOptionLabel`.
 * `autoFocus: boolean`:

--- a/src/menu/option-list.js
+++ b/src/menu/option-list.js
@@ -23,7 +23,7 @@ export default function OptionList({
   };
   return (
     <ListItem {...sharedProps} {...restProps} {...listItemProps}>
-      {getItemLabel(item)}
+      {getItemLabel({isHighlighted: restProps.$isHighlighted, ...item})}
     </ListItem>
   );
 }

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -133,6 +133,7 @@ export type OptionListPropsT = {
   overrides: {
     ListItem?: OverrideT<*>,
   },
+  $isHighlighted?: boolean,
 };
 
 export type OptionProfilePropsT = {


### PR DESCRIPTION
#377

Fix for 4

> When a custom option is used, the keyboard arrows will accurately navigate through the dropdown options. However, the style of the focused item is overridden by the custom option (this means you cannot see which item is focused on the UI any longer). There is no prop that I can find that indicates which option/index is focused. Therefore I cannot apply custom styles to the focused option to indicate to the user that it will be selected once Enter is pressed.