### PR TITLE
Update README.md to handle dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 Add `baseui` and it's peer dependencies to your project:
 
 ```bash
-# using yarn 
+# using yarn
 yarn add baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
 
 # using npm

--- a/README.md
+++ b/README.md
@@ -10,19 +10,23 @@
 
 ## Usage
 
-Add `baseui` to your project:
+Add `baseui` and it's peer dependencies to your project:
 
 ```bash
-# using yarn
-yarn add baseui
+# using yarn 
+yarn add baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
 
 # using npm
-npm install baseui
+npm install baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
 ```
 
 ```javascript
+import {Client as StyletronProvider} from 'styletron-engine-atomic';
+import {Provider as Styletron} from 'styletron-react'
 import {LightTheme, ThemeProvider, styled} from 'baseui';
 import {StatefulInput} from 'baseui/input';
+
+const engine = new Styletron();
 
 const Centered = styled('div', {
   display: 'flex',
@@ -33,11 +37,13 @@ const Centered = styled('div', {
 
 export default function Hello() {
   return (
-    <ThemeProvider theme={LightTheme}>
-      <Centered>
-        <StatefulInput />
-      </Centered>
-    </ThemeProvider>
+    <StyletronProvider value={engine}>
+      <ThemeProvider theme={LightTheme}>
+        <Centered>
+          <StatefulInput />
+        </Centered>
+      </ThemeProvider>
+    </StyletronProvider>
   );
 }
 ```


### PR DESCRIPTION
Baseui requires peer dependencies, which should be installed but are not listed in the `Usage` section. Additionally, update the example with loading of the Styletron Client and Provider (seems required?)