### PR TITLE
fix(select): position the search icon in the middle vertically

### DIFF
--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -154,5 +154,7 @@ export const SelectSpinner = styled('div', () => {
 });
 
 export const SelectionContainer = styled('div', props => {
-  return {};
+  return {
+    lineHeight: '12px',
+  };
 });


### PR DESCRIPTION
from

<img width="283" alt="screen shot 2018-11-07 at 3 25 49 pm" src="https://user-images.githubusercontent.com/2174968/48167711-711ae480-e2a1-11e8-8250-fa6af8279d35.png">

to

<img width="325" alt="screen shot 2018-11-07 at 3 25 52 pm" src="https://user-images.githubusercontent.com/2174968/48167717-7a0bb600-e2a1-11e8-8d31-a6009ea56ce8.png">

