### PR TITLE
chore: add license header eslint rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,11 @@
 module.exports = {
   parser: 'babel-eslint',
-  plugins: ['flowtype', 'eslint-plugin-react', 'eslint-plugin-import'],
+  plugins: [
+    'flowtype',
+    'eslint-plugin-react',
+    'eslint-plugin-import',
+    'header',
+  ],
   env: {
     jest: true,
   },
@@ -29,6 +34,7 @@ module.exports = {
     ],
     'import/no-extraneous-dependencies': ['error', {devDependencies: true}],
     'import/prefer-default-export': ['off'],
+    'header/header': [2, 'LICENSE-HEAD'],
   },
   overrides: [
     {

--- a/LICENSE-HEAD
+++ b/LICENSE-HEAD
@@ -1,4 +1,6 @@
+/*
 Copyright (c) 2018 Uber Technologies, Inc.
 
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
+*/

--- a/babel/cup.js
+++ b/babel/cup.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 /*eslint-env node*/
 module.exports = {extends: ['@commitlint/config-conventional']};

--- a/e2e/assertions/hasFocus.js
+++ b/e2e/assertions/hasFocus.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* global exports document */
 

--- a/e2e/helpers/index.js
+++ b/e2e/helpers/index.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* eslint-env node */
 

--- a/e2e/index.js
+++ b/e2e/index.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 /* eslint-env browser */
 

--- a/examples/fusion/src/main.js
+++ b/examples/fusion/src/main.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import App from 'fusion-react';
 import Router from 'fusion-plugin-react-router';

--- a/examples/fusion/src/pages/home.js
+++ b/examples/fusion/src/pages/home.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import React from 'react';
 import {styled} from 'baseui';

--- a/examples/fusion/src/pages/pageNotFound.js
+++ b/examples/fusion/src/pages/pageNotFound.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import React from 'react';
 import {NotFound} from 'fusion-plugin-react-router';

--- a/examples/fusion/src/root.js
+++ b/examples/fusion/src/root.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import React from 'react';
 import {Route, Switch} from 'fusion-plugin-react-router';

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 /*eslint-env node*/
 module.exports = {

--- a/nightwatch.conf.js
+++ b/nightwatch.conf.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "eslint-config-uber-universal-stage-3": "^3.0.0",
     "eslint-plugin-cup": "^2.0.0",
     "eslint-plugin-flowtype": "^3.0.0",
+    "eslint-plugin-header": "^2.0.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-jsx-a11y": "^6.1.0",
     "eslint-plugin-prettier": "^3.0.0",
@@ -94,7 +95,6 @@
     "husky": "^1.0.0",
     "jest": "^23.3.0",
     "jest-enzyme": "^7.0.0",
-    "license-check-and-add": "^2.3.6",
     "localtunnel": "^1.9.1",
     "markdownlint-cli": "^0.13.0",
     "nightwatch": "^0.9.21",
@@ -132,19 +132,6 @@
     "node": ">=8.11.0",
     "npm": ">=5.6.0",
     "yarn": ">=1.5.1"
-  },
-  "license-check-and-add-config": {
-    "folder": ".",
-    "license": "LICENSE-HEAD",
-    "exact_paths_method": "INCLUDE",
-    "exact_paths": [
-      "src"
-    ],
-    "file_type_method": "INCLUDE",
-    "file_types": [
-      ".js"
-    ],
-    "insert_license": true
   },
   "husky": {
     "hooks": {

--- a/scripts/flow-copy-src.js
+++ b/scripts/flow-copy-src.js
@@ -1,5 +1,12 @@
 #!/usr/bin/env node
 
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 // @flow
 

--- a/src/button/examples-list.js
+++ b/src/button/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 
 import React from 'react';

--- a/src/card/examples-list.js
+++ b/src/card/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/card/images.js
+++ b/src/card/images.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 
 export const thumbnail =

--- a/src/card/index.js
+++ b/src/card/index.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 
 export {default as Card, hasThumbnail} from './card';

--- a/src/card/stories.js
+++ b/src/card/stories.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 /*global module */
 import {storiesOf} from '@storybook/react';

--- a/src/card/styled-components.js
+++ b/src/card/styled-components.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 
 import {styled} from '../styles/index';

--- a/src/checkbox/examples-list.js
+++ b/src/checkbox/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 module.exports = {

--- a/src/form-control/__tests__/form-control.test.js
+++ b/src/form-control/__tests__/form-control.test.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import React from 'react';
 import {mount} from 'enzyme';

--- a/src/form-control/__tests__/styled-components.test.js
+++ b/src/form-control/__tests__/styled-components.test.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import React from 'react';
 import {shallow} from 'enzyme';

--- a/src/form-control/constants.js
+++ b/src/form-control/constants.js
@@ -1,5 +1,6 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */

--- a/src/form-control/examples.js
+++ b/src/form-control/examples.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import * as React from 'react';
 import {styled} from '../styles';

--- a/src/form-control/form-control.js
+++ b/src/form-control/form-control.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import * as React from 'react';
 import {getOverride, getOverrideProps} from '../helpers/overrides';

--- a/src/form-control/index.js
+++ b/src/form-control/index.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 export {default as FormControl} from './form-control';
 export {

--- a/src/form-control/stories.js
+++ b/src/form-control/stories.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 /* global module */
 import {storiesOf} from '@storybook/react';

--- a/src/form-control/styled-components.js
+++ b/src/form-control/styled-components.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import {styled} from '../styles';
 

--- a/src/form-control/types.js
+++ b/src/form-control/types.js
@@ -1,8 +1,10 @@
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
+
 This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 import * as React from 'react';
 import type {OverrideT} from '../helpers/overrides';

--- a/src/icon/build-icons.js
+++ b/src/icon/build-icons.js
@@ -1,9 +1,12 @@
 #!/usr/bin/env node
+
 /*
 Copyright (c) 2018 Uber Technologies, Inc.
- This source code is licensed under the MIT license found in the
+
+This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
+
 // @flow
 /* eslint-env node*/
 import fs from 'fs';

--- a/src/icon/icon-exports.js
+++ b/src/icon/icon-exports.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 export {default as Alert} from './alert';
 export {default as ArrowDown} from './arrow-down';

--- a/src/input/e2e.js
+++ b/src/input/e2e.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* global after */

--- a/src/input/examples-list.js
+++ b/src/input/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/input/examples.js
+++ b/src/input/examples.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import * as React from 'react';
 import {withStyle} from 'styletron-react';

--- a/src/link/stories.js
+++ b/src/link/stories.js
@@ -1,5 +1,13 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* @flow */
 /*global module */
+
 import {storiesOf} from '@storybook/react';
 
 import examples from './examples';

--- a/src/menu/__tests__/option-list.test.js
+++ b/src/menu/__tests__/option-list.test.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import React from 'react';
 import {mount} from 'enzyme';

--- a/src/menu/__tests__/option-profile.test.js
+++ b/src/menu/__tests__/option-profile.test.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import React from 'react';
 import {mount} from 'enzyme';

--- a/src/menu/option-list.js
+++ b/src/menu/option-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import * as React from 'react';
 // Components

--- a/src/menu/option-profile.js
+++ b/src/menu/option-profile.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import * as React from 'react';
 // Components

--- a/src/modal/examples-list.js
+++ b/src/modal/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/pagination/constants.js
+++ b/src/pagination/constants.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 
 export const STATE_CHANGE_TYPE = {

--- a/src/pagination/examples-list.js
+++ b/src/pagination/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 module.exports = {

--- a/src/popover/examples-list.js
+++ b/src/popover/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/radio/examples-list.js
+++ b/src/radio/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 module.exports = {

--- a/src/select/examples-list.js
+++ b/src/select/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/slider/constants.js
+++ b/src/slider/constants.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 
 export const STATE_CHANGE_TYPE = {

--- a/src/textarea/e2e.js
+++ b/src/textarea/e2e.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* global after */

--- a/src/textarea/examples-list.js
+++ b/src/textarea/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/toast/examples-list.js
+++ b/src/toast/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import * as React from 'react';
 import ReactDOM from 'react-dom';

--- a/src/tooltip/examples-list.js
+++ b/src/tooltip/examples-list.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 /* eslint-env node */
 /* eslint-disable flowtype/require-valid-file-annotation */
 

--- a/src/utils/__tests__/deep-merge.test.js
+++ b/src/utils/__tests__/deep-merge.test.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 import deepMerge from '../deep-merge';
 

--- a/src/utils/deep-merge.js
+++ b/src/utils/deep-merge.js
@@ -1,3 +1,10 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
 // @flow
 
 export default function deepMerge(

--- a/yarn.lock
+++ b/yarn.lock
@@ -4723,6 +4723,11 @@ eslint-plugin-flowtype@^3.0.0:
   dependencies:
     lodash "^4.17.10"
 
+eslint-plugin-header@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-header/-/eslint-plugin-header-2.0.0.tgz#c0f729f4e6669d8f63881977bb9dcafafdac2420"
+  integrity sha512-vISfrajZaWRmToJ3GLULhnrwuaBmDap3arHf2+q0uMW2W+YSjFuCKzh/BcP3Ea5UPT8wN0S8uGz/I+QJkKBIoA==
+
 eslint-plugin-import@^2.13.0:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.13.0.tgz#df24f241175e312d91662dc91ca84064caec14ed"
@@ -7203,12 +7208,6 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-license-check-and-add@^2.3.6:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/license-check-and-add/-/license-check-and-add-2.3.6.tgz#a44e2aa1ceb0eb05dd2c2909a1490198bce65016"
-  dependencies:
-    pkg-conf "^1.1.2"
-
 lie@~3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/lie/-/lie-3.1.1.tgz#9a436b2cc7746ca59de7a41fa469b3efb76bd87e"
@@ -7221,7 +7220,7 @@ linkify-it@^2.0.0:
   dependencies:
     uc.micro "^1.0.1"
 
-load-json-file@^1.0.0, load-json-file@^1.1.0:
+load-json-file@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-1.1.0.tgz#956905708d58b4bab4c2261b04f59f31c99374c0"
   dependencies:
@@ -8792,15 +8791,6 @@ pinkie-promise@^2.0.0:
 pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
-
-pkg-conf@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/pkg-conf/-/pkg-conf-1.1.3.tgz#378e56d6fd13e88bfb6f4a25df7a83faabddba5b"
-  dependencies:
-    find-up "^1.0.0"
-    load-json-file "^1.1.0"
-    object-assign "^4.0.1"
-    symbol "^0.2.1"
 
 pkg-dir@^1.0.0:
   version "1.0.0"
@@ -10669,10 +10659,6 @@ symbol.prototype.description@^1.0.0:
   resolved "https://registry.yarnpkg.com/symbol.prototype.description/-/symbol.prototype.description-1.0.0.tgz#6e355660eb1e44ca8ad53a68fdb72ef131ca4b12"
   dependencies:
     has-symbols "^1.0.0"
-
-symbol@^0.2.1:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/symbol/-/symbol-0.2.3.tgz#3b9873b8a901e47c6efe21526a3ac372ef28bbc7"
 
 table@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
#### Fixed Issues

There are many files that are currently missing our MIT license header.  This PR introduces a new eslint plugin to assist with header linting and automated fixes.

#### Reasoning

The current license check mechanism, [license-check-and-add](https://www.npmjs.com/package/license-check-and-add), is manually triggered. When ran it seems some of the logic is wiping out some necessary flow annotations and `#!/usr/bin/env node` usages.

Due to the aggressive comment removal from the current mechanism, I would suggest using the more popular, [eslint-plugin-header](https://www.npmjs.com/package/eslint-plugin-header) plugin.

The license check is now ran as a part of the standard `yarn lint` command. It also supports the `eslint --fix` functionality which I have used to apply the missing license to all files with a missing license.

#### Any Dependency Changes

Removed: `license-check-and-add`
Added: `eslint-plugin-header` [MIT LICENSED] 
