### PR TITLE
Make button/input respect useRoundedCorners

### DIFF
--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -25,7 +25,12 @@ export const BaseButton = styled(
     alignItems: 'center',
     justifyContent: 'center',
     border: 'none',
-    borderRadius: $shape === SHAPE.round ? '50%' : $theme.borders.radius200,
+    borderRadius:
+      $shape === SHAPE.round
+        ? '50%'
+        : $theme.borders.useRoundedCorners
+          ? $theme.borders.radius200
+          : '0px',
     textDecoration: 'none',
     outline: 'none',
     WebkitAppearance: 'none',

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -85,7 +85,7 @@ export const getInputContainerStyles = (props: SharedPropsT) => {
     $error,
     $disabled,
     $size,
-    $theme: {colors, sizing, typography, animation},
+    $theme: {colors, sizing, typography, animation, borders},
   } = props;
   return {
     ...getFont($size, typography),
@@ -109,7 +109,9 @@ export const getInputContainerStyles = (props: SharedPropsT) => {
         : $isFocused
           ? colors.primary400
           : colors.mono200,
-    borderRadius: getBorderRadius($adjoined, sizing.scale100),
+    borderRadius: borders.useRoundedCorners
+      ? getBorderRadius($adjoined, sizing.scale100)
+      : '0px',
     boxShadow: `0 2px 6px ${
       $disabled
         ? 'transparent'


### PR DESCRIPTION
Makes `Button` and `Input` respect the `borders.useRoundedCorners` theme setting

<img width="300" alt="screen shot 2018-11-14 at 4 53 25 pm" src="https://user-images.githubusercontent.com/875591/48522741-ac338f80-e82e-11e8-9b49-f2f4cecf068c.png">

<img width="300" alt="screen shot 2018-11-14 at 4 53 25 pm" src="https://user-images.githubusercontent.com/875591/48522756-bfdef600-e82e-11e8-94a9-fcfc9590c782.png">
