### PR TITLE
fix: update styles of ProgressSteps example

### DIFF
--- a/src/progress-steps/examples.js
+++ b/src/progress-steps/examples.js
@@ -11,6 +11,7 @@ import React from 'react';
 import {ProgressSteps, Step, NumberedStep} from './';
 import examples from './examples-list';
 import {Button} from '../button';
+import {Block} from '../block';
 import {styled} from '../styles/index';
 import type {ThemeT} from '../styles/types';
 
@@ -73,39 +74,45 @@ class DefaultExampleComponent extends React.Component<
     return (
       <ProgressSteps current={this.state.current}>
         <GenericStep title="Create Account" {...overrideProps}>
-          <div>Here is some step content</div>
-          <div>
-            <SpacedButton disabled>Previous</SpacedButton>
-            <SpacedButton onClick={() => this.setState({current: 1})}>
-              Next
-            </SpacedButton>
-          </div>
+          <Block font="font400">
+            <div>Here is some step content</div>
+            <div>
+              <SpacedButton disabled>Previous</SpacedButton>
+              <SpacedButton onClick={() => this.setState({current: 1})}>
+                Next
+              </SpacedButton>
+            </div>
+          </Block>
         </GenericStep>
         <GenericStep title="Verify Payment" {...overrideProps}>
-          <div>
-            Sed ut perspiciatis unde omnis iste natus error sit voluptatem
-            accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
-            quae ab illo inventore veritatis et quasi architecto beatae vitae
-            dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
-            aspernatur aut odit aut fugit...
-          </div>
-          <div>
-            <SpacedButton onClick={() => this.setState({current: 0})}>
-              Previous
-            </SpacedButton>
-            <SpacedButton onClick={() => this.setState({current: 2})}>
-              Next
-            </SpacedButton>
-          </div>
+          <Block font="font400">
+            <div>
+              Sed ut perspiciatis unde omnis iste natus error sit voluptatem
+              accusantium doloremque laudantium, totam rem aperiam, eaque ipsa
+              quae ab illo inventore veritatis et quasi architecto beatae vitae
+              dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit
+              aspernatur aut odit aut fugit...
+            </div>
+            <div>
+              <SpacedButton onClick={() => this.setState({current: 0})}>
+                Previous
+              </SpacedButton>
+              <SpacedButton onClick={() => this.setState({current: 2})}>
+                Next
+              </SpacedButton>
+            </div>
+          </Block>
         </GenericStep>
         <GenericStep title="Add Payment Method" {...overrideProps}>
-          <div>Here is some step content</div>
-          <div>
-            <SpacedButton onClick={() => this.setState({current: 1})}>
-              Previous
-            </SpacedButton>
-            <SpacedButton disabled>Next</SpacedButton>
-          </div>
+          <Block font="font400">
+            <div>Here is some step content</div>
+            <div>
+              <SpacedButton onClick={() => this.setState({current: 1})}>
+                Previous
+              </SpacedButton>
+              <SpacedButton disabled>Next</SpacedButton>
+            </div>
+          </Block>
         </GenericStep>
       </ProgressSteps>
     );

--- a/src/progress-steps/styled-components.js
+++ b/src/progress-steps/styled-components.js
@@ -38,7 +38,7 @@ export const StyledIcon = styled(
   ({$theme, $isActive, $isCompleted, $disabled}: StyledStepPropsT) => {
     let currentColor = $theme.colors.mono400;
     let size = $theme.sizing.scale300;
-    let marginTop = $theme.sizing.scale400;
+    let marginTop = $theme.sizing.scale300;
     let marginRight = $theme.sizing.scale500;
     let marginLeft = $theme.sizing.scale100;
 
@@ -50,7 +50,7 @@ export const StyledIcon = styled(
 
     if ($isActive) {
       size = $theme.sizing.scale600;
-      marginTop = $theme.sizing.scale300;
+      marginTop = $theme.sizing.scale200;
       marginLeft = 0;
       marginRight = $theme.sizing.scale300;
     }


### PR DESCRIPTION
#### Fixed Issues

The original examples for `ProgressSteps` didn't apply the correct font styles to the step content.  The examples now use the `Block` component to apply the correct styles.

#### License

MIT

<!-- Describe your changes below in as much detail as possible -->
