### PR TITLE
fix(form-control): add support for control container override

### DIFF
--- a/src/form-control/__tests__/form-control.test.js
+++ b/src/form-control/__tests__/form-control.test.js
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 import {mount} from 'enzyme';
 import FormControl from '../form-control';
-import {Label, Caption} from '../styled-components';
+import {Label, Caption, ControlContainer} from '../styled-components';
 import {Input} from '../../input';
 import {Textarea} from '../../textarea';
 import {Checkbox} from '../../checkbox';
@@ -245,5 +245,50 @@ test('Renders label and caption for the RadioGroup component', () => {
     $error: undefined,
     $required: true,
     children: 'Caption test',
+  });
+});
+
+describe('FormControl - overrides', () => {
+  test('Renders control container override', () => {
+    const ControlContainerOverride = () => (
+      <ControlContainer className="override" />
+    );
+    const formControlOverrides = {
+      ControlContainer: ControlContainerOverride,
+    };
+    const rendered = mount(
+      <FormControl overrides={formControlOverrides}>
+        <Input />
+      </FormControl>,
+    );
+    expect(
+      rendered.contains(<ControlContainer className="override" />),
+    ).toEqual(true);
+  });
+
+  test('Renders label override', () => {
+    const LabelOverride = () => <Label className="override" />;
+    const formControlOverrides = {
+      Label: LabelOverride,
+    };
+    const rendered = mount(
+      <FormControl overrides={formControlOverrides} label="Label test">
+        <Input />
+      </FormControl>,
+    );
+    expect(rendered.contains(<Label className="override" />)).toEqual(true);
+  });
+
+  test('Renders caption override', () => {
+    const CaptionOverride = () => <Caption className="override" />;
+    const formControlOverrides = {
+      Caption: CaptionOverride,
+    };
+    const rendered = mount(
+      <FormControl overrides={formControlOverrides} caption="Caption test">
+        <Input />
+      </FormControl>,
+    );
+    expect(rendered.contains(<Caption className="override" />)).toEqual(true);
   });
 });

--- a/src/form-control/form-control.js
+++ b/src/form-control/form-control.js
@@ -36,7 +36,11 @@ export default class FormControl extends React.Component<FormControlPropsT> {
 
   render() {
     const {
-      overrides: {Label: LabelOverride, Caption: CaptionOverride},
+      overrides: {
+        Label: LabelOverride,
+        Caption: CaptionOverride,
+        ControlContainer: ControlContainerOverride,
+      },
       label,
       caption,
       error,
@@ -48,6 +52,8 @@ export default class FormControl extends React.Component<FormControlPropsT> {
     sharedProps.$error = this.props.error || sharedProps.$error;
     const Label = getOverride(LabelOverride) || StyledLabel;
     const Caption = getOverride(CaptionOverride) || StyledCaption;
+    const ControlContainer =
+      getOverride(ControlContainerOverride) || StyledControlContainer;
 
     return (
       <React.Fragment>
@@ -60,7 +66,10 @@ export default class FormControl extends React.Component<FormControlPropsT> {
             {typeof label === 'function' ? label(sharedProps) : label}
           </Label>
         )}
-        <StyledControlContainer>
+        <ControlContainer
+          {...sharedProps}
+          {...getOverrideProps(ControlContainerOverride)}
+        >
           {children}
           {(caption || error) && (
             <Caption {...sharedProps} {...getOverrideProps(CaptionOverride)}>
@@ -73,7 +82,7 @@ export default class FormControl extends React.Component<FormControlPropsT> {
                   : caption}
             </Caption>
           )}
-        </StyledControlContainer>
+        </ControlContainer>
       </React.Fragment>
     );
   }

--- a/src/form-control/types.js
+++ b/src/form-control/types.js
@@ -13,6 +13,7 @@ export type FormControlPropsT = {
   overrides: {
     Label?: OverrideT<*>,
     Caption?: OverrideT<*>,
+    ControlContainer?: OverrideT<*>,
   },
   label: ?(React.Node | ((props: {}) => React.Node)),
   caption: ?(React.Node | ((props: {}) => React.Node)),


### PR DESCRIPTION

#### Fixed Issue

The form control container is not currently capable of being overridden. According to the [Form Control docs](https://baseui.netlify.com/?selectedKind=Form%20control&selectedStory=controls%20with%20label%20and%20caption&full=0&addons=1&stories=1&panelRight=0&addonPanel=REACT_STORYBOOK%2Freadme%2Fpanel) `ControlContainer` should be part of the `overrides`. This PR adds that missing functionality.

#### Tests Added + Pass?

Yes

#### Any Dependency Changes?

No

#### License

MIT
