### PR TITLE
fix(toast): fix animate in

### DIFF
--- a/src/toast/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/toast/__tests__/__snapshots__/styled-components.test.js.snap
@@ -13,7 +13,7 @@ Object {
   "lineHeight": "$theme.typography.font300.lineHeight",
   "marginBottom": "$theme.sizing.scale300",
   "marginTop": "$theme.sizing.scale300",
-  "opacity": 1,
+  "opacity": 0,
   "paddingBottom": "$theme.sizing.scale600",
   "paddingLeft": "$theme.sizing.scale600",
   "paddingRight": "$theme.sizing.scale600",

--- a/src/toast/__tests__/styled-components.test.js
+++ b/src/toast/__tests__/styled-components.test.js
@@ -37,17 +37,11 @@ describe('Component styled components', () => {
       '$theme.colors.negative500',
     );
 
-    component.setProps({$isHidden: false, $isAnimating: false});
-    expect(component.instance().getStyles().height).toEqual('auto');
+    component.setProps({$isVisible: false});
+    expect(component.instance().getStyles().opacity).toEqual(0);
+
+    component.setProps({$isVisible: true});
     expect(component.instance().getStyles().opacity).toEqual(1);
-
-    component.setProps({$isHidden: true, $isAnimating: true});
-    expect(component.instance().getStyles().height).toEqual('auto');
-    expect(component.instance().getStyles().opacity).toEqual(0);
-
-    component.setProps({$isHidden: true, $isAnimating: false});
-    expect(component.instance().getStyles().height).toEqual(0);
-    expect(component.instance().getStyles().opacity).toEqual(0);
   });
   test('StyledCloseIcon - basic render', () => {
     const component = shallow(<StyledCloseIcon $prop={false} />);

--- a/src/toast/__tests__/toast.test.js
+++ b/src/toast/__tests__/toast.test.js
@@ -16,8 +16,8 @@ describe('Toast', () => {
   test('basic functionality', () => {
     const wrapper = mount(<Toast>Notification</Toast>);
 
-    expect(wrapper.instance().state.isHidden).toBe(false);
-    expect(wrapper.instance().state.isAnimating).toBe(true);
+    expect(wrapper.instance().state.isRendered).toBe(true);
+    expect(wrapper.instance().state.isVisible).toBe(false);
 
     expect(wrapper.find(StyledBody).first()).toExist();
     expect(wrapper.find(StyledCloseIcon).first()).toExist();
@@ -31,8 +31,8 @@ describe('Toast', () => {
     expect(renderedRoot).toExist();
     expect(renderedRoot.props().$kind).toBe(KIND.info);
     expect(renderedRoot.props().$closeable).toBe(true);
-    expect(renderedRoot.props().$isHidden).toBe(false);
-    expect(renderedRoot.props().$isAnimating).toBe(true);
+    expect(renderedRoot.props().$isRendered).toBe(true);
+    expect(renderedRoot.props().$isVisible).toBe(false);
 
     // pass new kind value set to KIND.positive
     // and closeable set to false
@@ -101,13 +101,13 @@ describe('Toast', () => {
 
     closeButton.simulate('click');
 
-    expect(wrapper.instance().state.isHidden).toBe(true);
-    expect(wrapper.instance().state.isAnimating).toBe(true);
+    expect(wrapper.instance().state.isRendered).toBe(true);
+    expect(wrapper.instance().state.isVisible).toBe(false);
     expect(props.onClose).not.toHaveBeenCalled();
 
     jest.runAllTimers();
     expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 600);
-    expect(wrapper.instance().state.isAnimating).toBe(false);
+    expect(wrapper.instance().state.isRendered).toBe(false);
     expect(props.onClose).toHaveBeenCalled();
   });
 

--- a/src/toast/styled-components.js
+++ b/src/toast/styled-components.js
@@ -82,12 +82,12 @@ export const Root = styled('div', (props: ToasterSharedStylePropsT) => {
 });
 
 export const Body = styled('div', (props: SharedStylePropsT) => {
-  const {$isHidden, $isAnimating, $kind, $theme} = props;
+  const {$isVisible, $kind, $theme} = props;
   return {
     ...$theme.typography.font300,
     pointerEvents: 'auto',
     color: $theme.colors.white,
-    height: $isHidden && !$isAnimating ? 0 : 'auto',
+    height: 'auto',
     width: '288px',
     paddingTop: $theme.sizing.scale600,
     paddingRight: $theme.sizing.scale600,
@@ -101,7 +101,7 @@ export const Body = styled('div', (props: SharedStylePropsT) => {
       ? $theme.borders.radius200
       : '0px',
     boxShadow: $theme.lighting.shadow600,
-    opacity: $isHidden ? 0 : 1,
+    opacity: $isVisible ? 1 : 0,
     transitionProperty: 'all',
     transitionDuration: $theme.animation.timing100,
     transitionTimingFunction: $theme.animation.easeInOutCurve,

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -147,7 +147,7 @@ class ToasterComponent extends React.Component<
     };
   };
 
-  render = () => {
+  render() {
     const sharedProps = this.getSharedProps();
 
     const {Root: RootOverride} = this.props.overrides;
@@ -183,7 +183,7 @@ class ToasterComponent extends React.Component<
       }
     }
     return null;
-  };
+  }
 }
 
 const toaster = {

--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -17,8 +17,8 @@ export type PlacementTypeT = $Keys<typeof PLACEMENT>;
 export type SharedStylePropsArgT = {
   $kind: KindTypeT,
   $closeable: boolean,
-  $isHidden: boolean,
-  $isAnimating: boolean,
+  $isRendered: boolean,
+  $isVisible: boolean,
   // styled function wrapper related
   $style?: ?{},
 };
@@ -47,8 +47,8 @@ export type ChildT = React.Node;
 export type ChildrenT = React.ChildrenArray<ChildT>;
 
 export type ToastPrivateStateT = {
-  isAnimating: boolean,
-  isHidden: boolean,
+  isVisible: boolean,
+  isRendered: boolean,
 };
 
 export type ToastPropsT = {


### PR DESCRIPTION
As of right now, `Toast`s do not animate in – they only animate out. This PR updates the logic so that they animate in as well.

![kapture 2018-11-16 at 15 09 17](https://user-images.githubusercontent.com/875591/48651861-a4e8bf00-e9b1-11e8-8ac5-49c0a0dc4f57.gif)

#### Patch: Bug Fix?

Yes

#### Major: Breaking Change?

No

#### Minor: New Feature?

No

#### Tests Added + Pass?

Yes