### PR TITLE
fix: update package json main paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
     "baseui"
   ],
   "license": "MIT",
-  "main": "baseui.js",
-  "module": "baseui.es.js",
+  "main": "index.js",
+  "module": "index.es.js",
   "repository": "uber-web/baseui",
   "scripts": {
     "lint:code": "eslint ./",


### PR DESCRIPTION
Unless I'm missing something, seems like these paths are a relic from the rollup days and should now be `index.js`/`index.es.js`?

```
bash-3.2$ cd node_modules/baseui
bash-3.2$ ls -l
total 72
2038 Nov 14 10:34 README.md
 736 Nov 14 11:31 accordion
 480 Nov 14 11:31 block
 704 Nov 14 11:31 button
 576 Nov 14 11:31 card
 768 Nov 14 11:31 checkbox
1024 Nov 14 11:31 es
 480 Nov 14 11:31 form-control
 224 Nov 14 11:31 helpers
2016 Nov 14 11:31 icon
1318 Nov 14 10:34 index.es.js
1317 Nov 14 10:34 index.js
 508 Nov 14 10:34 index.js.flow
 832 Nov 14 11:31 input
 256 Nov 14 11:31 link
 896 Nov 14 11:31 menu
 768 Nov 14 11:31 modal
  96 Nov 14 16:19 node_modules
5815 Nov 14 10:34 package.json
 832 Nov 14 11:31 pagination
 864 Nov 14 11:31 popover
 416 Nov 14 11:31 progress-bar
 800 Nov 14 11:31 radio
 768 Nov 14 11:31 select
 736 Nov 14 11:31 slider
 416 Nov 14 11:31 spinner
 448 Nov 14 11:31 styles
 576 Nov 14 11:31 tag
 384 Nov 14 11:31 template-component
 224 Nov 14 11:31 test
 704 Nov 14 11:31 textarea
 448 Nov 14 11:31 themes
 608 Nov 14 11:31 toast
 768 Nov 14 11:31 tooltip
 256 Nov 14 11:31 utils
9239 Nov 14 10:34 welcome.stories.js
```