### PR TITLE
docs: fix modal example [skip ci]

### DIFF
--- a/rfcs/modal-component.md
+++ b/rfcs/modal-component.md
@@ -18,7 +18,7 @@ class App extends React.Component {
         <Button onClick={() => this.setState({open: true})}>Open</Button>
         <Modal
           isOpen={this.state.open}
-          close={() => this.setState({open: false})}
+          onClose={() => this.setState({open: false})}
         >
           {({close}) => (
             <>


### PR DESCRIPTION
Pretty sure I messed this up – should be `onClose` not `close`