### PR TITLE
fix: enable jsx-a11y checks in eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     'eslint-plugin-react',
     'eslint-plugin-import',
     'header',
+    'jsx-a11y',
   ],
   env: {
     jest: true,
@@ -13,6 +14,7 @@ module.exports = {
     'plugin:flowtype/recommended',
     'plugin:react/recommended',
     require.resolve('eslint-config-uber-universal-stage-3'),
+    'plugin:jsx-a11y/recommended',
   ],
   rules: {
     // Enforce flow file declarations

--- a/e2e/tests.js
+++ b/e2e/tests.js
@@ -44,8 +44,12 @@ const Examples = [
 const createError = ({suite, test}) => {
   return (
     <div style={{background: 'red', padding: '10px'}}>
-      <h1>Test or suite was not found 🤭</h1>
-
+      <h1>
+        Test or suite was not found{' '}
+        <span role="img" aria-label="Face With Hand Over Mouth">
+          🤭
+        </span>
+      </h1>
       <p>
         Suite: {suite} | Test: {test}
       </p>

--- a/src/card/__tests__/card.test.js
+++ b/src/card/__tests__/card.test.js
@@ -12,7 +12,7 @@ import {header as headerImg, thumbnail as thumbnailImg} from '../images';
 
 test('Card - basic functionality', () => {
   const props = {
-    action: <a href="#">Link to a Place&nbsp;&nbsp;&nbsp;&gt;</a>,
+    action: <a href="#test">Link to a Place&nbsp;&nbsp;&nbsp;&gt;</a>,
     headerImage: headerImg,
     thumbnail: thumbnailImg,
     title: 'Card title',
@@ -26,7 +26,7 @@ test('Card - basic functionality', () => {
 
 test('Card - no images', () => {
   const props = {
-    action: <a href="#">Link to a Place&nbsp;&nbsp;&nbsp;&gt;</a>,
+    action: <a href="#test">Link to a Place&nbsp;&nbsp;&nbsp;&gt;</a>,
     title: 'Card title',
   };
 

--- a/src/checkbox/examples.js
+++ b/src/checkbox/examples.js
@@ -263,7 +263,7 @@ export default {
             }
           }}
         />
-        <Checkbox onChange={onChange} inputRef={inputRef} autoFocus={isFocused}>
+        <Checkbox onChange={onChange} inputRef={inputRef}>
           Focused checkbox
         </Checkbox>
       </div>

--- a/src/input/examples.js
+++ b/src/input/examples.js
@@ -128,7 +128,6 @@ export default {
         <br />
         <Input
           initialState={{value: 'uber'}}
-          autoFocus
           startEnhancer="@"
           endEnhancer=".com"
           size={SIZE.compact}
@@ -245,7 +244,6 @@ export default {
       <React.Fragment>
         <Input
           overrides={{InputContainer: {component: RootWithStyle}}}
-          autoFocus
           placeholder="Input with a custom InputContainer override"
         />
         <br />

--- a/src/modal/__tests__/modal.test.js
+++ b/src/modal/__tests__/modal.test.js
@@ -175,6 +175,7 @@ describe('Modal', () => {
 
   test('role', () => {
     wrapper = mount(
+      // eslint-disable-next-line jsx-a11y/aria-role
       <Modal role="mycustomrole" isOpen>
         <ModalBody>Modal Body</ModalBody>
       </Modal>,

--- a/src/pagination/icons.js
+++ b/src/pagination/icons.js
@@ -52,6 +52,7 @@ export function ArrowDown() {
       src={
         'data:image/svg+xml;utf8,<svg width="12" height="6" viewBox="0 0 12 6" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M5.29289 5.29289L0.853553 0.853553C0.538571 0.538571 0.761654 0 1.20711 0H10.7929C11.2383 0 11.4614 0.538571 11.1464 0.853554L6.70711 5.29289C6.31658 5.68342 5.68342 5.68342 5.29289 5.29289Z" transform="translate(12) scale(-1 1)" fill="%23666666"/></svg>'
       }
+      alt="Expand"
     />
   );
 }

--- a/src/tag/examples.js
+++ b/src/tag/examples.js
@@ -107,7 +107,7 @@ export default {
                 })),
               }}
             >
-              Color {color} <img src={icon} />
+              Color {color} <img src={icon} alt={`${color} color swatch`} />
             </Tag>
           ))}
         </div>

--- a/src/textarea/examples.js
+++ b/src/textarea/examples.js
@@ -92,7 +92,6 @@ export default {
         <br />
         <Textarea
           initialState={{value: 'uber'}}
-          autoFocus
           size={SIZE.compact}
           placeholder="Placeholder"
         />
@@ -111,7 +110,6 @@ export default {
     return (
       <React.Fragment>
         <Textarea
-          autoFocus
           overrides={{Input: TextareaWithStyle}}
           placeholder="With style overrides on the textarea element"
         />

--- a/src/textarea/examples.js
+++ b/src/textarea/examples.js
@@ -90,6 +90,9 @@ export default {
       <React.Fragment>
         <Textarea size={SIZE.compact} placeholder="Placeholder" />
         <br />
+        {/* eslint-disable-next-line jsx-a11y/no-autofocus */}
+        <Textarea size={SIZE.compact} placeholder="Focused" autoFocus />
+        <br />
         <Textarea
           initialState={{value: 'uber'}}
           size={SIZE.compact}


### PR DESCRIPTION
#### Fixed Issues

Even though we had the `jsx-a11y` dependency installed, the eslint rule wasn't enabled for some reason.

This PR enables the recommended linting rules and corrects the failing areas (most of which are in our examples).

Here is an example output for an accessibility issue:

<img width="752" alt="screen shot 2018-11-20 at 2 04 23 pm" src="https://user-images.githubusercontent.com/4030377/48805984-ca393e00-eccd-11e8-82a2-29e274827eaa.png">

#### License

MIT

<!-- Describe your changes below in as much detail as possible -->
