### PR TITLE
fix: remove radio animation jitter in firefox

### DIFF
--- a/src/radio/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/radio/__tests__/__snapshots__/styled-components.test.js.snap
@@ -112,7 +112,7 @@ Object {
 }
 `;
 
-exports[`RadioGroup styled components StyledRadioMark : has correct styles when  1`] = `
+exports[`RadioGroup styled components StyledRadioMarkInner : has correct styles when  1`] = `
 Object {
   ":active": Object {
     "backgroundColor": "$theme.colors.mono400",
@@ -120,29 +120,16 @@ Object {
   ":hover": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
-  "backgroundColor": "transparent",
-  "backgroundImage": null,
-  "backgroundPosition": "center",
-  "backgroundRepeat": "no-repeat",
-  "borderColor": "$theme.colors.mono700",
+  "backgroundColor": "white",
   "borderRadius": "50%",
-  "borderStyle": "solid",
-  "borderWidth": "$theme.sizing.scale0",
-  "display": "inline-block",
-  "flex": "0 0 auto",
   "height": "$theme.sizing.scale600",
-  "marginBottom": "$theme.sizing.scale200",
-  "marginLeft": "$theme.sizing.scale200",
-  "marginRight": "$theme.sizing.scale200",
-  "marginTop": "$theme.sizing.scale200",
   "transitionDuration": "$theme.animation.timing100",
   "transitionTimingFunction": "$theme.animation.easeOutCurve",
-  "verticalAlign": "middle",
   "width": "$theme.sizing.scale600",
 }
 `;
 
-exports[`RadioGroup styled components StyledRadioMark : has correct styles when $isError 1`] = `
+exports[`RadioGroup styled components StyledRadioMarkInner : has correct styles when $isError 1`] = `
 Object {
   ":active": Object {
     "backgroundColor": null,
@@ -150,29 +137,16 @@ Object {
   ":hover": Object {
     "backgroundColor": null,
   },
-  "backgroundColor": "transparent",
-  "backgroundImage": null,
-  "backgroundPosition": "center",
-  "backgroundRepeat": "no-repeat",
-  "borderColor": "$theme.colors.negative400",
+  "backgroundColor": "white",
   "borderRadius": "50%",
-  "borderStyle": "solid",
-  "borderWidth": "$theme.sizing.scale0",
-  "display": "inline-block",
-  "flex": "0 0 auto",
   "height": "$theme.sizing.scale600",
-  "marginBottom": "$theme.sizing.scale200",
-  "marginLeft": "$theme.sizing.scale200",
-  "marginRight": "$theme.sizing.scale200",
-  "marginTop": "$theme.sizing.scale200",
   "transitionDuration": "$theme.animation.timing100",
   "transitionTimingFunction": "$theme.animation.easeOutCurve",
-  "verticalAlign": "middle",
   "width": "$theme.sizing.scale600",
 }
 `;
 
-exports[`RadioGroup styled components StyledRadioMark : has correct styles when $isFocused 1`] = `
+exports[`RadioGroup styled components StyledRadioMarkInner : has correct styles when $isFocused 1`] = `
 Object {
   ":active": Object {
     "backgroundColor": "$theme.colors.mono500",
@@ -180,29 +154,16 @@ Object {
   ":hover": Object {
     "backgroundColor": "$theme.colors.mono500",
   },
-  "backgroundColor": "transparent",
-  "backgroundImage": null,
-  "backgroundPosition": "center",
-  "backgroundRepeat": "no-repeat",
-  "borderColor": "$theme.colors.mono700",
+  "backgroundColor": "white",
   "borderRadius": "50%",
-  "borderStyle": "solid",
-  "borderWidth": "$theme.sizing.scale0",
-  "display": "inline-block",
-  "flex": "0 0 auto",
   "height": "$theme.sizing.scale600",
-  "marginBottom": "$theme.sizing.scale200",
-  "marginLeft": "$theme.sizing.scale200",
-  "marginRight": "$theme.sizing.scale200",
-  "marginTop": "$theme.sizing.scale200",
   "transitionDuration": "$theme.animation.timing100",
   "transitionTimingFunction": "$theme.animation.easeOutCurve",
-  "verticalAlign": "middle",
   "width": "$theme.sizing.scale600",
 }
 `;
 
-exports[`RadioGroup styled components StyledRadioMark : has correct styles when checked 1`] = `
+exports[`RadioGroup styled components StyledRadioMarkInner : has correct styles when checked 1`] = `
 Object {
   ":active": Object {
     "backgroundColor": "$theme.colors.mono400",
@@ -210,29 +171,16 @@ Object {
   ":hover": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
-  "backgroundColor": "transparent",
-  "backgroundImage": null,
-  "backgroundPosition": "center",
-  "backgroundRepeat": "no-repeat",
-  "borderColor": "$theme.colors.mono700",
+  "backgroundColor": "white",
   "borderRadius": "50%",
-  "borderStyle": "solid",
-  "borderWidth": "$theme.sizing.scale0",
-  "display": "inline-block",
-  "flex": "0 0 auto",
   "height": "$theme.sizing.scale600",
-  "marginBottom": "$theme.sizing.scale200",
-  "marginLeft": "$theme.sizing.scale200",
-  "marginRight": "$theme.sizing.scale200",
-  "marginTop": "$theme.sizing.scale200",
   "transitionDuration": "$theme.animation.timing100",
   "transitionTimingFunction": "$theme.animation.easeOutCurve",
-  "verticalAlign": "middle",
   "width": "$theme.sizing.scale600",
 }
 `;
 
-exports[`RadioGroup styled components StyledRadioMark : has correct styles when disabled 1`] = `
+exports[`RadioGroup styled components StyledRadioMarkInner : has correct styles when disabled 1`] = `
 Object {
   ":active": Object {
     "backgroundColor": "$theme.colors.mono400",
@@ -240,25 +188,26 @@ Object {
   ":hover": Object {
     "backgroundColor": "$theme.colors.mono400",
   },
-  "backgroundColor": "transparent",
-  "backgroundImage": null,
-  "backgroundPosition": "center",
-  "backgroundRepeat": "no-repeat",
-  "borderColor": "$theme.colors.mono700",
+  "backgroundColor": "white",
   "borderRadius": "50%",
-  "borderStyle": "solid",
-  "borderWidth": "$theme.sizing.scale0",
-  "display": "inline-block",
-  "flex": "0 0 auto",
   "height": "$theme.sizing.scale600",
-  "marginBottom": "$theme.sizing.scale200",
-  "marginLeft": "$theme.sizing.scale200",
-  "marginRight": "$theme.sizing.scale200",
-  "marginTop": "$theme.sizing.scale200",
   "transitionDuration": "$theme.animation.timing100",
   "transitionTimingFunction": "$theme.animation.easeOutCurve",
-  "verticalAlign": "middle",
   "width": "$theme.sizing.scale600",
+}
+`;
+
+exports[`RadioGroup styled components StyledRadioMarkOuter : StyledRadioMarkOuter has correct styles 1`] = `
+Object {
+  "alignItems": "center",
+  "backgroundColor": "$theme.colors.mono700",
+  "borderRadius": "50%",
+  "display": "flex",
+  "height": "$theme.sizing.scale700",
+  "justifyContent": "center",
+  "margin": "$theme.sizing.scale200",
+  "verticalAlign": "middle",
+  "width": "$theme.sizing.scale700",
 }
 `;
 

--- a/src/radio/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/radio/__tests__/__snapshots__/styled-components.test.js.snap
@@ -205,7 +205,10 @@ Object {
   "display": "flex",
   "height": "$theme.sizing.scale700",
   "justifyContent": "center",
-  "margin": "$theme.sizing.scale200",
+  "marginBottom": "$theme.sizing.scale200",
+  "marginLeft": "$theme.sizing.scale200",
+  "marginRight": "$theme.sizing.scale200",
+  "marginTop": "$theme.sizing.scale200",
   "verticalAlign": "middle",
   "width": "$theme.sizing.scale700",
 }

--- a/src/radio/__tests__/styled-components.test.js
+++ b/src/radio/__tests__/styled-components.test.js
@@ -10,7 +10,8 @@ import {shallow} from 'enzyme';
 import {
   StyledRoot,
   StyledLabel,
-  StyledRadioMark,
+  StyledRadioMarkInner,
+  StyledRadioMarkOuter,
   StyledInput,
   StyledRadioGroupRoot,
 } from '../index';
@@ -67,22 +68,35 @@ describe('RadioGroup styled components', () => {
     });
   });
 
-  describe('StyledRadioMark', () => {
+  describe('StyledRadioMarkInner', () => {
     test.each([[''], ['disabled'], ['$isFocused'], ['checked'], ['$isError']])(
       '',
       prop => {
         const props = {};
         props[prop] = true;
         const component = shallow(
-          <StyledRadioMark {...props}>
+          <StyledRadioMarkInner {...props}>
             <div />
-          </StyledRadioMark>,
+          </StyledRadioMarkInner>,
         );
         expect(component.instance().getStyles()).toMatchSnapshot(
           'has correct styles when ' + prop,
         );
       },
     );
+  });
+
+  describe('StyledRadioMarkOuter', function() {
+    test('', () => {
+      const component = shallow(
+        <StyledRadioMarkOuter>
+          <div />
+        </StyledRadioMarkOuter>,
+      );
+      expect(component.instance().getStyles()).toMatchSnapshot(
+        'StyledRadioMarkOuter has correct styles',
+      );
+    });
   });
 
   describe('StyledInput', function() {
@@ -97,6 +111,7 @@ describe('RadioGroup styled components', () => {
       );
     });
   });
+
   describe('StyledRoot', function() {
     test('', () => {
       const component = shallow(
@@ -108,6 +123,7 @@ describe('RadioGroup styled components', () => {
         'StyledRoot has correct styles',
       );
     });
+
     test.each([['top'], ['bottom'], ['left'], ['right']])('', prop => {
       const props = {
         $labelPlacement: prop,

--- a/src/radio/index.js
+++ b/src/radio/index.js
@@ -12,10 +12,12 @@ export {default as RadioGroup} from './radiogroup';
 // Styled elements
 export {
   Root as StyledRoot,
-  RadioMark as StyledRadioMark,
   Label as StyledLabel,
   Input as StyledInput,
+  RadioMarkInner as StyledRadioMarkInner,
+  RadioMarkOuter as StyledRadioMarkOuter,
   RadioGroupRoot as StyledRadioGroupRoot,
 } from './styled-components';
+export {default as StyledRadioMark} from './radiomark';
 export {default as StyledRadio} from './radio';
 export * from './types';

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import React from 'react';
 
-import {default as StyledRadioMark} from './radiomark';
+import StyledRadioMark from './radiomark';
 import {
   RadioGroupRoot as StyledRadioGroupRoot,
   Label as StyledLabel,

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -6,14 +6,15 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import React from 'react';
-import type {PropsT, DefaultPropsT, StatelessStateT} from './types';
+
+import {default as StyledRadioMark} from './radiomark';
 import {
   RadioGroupRoot as StyledRadioGroupRoot,
-  RadioMark as StyledRadioMark,
   Label as StyledLabel,
   Input as StyledInput,
   Root as StyledRoot,
 } from './styled-components';
+import type {PropsT, DefaultPropsT, StatelessStateT} from './types';
 
 class StatelessRadioGroup extends React.Component<PropsT, StatelessStateT> {
   static defaultProps: DefaultPropsT = {

--- a/src/radio/radiomark.js
+++ b/src/radio/radiomark.js
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {RadioMarkOuter, RadioMarkInner} from './styled-components';
+
+function StyledRadioMark(props: *) {
+  return (
+    <RadioMarkOuter {...props}>
+      <RadioMarkInner {...props} />
+    </RadioMarkOuter>
+  );
+}
+
+export default StyledRadioMark;

--- a/src/radio/radiomark.js
+++ b/src/radio/radiomark.js
@@ -10,7 +10,7 @@ import React from 'react';
 
 import {RadioMarkOuter, RadioMarkInner} from './styled-components';
 
-function StyledRadioMark(props: *) {
+function RadioMark(props: *) {
   return (
     <RadioMarkOuter {...props}>
       <RadioMarkInner {...props} />
@@ -18,4 +18,4 @@ function StyledRadioMark(props: *) {
   );
 }
 
-export default StyledRadioMark;
+export default RadioMark;

--- a/src/radio/styled-components.js
+++ b/src/radio/styled-components.js
@@ -28,6 +28,7 @@ function getLabelPadding(props) {
     [paddingSide]: scale200,
   };
 }
+
 function getLabelColor(props) {
   const {$disabled, $theme} = props;
   const {colors} = $theme;
@@ -57,12 +58,10 @@ export const Root = styled('label', props => {
   };
 });
 
-export const RadioMark = styled('span', props => {
+export const RadioMarkInner = styled('div', props => {
   const {$checked, $disabled, $theme, $isFocused, $isError} = props;
-  const {colors, animation} = $theme;
-  const {
-    sizing: {scale0, scale100, scale300, scale600},
-  } = $theme;
+  const {animation, colors, sizing} = $theme;
+
   const activeStyle = {
     backgroundColor:
       $checked || $isError
@@ -73,28 +72,32 @@ export const RadioMark = styled('span', props => {
             ? colors.mono400
             : null,
   };
+
   return {
-    backgroundColor: 'transparent',
+    backgroundColor: 'white',
     borderRadius: '50%',
-    borderWidth: $checked ? scale300 : scale0,
-    width: $checked ? scale100 : scale600,
-    height: $checked ? scale100 : scale600,
-    backgroundImage: null,
-    flex: '0 0 auto',
+    height: $checked ? sizing.scale100 : sizing.scale600,
     transitionDuration: animation.timing100,
     transitionTimingFunction: animation.easeOutCurve,
-    borderStyle: 'solid',
-    borderColor: getBorderColor(props),
-    display: 'inline-block',
-    verticalAlign: 'middle',
-    backgroundRepeat: 'no-repeat',
-    backgroundPosition: 'center',
-    marginTop: $theme.sizing.scale200,
-    marginBottom: $theme.sizing.scale200,
-    marginLeft: $theme.sizing.scale200,
-    marginRight: $theme.sizing.scale200,
+    width: $checked ? sizing.scale100 : sizing.scale600,
     ':hover': activeStyle,
     ':active': activeStyle,
+  };
+});
+
+export const RadioMarkOuter = styled('div', props => {
+  const {sizing} = props.$theme;
+
+  return {
+    alignItems: 'center',
+    backgroundColor: getBorderColor(props),
+    borderRadius: '50%',
+    display: 'flex',
+    height: sizing.scale700,
+    justifyContent: 'center',
+    margin: sizing.scale200,
+    verticalAlign: 'middle',
+    width: sizing.scale700,
   };
 });
 
@@ -109,6 +112,7 @@ export const Label = styled('div', props => {
     ...typography.font400,
   };
 });
+
 // tricky style for focus event cause display: none doesn't work
 export const Input = styled('input', {
   opacity: 0,

--- a/src/radio/styled-components.js
+++ b/src/radio/styled-components.js
@@ -95,7 +95,10 @@ export const RadioMarkOuter = styled('div', props => {
     display: 'flex',
     height: sizing.scale700,
     justifyContent: 'center',
-    margin: sizing.scale200,
+    marginTop: sizing.scale200,
+    marginRight: sizing.scale200,
+    marginBottom: sizing.scale200,
+    marginLeft: sizing.scale200,
     verticalAlign: 'middle',
     width: sizing.scale700,
   };


### PR DESCRIPTION
#### Patch: Bug Fix

![image-2018-11-12-10-37-14-705](https://user-images.githubusercontent.com/5317799/48858547-86e3db80-ed70-11e8-9eb7-a7d4f0700f32.png)

Selecting a radio element in firefox previously caused a 'jitter' due to animating both the element `width/height` and `border-width` at the same time. Isolating either the `width/height` or `border-width` animations resulted in smooth transitions. [minimal reproducing example](https://codesandbox.io/s/v387xqmq0y)

Approach to fix was to break the single element into two nested elements so that only the inner circle needs to animate.

