### PR TITLE
feat: add theming values to storybook theme

### DIFF
--- a/.storybook-dark/config.js
+++ b/.storybook-dark/config.js
@@ -17,11 +17,15 @@ withOptions({
 
 setOptions({
   theme: {
-    ...themes.normal,
-    mainFill: '#141414',
-    mainBackground: '#1F1F1F',
-    mainTextColor: '#CCCCCC',
-    dimmedTextColor: '#CCCCCC',
+    ...themes.dark,
+    mainFill: DarkTheme.colors.mono800,
+    mainBackground: DarkTheme.colors.mono700,
+    mainTextColor: DarkTheme.colors.mono100,
+    dimmedTextColor: DarkTheme.colors.mono100,
+    highlightColor: DarkTheme.colors.primary,
+    successColor: DarkTheme.colors.positive,
+    warningColor: DarkTheme.colors.warning,
+    failColor: DarkTheme.colors.negative,
   },
 });
 

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import {configure, addDecorator} from '@storybook/react';
-import {withOptions} from '@storybook/addon-options';
+import {themes} from '@storybook/components';
+import {withOptions, setOptions} from '@storybook/addon-options';
 import {Provider as StyletronProvider} from 'styletron-react';
 import {Client as Styletron} from 'styletron-engine-atomic';
 import {ThemeProvider} from '../src/styles';
@@ -12,6 +13,16 @@ import {withKnobs} from '@storybook/addon-knobs';
 withOptions({
   name: 'baseui',
   url: 'https://github.com/uber-web/baseui',
+});
+
+setOptions({
+  theme: {
+    ...themes.normal,
+    highlightColor: LightTheme.colors.primary,
+    successColor: LightTheme.colors.positive,
+    warningColor: LightTheme.colors.warning,
+    failColor: LightTheme.colors.negative,
+  },
 });
 
 const engine = new Styletron();


### PR DESCRIPTION
#### Docs: New Feature

This PR updates our Light and Dark storybook examples to use the values provided from the applicable theme.

### Light Theme

#### Before

<img width="1104" alt="screen shot 2018-11-28 at 11 07 35 am" src="https://user-images.githubusercontent.com/4030377/49175666-f708d900-f2fd-11e8-8d7d-4f8425000e93.png">

#### After

<img width="1102" alt="screen shot 2018-11-28 at 11 07 55 am" src="https://user-images.githubusercontent.com/4030377/49175674-fa9c6000-f2fd-11e8-8573-0b0eb1165f22.png">

### Dark Theme

#### Before

<img width="1099" alt="screen shot 2018-11-28 at 11 08 14 am" src="https://user-images.githubusercontent.com/4030377/49175690-02f49b00-f2fe-11e8-8dd5-a4a5ddfed9a6.png">

#### After

<img width="1101" alt="screen shot 2018-11-28 at 11 08 35 am" src="https://user-images.githubusercontent.com/4030377/49175695-05ef8b80-f2fe-11e8-8dcd-11d717565d9f.png">

#### License

MIT
