### PR TITLE
fix(input): change onInputChange event to be type input

### DIFF
--- a/src/select/types.js
+++ b/src/select/types.js
@@ -86,7 +86,7 @@ export type PropsT = {
   onBlurResetsInput: boolean,
   onChange: (params: OnChangeParamsT) => void,
   onFocus: (e: SyntheticEvent<HTMLElement>) => void,
-  onInputChange: (e: SyntheticEvent<HTMLInputElement>) => void,
+  onInputChange: (e: SyntheticInputEvent<HTMLInputElement>) => void,
   onCloseResetsInput: boolean,
   onSelectResetsInput: boolean,
   onOpen: ?() => void,


### PR DESCRIPTION
Referencing `e.target.value` throws flow error `Cannot get e.target.value because property value is missing in EventTarget [1].`.  Input type should be updated to `SyntheticInputEvent`
