### PR TITLE
fix: proper fallback for size prop

### DIFF
--- a/src/icon/__tests__/styled-components.test.js
+++ b/src/icon/__tests__/styled-components.test.js
@@ -28,4 +28,11 @@ describe('Icon styled components', () => {
     expect(styles).toHaveProperty('width', '$theme.sizing.scale400');
     expect(styles).toHaveProperty('height', '$theme.sizing.scale400');
   });
+
+  test('Svg handles default size', () => {
+    const wrapper = shallow(<Svg $size="default" />);
+    const styles = wrapper.instance().getStyles();
+    expect(styles).toHaveProperty('width', '$theme.sizing.scale600');
+    expect(styles).toHaveProperty('height', '$theme.sizing.scale600');
+  });
 });

--- a/src/icon/examples.js
+++ b/src/icon/examples.js
@@ -99,7 +99,7 @@ export default {
             const Icon = Icons[key];
             return (
               <ButtonContainer key={key}>
-                <Button kind={buttonKind} endEnhancer={() => <Icon />}>
+                <Button kind={buttonKind} endEnhancer={Icon}>
                   {Icon.name}
                 </Button>
               </ButtonContainer>

--- a/src/icon/styled-components.js
+++ b/src/icon/styled-components.js
@@ -14,6 +14,8 @@ export function getSvgStyles({$theme, $size, $color}: StyledComponentParamsT) {
       $size = $theme.sizing[$size];
     } else if (typeof $size === 'number') {
       $size = `${$size}px`;
+    } else {
+      $size = $theme.sizing.scale600;
     }
   } else {
     $size = $theme.sizing.scale600;


### PR DESCRIPTION
Previously, if you passed in a string for $size, Icon would set the height and width to that string, resulting in an invalid CSS property (and causing the icon to not render). This is easy to repro by supplying an icon as a Button enhancer and leaving the size as the default. (Button spreads the $size prop to the Icon eventually)

This didn't get caught before because the examples use
`enhancer={() => <Icon />}` instead of `enhancer={Icon}`, which creates an intermediate component layer between Button and Icon, which "traps" the props and prevents them from being spread all the way down.