### PR TITLE
feat: introduce Notification component

### DIFF
--- a/rfcs/notification-component.md
+++ b/rfcs/notification-component.md
@@ -1,0 +1,51 @@
+# Notification Component
+
+## Usage
+
+### Basic usage
+
+```javascript
+import * as React from 'react';
+import {Notification} from 'baseui/notification';
+
+export default () => (
+  <Notification>
+    This is a notification message.
+  </Notification>
+);
+```
+
+### Advanced usage
+
+```javascript
+import * as React from 'react';
+import {Notification, KIND} from 'baseui/notification';
+
+export default () => (
+  <Notification kind={KIND.warning}>
+    This is a warning notification message.
+  </Notification>
+);
+```
+
+## Exports
+
+* `Notification`
+* `StyledNotification`
+* `KIND`
+
+## `Foo` API
+
+* `kind: 'primary' | 'warning' | 'success' | 'error'` - Optional
+  The type of Notification styling to show
+
+## Presentational components props API
+
+These properties are passed to every presentational (styled) component that is exported:
+
+* `$theme: Theme`
+* `$kind: 'primary' | 'warning' | 'success' | 'error'`
+
+## Accessibility
+
+This component is built to the [WAI-ARIA Alert Pattern](https://www.w3.org/TR/wai-aria-practices-1.1/#alert).

--- a/screener.config.js
+++ b/screener.config.js
@@ -15,6 +15,7 @@ const Card = require('./src/card/examples-list');
 const Checkbox = require('./src/checkbox/examples-list');
 const Input = require('./src/input/examples-list');
 const Modal = require('./src/modal/examples-list');
+const Notification = require('./src/notification/examples-list');
 const Pagination = require('./src/pagination/examples-list');
 const Popover = require('./src/popover/examples-list');
 const Radio = require('./src/radio/examples-list');
@@ -45,6 +46,10 @@ module.exports = {
     new RegExp(Input.VALUE_EXAMPLE),
     /Stateless Menu/,
     new RegExp(`${Modal.SIMPLE_EXAMPLE}$`),
+    new RegExp(Notification.DEFAULT),
+    new RegExp(Notification.SUCCESS),
+    new RegExp(Notification.WARNING),
+    new RegExp(Notification.ERROR),
     new RegExp(Pagination.STATEFUL_PAGINATION),
     new RegExp(Popover.SIMPLE_EXAMPLE),
     new RegExp(Radio.SIMPLE_EXAMPLE),

--- a/src/notification/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/notification/__tests__/__snapshots__/styled-components.test.js.snap
@@ -1,0 +1,65 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`StyledComponents StyledRoot displays correct styles for error notification 1`] = `
+Object {
+  "backgroundColor": "$theme.colors.notificationErrorBackground",
+  "borderRadius": "$theme.borders.radius200",
+  "color": "$theme.colors.notificationErrorText",
+  "fontFamily": "$theme.typography.font350.fontFamily",
+  "fontSize": "$theme.typography.font350.fontSize",
+  "fontWeight": "$theme.typography.font350.fontWeight",
+  "lineHeight": "$theme.typography.font350.lineHeight",
+  "paddingBottom": "$theme.sizing.scale600",
+  "paddingLeft": "$theme.sizing.scale600",
+  "paddingRight": "$theme.sizing.scale600",
+  "paddingTop": "$theme.sizing.scale600",
+}
+`;
+
+exports[`StyledComponents StyledRoot displays correct styles for primary notification 1`] = `
+Object {
+  "backgroundColor": "$theme.colors.notificationPrimaryBackground",
+  "borderRadius": "$theme.borders.radius200",
+  "color": "$theme.colors.notificationPrimaryText",
+  "fontFamily": "$theme.typography.font350.fontFamily",
+  "fontSize": "$theme.typography.font350.fontSize",
+  "fontWeight": "$theme.typography.font350.fontWeight",
+  "lineHeight": "$theme.typography.font350.lineHeight",
+  "paddingBottom": "$theme.sizing.scale600",
+  "paddingLeft": "$theme.sizing.scale600",
+  "paddingRight": "$theme.sizing.scale600",
+  "paddingTop": "$theme.sizing.scale600",
+}
+`;
+
+exports[`StyledComponents StyledRoot displays correct styles for success notification 1`] = `
+Object {
+  "backgroundColor": "$theme.colors.notificationSuccessBackground",
+  "borderRadius": "$theme.borders.radius200",
+  "color": "$theme.colors.notificationSuccessText",
+  "fontFamily": "$theme.typography.font350.fontFamily",
+  "fontSize": "$theme.typography.font350.fontSize",
+  "fontWeight": "$theme.typography.font350.fontWeight",
+  "lineHeight": "$theme.typography.font350.lineHeight",
+  "paddingBottom": "$theme.sizing.scale600",
+  "paddingLeft": "$theme.sizing.scale600",
+  "paddingRight": "$theme.sizing.scale600",
+  "paddingTop": "$theme.sizing.scale600",
+}
+`;
+
+exports[`StyledComponents StyledRoot displays correct styles for warning notification 1`] = `
+Object {
+  "backgroundColor": "$theme.colors.notificationWarningBackground",
+  "borderRadius": "$theme.borders.radius200",
+  "color": "$theme.colors.notificationWarningText",
+  "fontFamily": "$theme.typography.font350.fontFamily",
+  "fontSize": "$theme.typography.font350.fontSize",
+  "fontWeight": "$theme.typography.font350.fontWeight",
+  "lineHeight": "$theme.typography.font350.lineHeight",
+  "paddingBottom": "$theme.sizing.scale600",
+  "paddingLeft": "$theme.sizing.scale600",
+  "paddingRight": "$theme.sizing.scale600",
+  "paddingTop": "$theme.sizing.scale600",
+}
+`;

--- a/src/notification/__tests__/notification.js
+++ b/src/notification/__tests__/notification.js
@@ -1,0 +1,18 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import {Notification} from '..';
+
+describe('Notification', () => {
+  it('applies correct accessibility attributes to root element', () => {
+    const example = shallow(<Notification>Test</Notification>);
+    expect(example).toHaveProp('role', 'alert');
+  });
+});

--- a/src/notification/__tests__/styled-components.test.js
+++ b/src/notification/__tests__/styled-components.test.js
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+import React from 'react';
+import {shallow} from 'enzyme';
+import {StyledRoot} from '../styled-components';
+import {KIND} from '../constants';
+
+describe('StyledComponents', () => {
+  describe('StyledRoot', () => {
+    it.each([[KIND.primary], [KIND.warning], [KIND.success], [KIND.error]])(
+      'displays correct styles for %s notification',
+      kind => {
+        const component = shallow(<StyledRoot $kind={kind} />);
+        expect(component.instance().getStyles()).toMatchSnapshot();
+      },
+    );
+  });
+});

--- a/src/notification/constants.js
+++ b/src/notification/constants.js
@@ -6,9 +6,9 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-export const KIND = {
+export const KIND = Object.freeze({
   primary: 'primary',
   success: 'success',
   warning: 'warning',
   error: 'error',
-};
+});

--- a/src/notification/constants.js
+++ b/src/notification/constants.js
@@ -1,0 +1,14 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+export const KIND = {
+  primary: 'primary',
+  success: 'success',
+  warning: 'warning',
+  error: 'error',
+};

--- a/src/notification/examples-list.js
+++ b/src/notification/examples-list.js
@@ -1,0 +1,17 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/* eslint-env node */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+module.exports = {
+  DEFAULT: 'Primary (default) notification',
+  SUCCESS: 'Success notification',
+  WARNING: 'Warning notification',
+  ERROR: 'Error notification',
+  OVERRIDES: 'Notification with custom overrides',
+};

--- a/src/notification/examples.js
+++ b/src/notification/examples.js
@@ -1,0 +1,52 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+import React from 'react';
+import {Notification, KIND} from './';
+import examples from './examples-list';
+
+export default {
+  [examples.DEFAULT]: function Story1() {
+    return <Notification>This is a primary notification</Notification>;
+  },
+  [examples.SUCCESS]: function Story2() {
+    return (
+      <Notification kind={KIND.success}>
+        This is a success notification
+      </Notification>
+    );
+  },
+  [examples.WARNING]: function Story3() {
+    return (
+      <Notification kind={KIND.warning}>
+        This is a warning notification
+      </Notification>
+    );
+  },
+  [examples.ERROR]: function Story4() {
+    return (
+      <Notification kind={KIND.error}>
+        This is a warning notification
+      </Notification>
+    );
+  },
+  [examples.OVERRIDES]: function Story5() {
+    return (
+      <Notification
+        overrides={{
+          Root: {
+            style: {backgroundColor: 'pink', color: 'black'},
+          },
+        }}
+      >
+        This is a custom notification
+      </Notification>
+    );
+  },
+};

--- a/src/notification/examples.js
+++ b/src/notification/examples.js
@@ -32,7 +32,7 @@ export default {
   [examples.ERROR]: function Story4() {
     return (
       <Notification kind={KIND.error}>
-        This is a warning notification
+        This is an error notification
       </Notification>
     );
   },

--- a/src/notification/index.js
+++ b/src/notification/index.js
@@ -1,0 +1,13 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+export {default as Notification} from './notification';
+export * from './styled-components';
+export * from './constants';
+export * from './types';

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+import React from 'react';
+import type {NotifcationPropsT} from './types';
+import {KIND} from './constants';
+import {StyledRoot} from './styled-components';
+import {getOverrides} from '../helpers/overrides';
+
+function Notification({children, kind, overrides = {}}: NotifcationPropsT) {
+  const [Root, baseRootProps] = getOverrides(overrides.Root, StyledRoot);
+
+  return (
+    <Root role="alert" $kind={kind} {...baseRootProps}>
+      {children}
+    </Root>
+  );
+}
+
+Notification.defaultProps = {
+  overrides: {},
+  kind: KIND.primary,
+};
+
+export default Notification;

--- a/src/notification/stories.js
+++ b/src/notification/stories.js
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/* @flow */
+/*global module */
+
+import {storiesOf} from '@storybook/react';
+import {withReadme} from 'storybook-readme';
+
+import examples from './examples';
+//$FlowFixMe
+import NotificationREADME from '../../rfcs/notification-component.md';
+
+Object.entries(examples).forEach(([description, example]) =>
+  storiesOf('Notification', module)
+    .addDecorator(withReadme(NotificationREADME))
+    // $FlowFixMe
+    .add(description, example),
+);

--- a/src/notification/styled-components.js
+++ b/src/notification/styled-components.js
@@ -1,0 +1,39 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+import {styled} from '../styles/index';
+import type {StyledRootPropsT} from './types';
+import {KIND} from './constants';
+
+export const StyledRoot = styled('div', ({$theme, $kind}: StyledRootPropsT) => {
+  let color = $theme.colors.notificationPrimaryText;
+  let backgroundColor = $theme.colors.notificationPrimaryBackground;
+
+  if ($kind === KIND.success) {
+    color = $theme.colors.notificationSuccessText;
+    backgroundColor = $theme.colors.notificationSuccessBackground;
+  } else if ($kind === KIND.warning) {
+    color = $theme.colors.notificationWarningText;
+    backgroundColor = $theme.colors.notificationWarningBackground;
+  } else if ($kind === KIND.error) {
+    color = $theme.colors.notificationErrorText;
+    backgroundColor = $theme.colors.notificationErrorBackground;
+  }
+
+  return {
+    ...$theme.typography.font350,
+    borderRadius: $theme.borders.radius200,
+    paddingTop: $theme.sizing.scale600,
+    paddingRight: $theme.sizing.scale600,
+    paddingBottom: $theme.sizing.scale600,
+    paddingLeft: $theme.sizing.scale600,
+    color,
+    backgroundColor,
+  };
+});

--- a/src/notification/styled-components.js
+++ b/src/notification/styled-components.js
@@ -12,18 +12,24 @@ import type {StyledRootPropsT} from './types';
 import {KIND} from './constants';
 
 export const StyledRoot = styled('div', ({$theme, $kind}: StyledRootPropsT) => {
-  let color = $theme.colors.notificationPrimaryText;
-  let backgroundColor = $theme.colors.notificationPrimaryBackground;
+  let color, backgroundColor;
 
-  if ($kind === KIND.success) {
-    color = $theme.colors.notificationSuccessText;
-    backgroundColor = $theme.colors.notificationSuccessBackground;
-  } else if ($kind === KIND.warning) {
-    color = $theme.colors.notificationWarningText;
-    backgroundColor = $theme.colors.notificationWarningBackground;
-  } else if ($kind === KIND.error) {
-    color = $theme.colors.notificationErrorText;
-    backgroundColor = $theme.colors.notificationErrorBackground;
+  switch ($kind) {
+    case KIND.success:
+      color = $theme.colors.notificationSuccessText;
+      backgroundColor = $theme.colors.notificationSuccessBackground;
+      break;
+    case KIND.warning:
+      color = $theme.colors.notificationWarningText;
+      backgroundColor = $theme.colors.notificationWarningBackground;
+      break;
+    case KIND.error:
+      color = $theme.colors.notificationErrorText;
+      backgroundColor = $theme.colors.notificationErrorBackground;
+      break;
+    default:
+      color = $theme.colors.notificationPrimaryText;
+      backgroundColor = $theme.colors.notificationPrimaryBackground;
   }
 
   return {

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -19,10 +19,10 @@ export type OverridesT = {
 export type NotifcationPropsT = {
   children?: Node,
   overrides?: OverridesT,
-  kind: $Keys<typeof KIND>,
+  kind: $Values<typeof KIND>,
 };
 
 export type StyledRootPropsT = {
   $theme: ThemeT,
-  $kind: $Keys<typeof KIND>,
+  $kind: $Values<typeof KIND>,
 };

--- a/src/notification/types.js
+++ b/src/notification/types.js
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+import type {Node} from 'react';
+import {KIND} from './constants';
+import type {ThemeT} from '../styles/types';
+import type {OverrideT} from '../helpers/overrides';
+
+export type OverridesT = {
+  Root?: OverrideT<*>,
+};
+
+export type NotifcationPropsT = {
+  children?: Node,
+  overrides?: OverridesT,
+  kind: $Keys<typeof KIND>,
+};
+
+export type StyledRootPropsT = {
+  $theme: ThemeT,
+  $kind: $Keys<typeof KIND>,
+};

--- a/src/styles/types.js
+++ b/src/styles/types.js
@@ -160,6 +160,16 @@ export type ColorsT = {
   // Menu
   menuFillHover: string,
 
+  // Notification
+  notificationPrimaryBackground: string,
+  notificationPrimaryText: string,
+  notificationWarningBackground: string,
+  notificationWarningText: string,
+  notificationSuccessBackground: string,
+  notificationSuccessText: string,
+  notificationErrorBackground: string,
+  notificationErrorText: string,
+
   // Shadow
   shadowFocus: string,
   shadowError: string,

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -175,6 +175,16 @@ export default function createTheme(
 
       // Menu
       menuFillHover: primitives.mono300,
+
+      // Notification
+      notificationPrimaryBackground: primitives.primary50,
+      notificationPrimaryText: primitives.primary400,
+      notificationWarningBackground: primitives.warning50,
+      notificationWarningText: primitives.warning400,
+      notificationSuccessBackground: primitives.positive50,
+      notificationSuccessText: primitives.positive400,
+      notificationErrorBackground: primitives.negative50,
+      notificationErrorText: primitives.negative400,
     },
     typography: {
       font100: {


### PR DESCRIPTION
#### Minor: New Feature

This PR introduces the `Notification` (in-line notification) component.  It includes 4 styles: `primary (default), success, warning, and error`.

<img width="507" alt="screen shot 2018-11-29 at 3 17 17 pm" src="https://user-images.githubusercontent.com/4030377/49258367-10874f00-f3ea-11e8-8ce1-d80059f2e57c.png">
<img width="508" alt="screen shot 2018-11-29 at 3 17 27 pm" src="https://user-images.githubusercontent.com/4030377/49258368-10874f00-f3ea-11e8-81b1-5aae82b175c9.png">
<img width="506" alt="screen shot 2018-11-29 at 3 17 36 pm" src="https://user-images.githubusercontent.com/4030377/49258369-111fe580-f3ea-11e8-9c7e-090fabe9a5fd.png">
<img width="756" alt="screen shot 2018-11-29 at 3 18 20 pm" src="https://user-images.githubusercontent.com/4030377/49258370-111fe580-f3ea-11e8-971d-3ded4953b773.png">

#### Tests Added + Pass

Yes

#### License

MIT

<!-- Describe your changes below in as much detail as possible -->
