### PR TITLE
fix(accordion): removes flowfixme comments in accordion component

### DIFF
--- a/src/accordion/__tests__/panel.test.js
+++ b/src/accordion/__tests__/panel.test.js
@@ -50,7 +50,6 @@ describe('Panel', () => {
       onClick: jest.fn(),
       title: 'title',
     };
-    // $FlowFixMe
     const wrapper = mount(<Panel {...props}>Content</Panel>);
     const header = wrapper.find(StyledHeader);
     header.simulate('click');

--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -36,7 +36,7 @@ export default class Accordion extends React.Component<
     ...this.props.initialState,
   };
 
-  onPanelChange(key: string, onChange: () => {}, ...args: *) {
+  onPanelChange(key: React.Key, onChange: () => {}, ...args: *) {
     let activeKeys = this.state.expanded;
     const {accordion} = this.props;
     if (accordion) {
@@ -68,7 +68,7 @@ export default class Accordion extends React.Component<
     const {expanded} = this.state;
     const {accordion, disabled, children} = this.props;
     // eslint-disable-next-line flowtype/no-weak-types
-    const newChildren = React.Children.map(children, (child: any, index) => {
+    const newChildren = React.Children.map(children, (child: *, index) => {
       if (!child) return;
       // If there is no key provide, use the panel order as default key
       // $FlowFixMe

--- a/src/accordion/examples.js
+++ b/src/accordion/examples.js
@@ -65,7 +65,6 @@ export default {
     return (
       <Centered>
         <Accordion>
-          {/* $FlowFixMe */}
           <Panel title="Accordion panel 1">{content}</Panel>
           <Panel title="Accordion panel 2">{content}</Panel>
           <Panel title="Accordion panel 3">{content}</Panel>
@@ -77,7 +76,6 @@ export default {
     return (
       <Centered>
         <Accordion initialState={{expanded: ['panel-1']}}>
-          {/* $FlowFixMe */}
           <Panel
             key="panel-1"
             title="Accordion panel 1"
@@ -98,7 +96,6 @@ export default {
   [examples.SINGLE_STATEFUL_PANEL]: function Story3() {
     return (
       <Centered>
-        {/* $FlowFixMe */}
         <StatefulPanel title="Expandable panel">{content}</StatefulPanel>
       </Centered>
     );

--- a/src/accordion/types.js
+++ b/src/accordion/types.js
@@ -12,7 +12,7 @@ import type {OverrideT} from '../helpers/overrides';
 import {STATE_CHANGE_TYPE} from './constants';
 
 export type AccordionStateT = {
-  expanded: Array<string>,
+  expanded: Array<React.Key>,
 };
 
 export type PanelStateT = {
@@ -44,13 +44,13 @@ export type PanelOverridesT<T> = {
   Content?: OverrideT<T>,
 };
 
-export type ChildT = React.Node;
-
-export type ChildrenT = React.ChildrenArray<ChildT>;
-
 export type OnChangeHandlerT = ({expanded: boolean}) => void;
 
-export type AccordionOnChangeHandlerT = ({expanded: Array<string>}) => void;
+export type AccordionOnChangeHandlerT = ({
+  expanded: Array<React.Key>,
+}) => void;
+
+type ChildrenT = React.ChildrenArray<React.Element<*>>;
 
 export type AccordionPropsT = {
   accordion?: boolean,
@@ -65,10 +65,10 @@ export type AccordionPropsT = {
 };
 
 export type PanelPropsT = {
-  children: ChildrenT,
+  children: React.Node,
   disabled?: boolean,
   expanded?: boolean,
-  key?: string,
+  key?: React.Key,
   onChange?: OnChangeHandlerT,
   onClick?: (e: Event) => void,
   onKeyDown?: (e: KeyboardEvent) => void,
@@ -78,7 +78,7 @@ export type PanelPropsT = {
 
 // Props for panel stateful container
 export type StatefulPanelContainerPropsT = {
-  children: (props: $Diff<PanelPropsT, {children: ChildrenT}>) => React.Node,
+  children: (props: $Diff<PanelPropsT, {children: React.Node}>) => React.Node,
   initialState?: PanelStateT,
   onChange?: OnChangeHandlerT,
   stateReducer: PanelStateReducerT,
@@ -87,7 +87,10 @@ export type StatefulPanelContainerPropsT = {
 // Props for stateful panel
 export type StatefulPanelPropsT = $Diff<
   StatefulPanelContainerPropsT,
-  {children: (props: PanelPropsT) => React.Node},
+  {
+    children: (props: PanelPropsT) => React.Node,
+    stateReducer: PanelStateReducerT,
+  },
 > &
   PanelPropsT;
 


### PR DESCRIPTION
based fix on flow children docs [here](https://flow.org/en/docs/react/children/#toc-only-allowing-a-specific-element-type-as-children) and information in flow issue [here](https://github.com/facebook/flow/issues/4625)

another issue was coming from how we reused the `key` prop. i replaces type references to that prop with reacts provided type `React.Key` for compatibility