### PR TITLE
fix(select): make option type inexact

### DIFF
--- a/src/select/types.js
+++ b/src/select/types.js
@@ -15,12 +15,12 @@ export type ChangeActionT = $Keys<typeof STATE_CHANGE_TYPE>;
 export type SizeT = $Keys<typeof SIZE>;
 export type TypeT = $Keys<typeof TYPE>;
 
-export type OptionT = $Shape<{
+export type OptionT = {
   id?: string,
   label?: React.Node,
   disabled?: boolean,
   clearableValue?: boolean,
-}>;
+};
 
 export type ValueT = Array<OptionT>;
 


### PR DESCRIPTION
```
Cannot assign object literal to opt because property content is missing in object literal [1] but exists in OptionT [2].

         3│
         4│ import {Select, TYPE, type OptionT, type ValueT} from 'baseui/select';
         5│
 [2][1]  6│ const opt: OptionT = {
         7│   id: 'test',
         8│   content: 'red',
         9│ };
        10│
```

$Shape makes all properties optional but also makes it an exact type where no other keys are allowed. This prevents us from using the `labelKey` prop to control which object property is used as the label.