### PR TITLE
fix(components): add displayName

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ This document helps you navigate the process.
 
 2.  Once your RFC PR is approved, start implementing the component
 
+- You can find the component template in `src/template-component`
 - To make the review process fast, please try to send small PRs, if you can
 - All T0D0s in the code have to have a corresponding issue created. Refer to the created issue in the T0D0s following the format `// TOD0(#44): Something`
 

--- a/src/accordion/panel.js
+++ b/src/accordion/panel.js
@@ -20,7 +20,7 @@ import {
 
 import type {PanelPropsT, SharedStylePropsArgT} from './types';
 
-class ExpansionPanel extends React.Component<PanelPropsT> {
+class Panel extends React.Component<PanelPropsT> {
   static defaultProps = {
     disabled: false,
     expanded: false,
@@ -120,4 +120,4 @@ class ExpansionPanel extends React.Component<PanelPropsT> {
   }
 }
 
-export default ExpansionPanel;
+export default Panel;

--- a/src/avatar/styled-components.js
+++ b/src/avatar/styled-components.js
@@ -28,6 +28,7 @@ export const Avatar = styled('img', (props: StylePropsT) => {
     width: themedSize,
   };
 });
+Avatar.displayName = 'StyledAvatar';
 
 export const Root = styled('div', (props: StylePropsT) => {
   const {$didImageFailToLoad} = props;
@@ -45,3 +46,4 @@ export const Root = styled('div', (props: StylePropsT) => {
     width: $didImageFailToLoad ? themedSize : null,
   };
 });
+Root.displayName = 'StyledRoot';

--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
@@ -1,31 +1,31 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Breadcrumbs displays separators in correct positions 1`] = `
-<MockStyledComponent
+<StyledRoot
   aria-label="Breadcrumbs navigation"
 >
-  <MockStyledComponent
+  <StyledLink
     href="#"
   >
     Parent Page
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledLink>
+  <StyledSeparator
     key="0"
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledIcon />
+  </StyledSeparator>
+  <StyledLink
     href="#"
   >
     Sub-Parent Page
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledLink>
+  <StyledSeparator
     key="1"
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
+    <StyledIcon />
+  </StyledSeparator>
   <span>
     Current Page
   </span>
-</MockStyledComponent>
+</StyledRoot>
 `;

--- a/src/breadcrumbs/styled-components.js
+++ b/src/breadcrumbs/styled-components.js
@@ -17,6 +17,7 @@ export const StyledRoot = styled('nav', ({$theme}: StyledRootPropsT) => {
     ...$theme.typography.font450,
   };
 });
+StyledRoot.displayName = 'StyledRoot';
 
 export const StyledSeparator = styled('div', ({$theme}: StyledSeparatorT) => {
   return {
@@ -26,9 +27,11 @@ export const StyledSeparator = styled('div', ({$theme}: StyledSeparatorT) => {
     marginRight: $theme.sizing.scale300,
   };
 });
+StyledSeparator.displayName = 'StyledSeparator';
 
 export const StyledIcon = styled(ChevronRight, () => {
   return {
     verticalAlign: 'text-bottom',
   };
 });
+StyledIcon.displayName = 'StyledIcon';

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -49,16 +49,19 @@ export const BaseButton = styled(
     ...getStyleForKind({$theme, $kind, $isLoading}),
   }),
 );
+BaseButton.displayName = 'StyledBaseButton';
 
 export const EndEnhancer = styled('div', ({$theme}: StylePropsT) => ({
   display: 'flex',
   marginLeft: $theme.sizing.scale500,
 }));
+EndEnhancer.displayName = 'StyledEndEnhancer';
 
 export const StartEnhancer = styled('div', ({$theme}: StylePropsT) => ({
   display: 'flex',
   marginRight: $theme.sizing.scale500,
 }));
+StartEnhancer.displayName = 'StyledStartEnhancer';
 
 export const LoadingSpinnerContainer = styled('div', {
   // To center within parent
@@ -67,6 +70,7 @@ export const LoadingSpinnerContainer = styled('div', {
   top: '50%',
   transform: 'translate(-50%, -50%)',
 });
+LoadingSpinnerContainer.displayName = 'StyledLoadingSpinnerContainer';
 
 export const LoadingSpinner = styled(
   'div',
@@ -100,6 +104,7 @@ export const LoadingSpinner = styled(
     };
   },
 );
+LoadingSpinner.displayName = 'StyledLoadingSpinner';
 
 export function getLoadingSpinnerColors({
   $theme,

--- a/src/card/styled-components.js
+++ b/src/card/styled-components.js
@@ -10,6 +10,7 @@ LICENSE file in the root directory of this source tree.
 import {styled} from '../styles/index';
 
 export const Action = styled('div', () => ({}));
+Action.displayName = 'StyledAction';
 
 export const Body = styled('div', ({$theme}) => {
   const {colors, sizing, typography} = $theme;
@@ -19,6 +20,7 @@ export const Body = styled('div', ({$theme}) => {
     ...typography.font400,
   };
 });
+Body.displayName = 'StyledBody';
 
 export const Contents = styled('div', ({$theme}) => {
   const {sizing} = $theme;
@@ -26,6 +28,7 @@ export const Contents = styled('div', ({$theme}) => {
     margin: sizing.scale800,
   };
 });
+Contents.displayName = 'StyledContents';
 
 export const HeaderImage = styled('img', ({$theme}) => {
   const {borders} = $theme;
@@ -36,6 +39,7 @@ export const HeaderImage = styled('img', ({$theme}) => {
     maxWidth: '100%',
   };
 });
+HeaderImage.displayName = 'StyledHeaderImage';
 
 export const Root = styled('div', ({$theme}) => {
   const {borders, lighting, colors} = $theme;
@@ -46,6 +50,7 @@ export const Root = styled('div', ({$theme}) => {
     backgroundColor: colors.backgroundAlt,
   };
 });
+Root.displayName = 'StyledWrapper';
 
 export const Thumbnail = styled('img', props => {
   const {
@@ -61,6 +66,7 @@ export const Thumbnail = styled('img', props => {
     margin: `0 0 ${sizing.scale500} ${sizing.scale500}`,
   };
 });
+Thumbnail.displayName = 'StyledThumbnail';
 
 export const Title = styled('h1', ({$hasThumbnail, $theme}) => {
   const {colors, sizing, typography} = $theme;
@@ -73,3 +79,4 @@ export const Title = styled('h1', ({$hasThumbnail, $theme}) => {
     padding: 0,
   };
 });
+Title.displayName = 'StyledTitle';

--- a/src/checkbox/styled-components.js
+++ b/src/checkbox/styled-components.js
@@ -112,6 +112,7 @@ export const Root = styled('label', props => {
     userSelect: 'none',
   };
 });
+Root.displayName = 'StyledRoot';
 
 function getToggleThumbColor(props) {
   const {
@@ -228,6 +229,7 @@ export const Checkmark = styled('span', props => {
     ? getToggleCheckMarkStyles(props)
     : getDefaultCheckMarkStyles(props);
 });
+Checkmark.displayName = 'StyledCheckmark';
 
 export const Label = styled('div', props => {
   const {$theme, $checkmarkType} = props;
@@ -241,6 +243,8 @@ export const Label = styled('div', props => {
     lineHeight: '24px',
   };
 });
+Label.displayName = 'StyledLabel';
+
 // tricky style for focus event cause display: none doesn't work
 export const Input = styled('input', {
   opacity: 0,
@@ -250,3 +254,4 @@ export const Input = styled('input', {
   margin: 0,
   padding: 0,
 });
+Input.displayName = 'StyledInput';

--- a/src/form-control/styled-components.js
+++ b/src/form-control/styled-components.js
@@ -29,6 +29,7 @@ export const Label = styled('label', props => {
     marginLeft: '0',
   };
 });
+Label.displayName = 'StyledLabel';
 
 export const Caption = styled('div', props => {
   const {
@@ -51,6 +52,7 @@ export const Caption = styled('div', props => {
     marginLeft: '0',
   };
 });
+Caption.displayName = 'StyledCaption';
 
 export const ControlContainer = styled('div', props => {
   const {
@@ -60,3 +62,4 @@ export const ControlContainer = styled('div', props => {
     marginBottom: sizing.scale600,
   };
 });
+ControlContainer.displayName = 'StyledControlContainer';

--- a/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
+++ b/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
@@ -4,7 +4,7 @@ exports[`Stateless header navigation should render component: Component has corr
 <HeaderNavigation
   overrides={Object {}}
 >
-  <MockStyledComponent
+  <StyledRoot
     role="navigation"
   >
     <nav
@@ -13,6 +13,6 @@ exports[`Stateless header navigation should render component: Component has corr
     >
       Some tag
     </nav>
-  </MockStyledComponent>
+  </StyledRoot>
 </HeaderNavigation>
 `;

--- a/src/header-navigation/styled-components.js
+++ b/src/header-navigation/styled-components.js
@@ -24,6 +24,7 @@ export const Root = styled('nav', props => {
     borderBottom: `1px solid ${border}`,
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const NavigationItem = styled('div', props => {
   const {$theme} = props;
@@ -35,6 +36,7 @@ export const NavigationItem = styled('div', props => {
     paddingLeft: scale800,
   };
 });
+NavigationItem.displayName = 'StyledNavigationItem';
 
 export const NavigationList: React.ComponentType<{
   align: string,
@@ -62,3 +64,4 @@ export const NavigationList: React.ComponentType<{
   }),
   ['align'],
 ): React.ComponentType<*>);
+NavigationList.displayName = 'StyledNavigationList';

--- a/src/icon/__tests__/__snapshots__/icon.test.js.snap
+++ b/src/icon/__tests__/__snapshots__/icon.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
-<MockStyledComponent
+<StyledSvg
   viewBox="0 0 23px 23px"
 >
   <title>
@@ -12,5 +12,5 @@ exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
     d="M6 12C6 11.4477 6.44772 11 7 11H17C17.5523 11 18 11.4477 18 12C18 12.5523 17.5523 13 17 13H7C6.44772 13 6 12.5523 6 12Z"
     fillRule="evenodd"
   />
-</MockStyledComponent>
+</StyledSvg>
 `;

--- a/src/icon/styled-components.js
+++ b/src/icon/styled-components.js
@@ -30,3 +30,4 @@ export function getSvgStyles({$theme, $size, $color}: StyledComponentParamsT) {
 }
 
 export const Svg = styled('svg', getSvgStyles);
+Svg.displayName = 'StyledSvg';

--- a/src/input/__tests__/__snapshots__/input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/input.test.js.snap
@@ -38,7 +38,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <StyledInput
       $adjoined="right"
       $disabled={false}
       $error={false}
@@ -92,7 +92,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <StyledInput
       $adjoined="both"
       $disabled={false}
       $error={false}
@@ -146,7 +146,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <StyledInput
       $adjoined="left"
       $disabled={false}
       $error={false}

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -61,6 +61,7 @@ export const Root = styled('div', props => {
     width: '100%',
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const InputEnhancer = styled('div', props => {
   const {
@@ -77,6 +78,7 @@ export const InputEnhancer = styled('div', props => {
     borderRadius: getDecoratorBorderRadius($position, sizing.scale100),
   };
 });
+InputEnhancer.displayName = 'StyledInputEnhancer';
 
 export const getInputContainerStyles = (props: SharedPropsT) => {
   const {
@@ -128,6 +130,7 @@ export const getInputContainerStyles = (props: SharedPropsT) => {
 };
 
 export const InputContainer = styled('div', getInputContainerStyles);
+InputContainer.displayName = 'StyledInputContainer';
 
 export const getInputStyles = (props: SharedPropsT) => {
   const {
@@ -156,3 +159,4 @@ export const getInputStyles = (props: SharedPropsT) => {
 };
 
 export const Input = styled('input', getInputStyles);
+Input.displayName = 'StyledInput';

--- a/src/link/styled-components.js
+++ b/src/link/styled-components.js
@@ -16,3 +16,5 @@ export const Link = styled('a', ({$theme}) => {
     textDecoration: 'none',
   };
 });
+
+Link.displayName = 'StyledLink';

--- a/src/menu/styled-components.js
+++ b/src/menu/styled-components.js
@@ -31,6 +31,7 @@ export const List = styled('ul', ({$theme}: StyledPropsT) => ({
   boxShadow: $theme.lighting.shadow600,
   overflow: 'auto',
 }));
+List.displayName = 'StyledList';
 
 export const ListItem = styled(
   'li',
@@ -73,6 +74,7 @@ export const ListItem = styled(
     },
   }),
 );
+ListItem.displayName = 'StyledListItem';
 
 export const ListItemProfile = styled('li', ({$theme}: StyledPropsT) => ({
   position: 'relative',
@@ -96,6 +98,7 @@ export const ListItemProfile = styled('li', ({$theme}: StyledPropsT) => ({
     marginBottom: $theme.sizing.scale300,
   },
 }));
+ListItemProfile.displayName = 'StyledListItemProfile';
 
 export const ProfileImgContainer = styled('div', {
   width: '60px',
@@ -104,12 +107,14 @@ export const ProfileImgContainer = styled('div', {
   justifyContent: 'center',
   alignItems: 'center',
 });
+ProfileImgContainer.displayName = 'StyledProfileImgContainer';
 
 export const ProfileImg = styled('img', {
   width: '100%',
   height: '100%',
   borderRadius: '50%',
 });
+ProfileImg.displayName = 'StyledProfileImg';
 
 export const ProfileLabelsContainer = styled('div', ({$theme}) => ({
   marginLeft: $theme.sizing.scale600,
@@ -117,6 +122,7 @@ export const ProfileLabelsContainer = styled('div', ({$theme}) => ({
   display: 'flex',
   flexDirection: 'column',
 }));
+ProfileLabelsContainer.displayName = 'StyledProfileLabelsContainer';
 
 export const ProfileTitle = styled('h6', ({$theme}) => ({
   ...$theme.typography.font450,
@@ -126,6 +132,7 @@ export const ProfileTitle = styled('h6', ({$theme}) => ({
   marginLeft: '0',
   marginRight: '0',
 }));
+ProfileTitle.displayName = 'StyledProfileTitle';
 
 export const ProfileSubtitle = styled('p', ({$theme}) => ({
   ...$theme.typography.font300,
@@ -135,6 +142,7 @@ export const ProfileSubtitle = styled('p', ({$theme}) => ({
   marginLeft: '0',
   marginRight: '0',
 }));
+ProfileSubtitle.displayName = 'StyledProfileSubtitle';
 
 export const ProfileBody = styled('p', ({$theme}) => ({
   ...$theme.typography.font200,
@@ -144,3 +152,4 @@ export const ProfileBody = styled('p', ({$theme}) => ({
   marginLeft: '0',
   marginRight: '0',
 }));
+ProfileBody.displayName = 'StyledProfileBody';

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -14,7 +14,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
     is-portal="true"
     key="portal"
   >
-    <MockStyledComponent
+    <StyledBackdrop
       $animate={true}
       $closeable={true}
       $isOpen={true}
@@ -44,7 +44,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
             styled-component="true"
           />
         </MockStyledComponent>
-        <MockStyledComponent
+        <StyledDialogContainer
           $animate={true}
           $closeable={true}
           $isOpen={true}
@@ -55,7 +55,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
           <div
             styled-component="true"
           >
-            <MockStyledComponent
+            <StyledDialog
               $animate={true}
               $closeable={true}
               $isOpen={true}
@@ -77,7 +77,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                 styled-component="true"
                 tabIndex="-1"
               >
-                <MockStyledComponent
+                <StyledClose
                   $animate={true}
                   $closeable={true}
                   $isOpen={true}
@@ -112,34 +112,34 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                       </svg>
                     </CloseIcon>
                   </button>
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </StyledClose>
+                <ModalHeader>
                   <div
                     styled-component="true"
                   >
                     Hello world
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </ModalHeader>
+                <ModalBody>
                   <div
                     styled-component="true"
                   >
                     Modal Body
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </ModalBody>
+                <ModalFooter>
                   <div
                     styled-component="true"
                   >
                     Footer
                   </div>
-                </MockStyledComponent>
+                </ModalFooter>
               </div>
-            </MockStyledComponent>
+            </StyledDialog>
           </div>
-        </MockStyledComponent>
+        </StyledDialogContainer>
       </div>
-    </MockStyledComponent>
+    </StyledBackdrop>
   </div>
 </Modal>
 `;

--- a/src/modal/styled-components.js
+++ b/src/modal/styled-components.js
@@ -47,6 +47,7 @@ export const Root = styled('div', (props: SharedStylePropsT) => {
     pointerEvents: $isOpen ? 'auto' : 'none',
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const Backdrop = styled('div', (props: SharedStylePropsT) => {
   const {$animate, $isOpen, $isVisible, $theme} = props;
@@ -72,6 +73,7 @@ export const Backdrop = styled('div', (props: SharedStylePropsT) => {
       : null),
   };
 });
+Root.displayName = 'StyledBackdrop';
 
 export const DialogContainer = styled('div', (props: SharedStylePropsT) => {
   return {
@@ -84,6 +86,7 @@ export const DialogContainer = styled('div', (props: SharedStylePropsT) => {
     userSelect: 'none',
   };
 });
+DialogContainer.displayName = 'StyledDialogContainer';
 
 export const Dialog = styled('div', (props: SharedStylePropsT) => {
   const {$animate, $isOpen, $isVisible, $size, $theme} = props;
@@ -118,6 +121,7 @@ export const Dialog = styled('div', (props: SharedStylePropsT) => {
     },
   };
 });
+Dialog.displayName = 'StyledDialog';
 
 export const Close = styled('button', (props: SharedStylePropsT) => {
   const {$theme} = props;
@@ -146,6 +150,7 @@ export const Close = styled('button', (props: SharedStylePropsT) => {
     },
   };
 });
+Close.displayName = 'StyledClose';
 
 export const ModalHeader = styled('div', ({$theme}: StyledComponentPropT) => ({
   ...$theme.typography.font500,
@@ -156,6 +161,7 @@ export const ModalHeader = styled('div', ({$theme}: StyledComponentPropT) => ({
   // Slightly more margin than left side to leave room for close button
   marginRight: $theme.sizing.scale900,
 }));
+ModalHeader.displayName = 'ModalHeader';
 
 export const ModalBody = styled('div', ({$theme}: StyledComponentPropT) => ({
   ...$theme.typography.font300,
@@ -165,6 +171,7 @@ export const ModalBody = styled('div', ({$theme}: StyledComponentPropT) => ({
   marginRight: $theme.sizing.scale800,
   marginBottom: $theme.sizing.scale700,
 }));
+ModalBody.displayName = 'ModalBody';
 
 export const ModalFooter = styled('div', ({$theme}: StyledComponentPropT) => ({
   ...$theme.typography.font300,
@@ -178,3 +185,4 @@ export const ModalFooter = styled('div', ({$theme}: StyledComponentPropT) => ({
   borderTopStyle: 'solid',
   borderTopColor: $theme.colors.mono400,
 }));
+ModalFooter.displayName = 'ModalFooter';

--- a/src/pagination/styled-components.js
+++ b/src/pagination/styled-components.js
@@ -13,18 +13,21 @@ export const Root = styled('div', {
   display: 'flex',
   alignItems: 'center',
 });
+Root.displayName = 'StyledRoot';
 
 export const MaxLabel = styled('span', ({$theme}) => ({
   ...$theme.typography.font300,
   marginLeft: $theme.sizing.scale300,
   marginRight: $theme.sizing.scale600,
 }));
+MaxLabel.displayName = 'StyledMaxLabel';
 
 export const DropdownContainer = styled('div', ({$theme}) => ({
   position: 'relative',
   marginLeft: $theme.sizing.scale600,
   marginRight: $theme.sizing.scale300,
 }));
+DropdownContainer.displayName = 'StyledDropdownContainer';
 
 export const DropdownMenu = styled(StyledList, ({$theme}) => ({
   position: 'absolute',
@@ -35,8 +38,10 @@ export const DropdownMenu = styled(StyledList, ({$theme}) => ({
   left: 0,
   right: 0,
 }));
+DropdownMenu.displayName = 'StyledDropdownMenu';
 
 export const DropdownButton = styled(StyledBaseButton, ({$theme}) => ({
   color: $theme.colors.foreground,
   minWidth: `calc(${$theme.sizing.scale1600} + ${$theme.sizing.scale400})`,
 }));
+DropdownButton.displayName = 'StyledDropdownButton';

--- a/src/popover/styled-components.js
+++ b/src/popover/styled-components.js
@@ -54,6 +54,7 @@ export function getBodyStyles(props: SharedStylePropsT) {
 }
 
 export const Body = styled('div', getBodyStyles);
+Body.displayName = 'StyledBody';
 
 /**
  * Arrow shown between the popover and the anchor element
@@ -73,6 +74,7 @@ export function getArrowStyles(props: SharedStylePropsT) {
 }
 
 export const Arrow = styled('div', getArrowStyles);
+Arrow.displayName = 'StyledArrow';
 
 /**
  * Extra div that holds the popover content. This extra element
@@ -93,6 +95,7 @@ export function getInnerStyles({$theme}: SharedStylePropsT) {
 }
 
 export const Inner = styled('div', getInnerStyles);
+Inner.displayName = 'StyledInner';
 
 /**
  * A drop-in component that provides the recommended padding
@@ -102,3 +105,4 @@ export const Inner = styled('div', getInnerStyles);
 export const Padding = styled('div', {
   padding: '12px',
 });
+Padding.displayName = 'StyledPadding';

--- a/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
+++ b/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
@@ -17,23 +17,23 @@ exports[`Stateless progress bar should render component: Component has correct r
       role="progressbar"
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledBar
         $successValue={100}
         $value={75}
       >
         <div
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledBarProgress
             $successValue={100}
             $value={75}
           >
             <div
               styled-component="true"
             />
-          </MockStyledComponent>
+          </StyledBarProgress>
         </div>
-      </MockStyledComponent>
+      </StyledBar>
     </div>
   </MockStyledComponent>
 </ProgressBar>

--- a/src/progress-bar/styled-components.js
+++ b/src/progress-bar/styled-components.js
@@ -25,6 +25,7 @@ export const Bar = styled('div', props => {
     height: '4px',
   };
 });
+Bar.displayName = 'StyledBar';
 
 export const BarProgress = styled('div', props => {
   const {$theme, $value, $successValue} = props;
@@ -38,6 +39,7 @@ export const BarProgress = styled('div', props => {
     height: '100%',
   };
 });
+BarProgress.displayName = 'StyledBarProgress';
 
 export const Label = styled('div', props => {
   return {
@@ -46,3 +48,4 @@ export const Label = styled('div', props => {
     color: props.$theme.colors.mono700,
   };
 });
+Label.displayName = 'StyledLabel';

--- a/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
@@ -1,143 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NumberedStep applies isActive prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies isCompleted prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={true}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={true}
   >
     <Check
       size={12}
     />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={true}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={true}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies isLast prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies title prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </MockStyledComponent>
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentTitle>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep renders children correctly if isActive is provided 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent>
+    <StyledContentDescription>
       Content
-    </MockStyledComponent>
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentDescription>
+  </StyledContent>
+</StyledNumberStep>
 `;

--- a/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
@@ -1,135 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Step applies isActive prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledInnerIcon />
+  </StyledIcon>
+  <StyledContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies isCompleted prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={true}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContentTail
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={true}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={true}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies isLast prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies title prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContentTail
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </MockStyledComponent>
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentTitle>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step renders children correctly if isActive is provided 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledInnerIcon />
+  </StyledIcon>
+  <StyledContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent>
+    <StyledContentDescription>
       Content
-    </MockStyledComponent>
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentDescription>
+  </StyledContent>
+</StyledStep>
 `;

--- a/src/progress-steps/styled-components.js
+++ b/src/progress-steps/styled-components.js
@@ -25,6 +25,7 @@ export const StyledProgressSteps = styled(
     };
   },
 );
+StyledProgressSteps.displayName = 'StyledProgressSteps';
 
 export const StyledStep = styled('div', ({$theme}: StyledStepPropsT) => {
   return {
@@ -32,6 +33,7 @@ export const StyledStep = styled('div', ({$theme}: StyledStepPropsT) => {
     overflow: 'visible',
   };
 });
+StyledStep.displayName = 'StyledStep';
 
 export const StyledIcon = styled(
   'div',
@@ -74,6 +76,7 @@ export const StyledIcon = styled(
     };
   },
 );
+StyledIcon.displayName = 'StyledIcon';
 
 export const StyledInnerIcon = styled('div', ({$theme}: StyledStepPropsT) => {
   return {
@@ -85,12 +88,14 @@ export const StyledInnerIcon = styled('div', ({$theme}: StyledStepPropsT) => {
     textAlign: 'center',
   };
 });
+StyledInnerIcon.displayName = 'StyledInnerIcon';
 
 export const StyledContent = styled('div', ({$theme}: StyledStepPropsT) => {
   return {
     overflow: 'hidden',
   };
 });
+StyledContent.displayName = 'StyledContent';
 
 export const StyledContentTitle = styled(
   'div',
@@ -109,10 +114,11 @@ export const StyledContentTitle = styled(
     };
   },
 );
+StyledContentTitle.displayName = 'StyledContentTitle';
 
 export const StyledContentTail = styled(
   'div',
-  ({$theme, $isActive, $isCompleted, $disabled}: StyledStepPropsT) => {
+  ({$theme, $isCompleted}: StyledStepPropsT) => {
     let currentColor = $theme.colors.mono400;
 
     if ($isCompleted) {
@@ -138,6 +144,7 @@ export const StyledContentTail = styled(
     };
   },
 );
+StyledContentTail.displayName = 'StyledContentTail';
 
 export const StyledContentDescription = styled(
   'div',
@@ -147,6 +154,7 @@ export const StyledContentDescription = styled(
     };
   },
 );
+StyledContentDescription.displayName = 'StyledContentDescription';
 
 export const StyledNumberStep = styled(
   'div',
@@ -157,6 +165,7 @@ export const StyledNumberStep = styled(
     };
   },
 );
+StyledNumberStep.displayName = 'StyledNumberStep';
 
 export const StyledNumberIcon = styled(
   'div',
@@ -195,6 +204,7 @@ export const StyledNumberIcon = styled(
     };
   },
 );
+StyledNumberIcon.displayName = 'StyledNumberIcon';
 
 export const StyledNumberContentTail = styled(
   'div',
@@ -229,3 +239,4 @@ export const StyledNumberContentTail = styled(
     };
   },
 );
+StyledNumberContentTail.displayName = 'StyledNumberContentTail';

--- a/src/radio/styled-components.js
+++ b/src/radio/styled-components.js
@@ -44,6 +44,7 @@ export const RadioGroupRoot = styled('div', props => {
     cursor: $disabled ? 'not-allowed' : 'pointer',
   };
 });
+RadioGroupRoot.displayName = 'StyledRadioGroupRoot';
 
 export const Root = styled('label', props => {
   const {$disabled, $labelPlacement} = props;
@@ -57,6 +58,7 @@ export const Root = styled('label', props => {
     cursor: $disabled ? 'not-allowed' : 'pointer',
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const RadioMarkInner = styled('div', props => {
   const {$checked, $disabled, $theme, $isFocused, $isError} = props;
@@ -84,6 +86,7 @@ export const RadioMarkInner = styled('div', props => {
     ':active': activeStyle,
   };
 });
+RadioMarkInner.displayName = 'StyledRadioMarkInner';
 
 export const RadioMarkOuter = styled('div', props => {
   const {sizing} = props.$theme;
@@ -103,6 +106,7 @@ export const RadioMarkOuter = styled('div', props => {
     width: sizing.scale700,
   };
 });
+RadioMarkOuter.displayName = 'StyledRadioMarkOuter';
 
 export const Label = styled('div', props => {
   const {
@@ -115,6 +119,7 @@ export const Label = styled('div', props => {
     ...typography.font400,
   };
 });
+Label.displayName = 'StyledLabel';
 
 // tricky style for focus event cause display: none doesn't work
 export const Input = styled('input', {
@@ -124,3 +129,4 @@ export const Input = styled('input', {
   margin: 0,
   padding: 0,
 });
+Input.displayName = 'StyledInput';

--- a/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EmoticonRating RatingItem applies correct props if item is active 1`] = `
-<MockStyledComponent
+<StyledEmoticon
   $index={1}
   $isActive={false}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`EmoticonRating RatingItem applies correct props if item is active 1`] =
 `;
 
 exports[`EmoticonRating RatingItem applies correct props if item is selected 1`] = `
-<MockStyledComponent
+<StyledEmoticon
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StarRating RatingItem applies correct props if item is active 1`] = `
-<MockStyledComponent
+<StyledStar
   $index={1}
   $isActive={true}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`StarRating RatingItem applies correct props if item is active 1`] = `
 `;
 
 exports[`StarRating RatingItem applies correct props if item is selected 1`] = `
-<MockStyledComponent
+<StyledStar
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/styled-components.js
+++ b/src/rating/styled-components.js
@@ -34,6 +34,7 @@ export const StyledRoot = styled('ul', ({$theme}: StyledRootPropsT) => {
     },
   };
 });
+StyledRoot.displayName = 'StyledRoot';
 
 export const StyledStar = styled(
   'li',
@@ -75,6 +76,7 @@ export const StyledStar = styled(
     return styles;
   },
 );
+StyledStar.displayName = 'StyledStar';
 
 export const StyledEmoticon = styled(
   'li',
@@ -121,3 +123,4 @@ export const StyledEmoticon = styled(
     return styles;
   },
 );
+StyledEmoticon.displayName = 'StyledEmoticon';

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -58,7 +58,7 @@ exports[`Select component renders component in search mode and false for multipl
   value={Array []}
   valueKey="id"
 >
-  <MockStyledComponent
+  <StyledRoot
     $clearable={true}
     $disabled={false}
     $error={false}
@@ -76,7 +76,7 @@ exports[`Select component renders component in search mode and false for multipl
     <div
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledControlContainer
         $clearable={true}
         $disabled={false}
         $error={false}
@@ -148,7 +148,7 @@ exports[`Select component renders component in search mode and false for multipl
               title="search"
               viewBox="0 0 24 24"
             >
-              <MockStyledComponent
+              <StyledSearchIcon
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -183,10 +183,10 @@ exports[`Select component renders component in search mode and false for multipl
                     />
                   </g>
                 </svg>
-              </MockStyledComponent>
+              </StyledSearchIcon>
             </Icon>
           </Search>
-          <MockStyledComponent
+          <StyledValueContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -205,7 +205,7 @@ exports[`Select component renders component in search mode and false for multipl
               role="list"
               styled-component="true"
             >
-              <MockStyledComponent
+              <StyledPlaceholder
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -224,8 +224,8 @@ exports[`Select component renders component in search mode and false for multipl
                 >
                   Select...
                 </div>
-              </MockStyledComponent>
-              <MockStyledComponent
+              </StyledPlaceholder>
+              <StyledInputContainer
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -276,7 +276,7 @@ exports[`Select component renders component in search mode and false for multipl
                     role="combobox"
                     value=""
                   >
-                    <MockStyledComponent
+                    <StyledInput
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -323,20 +323,20 @@ exports[`Select component renders component in search mode and false for multipl
                         styled-component="true"
                         value=""
                       />
-                    </MockStyledComponent>
-                    <MockStyledComponent
+                    </StyledInput>
+                    <StyledInputSizer
                       $ref={[Function]}
                     >
                       <div
                         styled-component="true"
                       />
-                    </MockStyledComponent>
+                    </StyledInputSizer>
                   </AutosizeInput>
                 </div>
-              </MockStyledComponent>
+              </StyledInputContainer>
             </span>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledValueContainer>
+          <StyledIconsContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -353,11 +353,11 @@ exports[`Select component renders component in search mode and false for multipl
             <div
               styled-component="true"
             />
-          </MockStyledComponent>
+          </StyledIconsContainer>
         </div>
-      </MockStyledComponent>
+      </StyledControlContainer>
     </div>
-  </MockStyledComponent>
+  </StyledRoot>
 </Select>
 `;
 
@@ -419,7 +419,7 @@ exports[`Select component renders component in search mode and true for multiple
   value={Array []}
   valueKey="id"
 >
-  <MockStyledComponent
+  <StyledRoot
     $clearable={true}
     $disabled={false}
     $error={false}
@@ -437,7 +437,7 @@ exports[`Select component renders component in search mode and true for multiple
     <div
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledControlContainer
         $clearable={true}
         $disabled={false}
         $error={false}
@@ -509,7 +509,7 @@ exports[`Select component renders component in search mode and true for multiple
               title="search"
               viewBox="0 0 24 24"
             >
-              <MockStyledComponent
+              <StyledSearchIcon
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -544,10 +544,10 @@ exports[`Select component renders component in search mode and true for multiple
                     />
                   </g>
                 </svg>
-              </MockStyledComponent>
+              </StyledSearchIcon>
             </Icon>
           </Search>
-          <MockStyledComponent
+          <StyledValueContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -566,7 +566,7 @@ exports[`Select component renders component in search mode and true for multiple
               role="list"
               styled-component="true"
             >
-              <MockStyledComponent
+              <StyledPlaceholder
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -585,8 +585,8 @@ exports[`Select component renders component in search mode and true for multiple
                 >
                   Select...
                 </div>
-              </MockStyledComponent>
-              <MockStyledComponent
+              </StyledPlaceholder>
+              <StyledInputContainer
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -637,7 +637,7 @@ exports[`Select component renders component in search mode and true for multiple
                     role="combobox"
                     value=""
                   >
-                    <MockStyledComponent
+                    <StyledInput
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -684,20 +684,20 @@ exports[`Select component renders component in search mode and true for multiple
                         styled-component="true"
                         value=""
                       />
-                    </MockStyledComponent>
-                    <MockStyledComponent
+                    </StyledInput>
+                    <StyledInputSizer
                       $ref={[Function]}
                     >
                       <div
                         styled-component="true"
                       />
-                    </MockStyledComponent>
+                    </StyledInputSizer>
                   </AutosizeInput>
                 </div>
-              </MockStyledComponent>
+              </StyledInputContainer>
             </span>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledValueContainer>
+          <StyledIconsContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -714,11 +714,11 @@ exports[`Select component renders component in search mode and true for multiple
             <div
               styled-component="true"
             />
-          </MockStyledComponent>
+          </StyledIconsContainer>
         </div>
-      </MockStyledComponent>
+      </StyledControlContainer>
     </div>
-  </MockStyledComponent>
+  </StyledRoot>
 </Select>
 `;
 
@@ -780,7 +780,7 @@ exports[`Select component renders component in select mode and false for multipl
   value={Array []}
   valueKey="id"
 >
-  <MockStyledComponent
+  <StyledRoot
     $clearable={true}
     $disabled={false}
     $error={false}
@@ -798,7 +798,7 @@ exports[`Select component renders component in select mode and false for multipl
     <div
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledControlContainer
         $clearable={true}
         $disabled={false}
         $error={false}
@@ -825,7 +825,7 @@ exports[`Select component renders component in select mode and false for multipl
           onTouchStart={[Function]}
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledValueContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -844,7 +844,7 @@ exports[`Select component renders component in select mode and false for multipl
               role="list"
               styled-component="true"
             >
-              <MockStyledComponent
+              <StyledPlaceholder
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -863,8 +863,8 @@ exports[`Select component renders component in select mode and false for multipl
                 >
                   Select...
                 </div>
-              </MockStyledComponent>
-              <MockStyledComponent
+              </StyledPlaceholder>
+              <StyledInputContainer
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -915,7 +915,7 @@ exports[`Select component renders component in select mode and false for multipl
                     role="combobox"
                     value=""
                   >
-                    <MockStyledComponent
+                    <StyledInput
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -962,20 +962,20 @@ exports[`Select component renders component in select mode and false for multipl
                         styled-component="true"
                         value=""
                       />
-                    </MockStyledComponent>
-                    <MockStyledComponent
+                    </StyledInput>
+                    <StyledInputSizer
                       $ref={[Function]}
                     >
                       <div
                         styled-component="true"
                       />
-                    </MockStyledComponent>
+                    </StyledInputSizer>
                   </AutosizeInput>
                 </div>
-              </MockStyledComponent>
+              </StyledInputContainer>
             </span>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledValueContainer>
+          <StyledIconsContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -1037,7 +1037,7 @@ exports[`Select component renders component in select mode and false for multipl
                   title="open"
                   viewBox="0 0 24 24"
                 >
-                  <MockStyledComponent
+                  <StyledSelectArrow
                     $clearable={true}
                     $disabled={false}
                     $error={false}
@@ -1065,15 +1065,15 @@ exports[`Select component renders component in select mode and false for multipl
                         d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                       />
                     </svg>
-                  </MockStyledComponent>
+                  </StyledSelectArrow>
                 </Icon>
               </TriangleDown>
             </div>
-          </MockStyledComponent>
+          </StyledIconsContainer>
         </div>
-      </MockStyledComponent>
+      </StyledControlContainer>
     </div>
-  </MockStyledComponent>
+  </StyledRoot>
 </Select>
 `;
 
@@ -1135,7 +1135,7 @@ exports[`Select component renders component in select mode and true for multiple
   value={Array []}
   valueKey="id"
 >
-  <MockStyledComponent
+  <StyledRoot
     $clearable={true}
     $disabled={false}
     $error={false}
@@ -1153,7 +1153,7 @@ exports[`Select component renders component in select mode and true for multiple
     <div
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledControlContainer
         $clearable={true}
         $disabled={false}
         $error={false}
@@ -1180,7 +1180,7 @@ exports[`Select component renders component in select mode and true for multiple
           onTouchStart={[Function]}
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledValueContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -1199,7 +1199,7 @@ exports[`Select component renders component in select mode and true for multiple
               role="list"
               styled-component="true"
             >
-              <MockStyledComponent
+              <StyledPlaceholder
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -1218,8 +1218,8 @@ exports[`Select component renders component in select mode and true for multiple
                 >
                   Select...
                 </div>
-              </MockStyledComponent>
-              <MockStyledComponent
+              </StyledPlaceholder>
+              <StyledInputContainer
                 $clearable={true}
                 $disabled={false}
                 $error={false}
@@ -1270,7 +1270,7 @@ exports[`Select component renders component in select mode and true for multiple
                     role="combobox"
                     value=""
                   >
-                    <MockStyledComponent
+                    <StyledInput
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -1317,20 +1317,20 @@ exports[`Select component renders component in select mode and true for multiple
                         styled-component="true"
                         value=""
                       />
-                    </MockStyledComponent>
-                    <MockStyledComponent
+                    </StyledInput>
+                    <StyledInputSizer
                       $ref={[Function]}
                     >
                       <div
                         styled-component="true"
                       />
-                    </MockStyledComponent>
+                    </StyledInputSizer>
                   </AutosizeInput>
                 </div>
-              </MockStyledComponent>
+              </StyledInputContainer>
             </span>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledValueContainer>
+          <StyledIconsContainer
             $clearable={true}
             $disabled={false}
             $error={false}
@@ -1392,7 +1392,7 @@ exports[`Select component renders component in select mode and true for multiple
                   title="open"
                   viewBox="0 0 24 24"
                 >
-                  <MockStyledComponent
+                  <StyledSelectArrow
                     $clearable={true}
                     $disabled={false}
                     $error={false}
@@ -1420,14 +1420,14 @@ exports[`Select component renders component in select mode and true for multiple
                         d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                       />
                     </svg>
-                  </MockStyledComponent>
+                  </StyledSelectArrow>
                 </Icon>
               </TriangleDown>
             </div>
-          </MockStyledComponent>
+          </StyledIconsContainer>
         </div>
-      </MockStyledComponent>
+      </StyledControlContainer>
     </div>
-  </MockStyledComponent>
+  </StyledRoot>
 </Select>
 `;

--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -76,6 +76,7 @@ export const StyledDropdownContainer = styled('div', props => {
     paddingRight: sizing.scale300,
   };
 });
+StyledDropdownContainer.displayName = 'StyledDropdownContainer';
 
 export const StyledOptionContent = styled('div', props => {
   const {$isHighlighted, $selected, $disabled, $theme} = props;
@@ -92,6 +93,7 @@ export const StyledOptionContent = styled('div', props => {
     fontWeight: $selected ? 'bold' : 'normal',
   };
 });
+StyledOptionContent.displayName = 'StyledOptionContent';
 
 export const StyledRoot = styled('div', (props: SharedStylePropsT) => {
   const {
@@ -104,6 +106,7 @@ export const StyledRoot = styled('div', (props: SharedStylePropsT) => {
     position: 'relative',
   };
 });
+StyledRoot.displayName = 'StyledRoot';
 
 export const StyledControlContainer = styled(
   'div',
@@ -161,6 +164,7 @@ export const StyledControlContainer = styled(
     };
   },
 );
+StyledControlContainer.displayName = 'StyledControlContainer';
 
 export const StyledValueContainer = styled(
   'span',
@@ -180,6 +184,7 @@ export const StyledValueContainer = styled(
     };
   },
 );
+StyledValueContainer.displayName = 'StyledValueContainer';
 
 export const StyledPlaceholder = styled('div', (props: SharedStylePropsT) => {
   const {
@@ -200,6 +205,7 @@ export const StyledPlaceholder = styled('div', (props: SharedStylePropsT) => {
     ...getControlPadding(props, true),
   };
 });
+StyledPlaceholder.displayName = 'StyledPlaceholder';
 
 export const StyledSingleValue = styled('div', (props: SharedStylePropsT) => {
   const {
@@ -220,6 +226,7 @@ export const StyledSingleValue = styled('div', (props: SharedStylePropsT) => {
     ...getControlPadding(props),
   };
 });
+StyledSingleValue.displayName = 'StyledSingleValue';
 
 export const StyledInputContainer = styled('div', props => {
   const {
@@ -249,6 +256,7 @@ export const StyledInputContainer = styled('div', props => {
     height: !$searchable ? font.lineHeight : 'auto',
   };
 });
+StyledInputContainer.displayName = 'StyledInputContainer';
 
 export const StyledInput = styled(
   'input',
@@ -281,6 +289,7 @@ export const StyledInput = styled(
     };
   },
 );
+StyledInput.displayName = 'StyledInput';
 
 export const StyledInputSizer = styled('div', {
   position: 'absolute',
@@ -291,6 +300,7 @@ export const StyledInputSizer = styled('div', {
   overflow: 'scroll',
   whiteSpace: 'pre',
 });
+StyledInputSizer.displayName = 'StyledInputSizer';
 
 export const StyledIconsContainer = styled('div', ({$theme: {sizing}}) => {
   return {
@@ -303,6 +313,7 @@ export const StyledIconsContainer = styled('div', ({$theme: {sizing}}) => {
     paddingRight: sizing.scale500,
   };
 });
+StyledIconsContainer.displayName = 'StyledIconsContainer';
 
 export const StyledSelectArrow = styled('svg', (props: SharedStylePropsT) => {
   const {$theme, $disabled} = props;
@@ -313,6 +324,7 @@ export const StyledSelectArrow = styled('svg', (props: SharedStylePropsT) => {
     cursor: $disabled ? 'not-allowed' : 'pointer',
   };
 });
+StyledSelectArrow.displayName = 'StyledSelectArrow';
 
 export const StyledClearIcon = styled('svg', (props: SharedStylePropsT) => {
   const {$theme} = props;
@@ -323,6 +335,7 @@ export const StyledClearIcon = styled('svg', (props: SharedStylePropsT) => {
     cursor: 'pointer',
   };
 });
+StyledClearIcon.displayName = 'StyledClearIcon';
 
 export const getLoadingIconStyles = (props: SharedStylePropsT) => {
   const {$theme} = props;
@@ -347,3 +360,4 @@ export const StyledSearchIcon = styled('svg', (props: SharedStylePropsT) => {
     zIndex: 1,
   };
 });
+StyledSearchIcon.displayName = 'StyledSearchIcon';

--- a/src/slider/__tests__/__snapshots__/slider.test.js.snap
+++ b/src/slider/__tests__/__snapshots__/slider.test.js.snap
@@ -20,7 +20,7 @@ exports[`Stateless slider should render slider component: Component has correctl
     ]
   }
 >
-  <MockStyledComponent
+  <StyledRoot
     $currentThumb={-1}
     $isRange={false}
     $max={100}
@@ -42,7 +42,7 @@ exports[`Stateless slider should render slider component: Component has correctl
       onClick={[Function]}
       styled-component="true"
     >
-      <MockStyledComponent
+      <StyledAxis
         $currentThumb={-1}
         $isRange={false}
         $max={100}
@@ -62,7 +62,7 @@ exports[`Stateless slider should render slider component: Component has correctl
         <div
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledAxisRange
             $currentThumb={-1}
             $index={0}
             $isRange={false}
@@ -83,8 +83,8 @@ exports[`Stateless slider should render slider component: Component has correctl
             <div
               styled-component="true"
             />
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledAxisRange>
+          <StyledThumb
             $currentThumb={-1}
             $index={0}
             $isRange={false}
@@ -113,10 +113,10 @@ exports[`Stateless slider should render slider component: Component has correctl
               onMouseDown={[Function]}
               styled-component="true"
             />
-          </MockStyledComponent>
+          </StyledThumb>
         </div>
-      </MockStyledComponent>
-      <MockStyledComponent
+      </StyledAxis>
+      <StyledTickBar
         $currentThumb={-1}
         $isRange={false}
         $max={100}
@@ -136,7 +136,7 @@ exports[`Stateless slider should render slider component: Component has correctl
         <div
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledTick
             $currentThumb={-1}
             $index={0}
             $isRange={false}
@@ -160,8 +160,8 @@ exports[`Stateless slider should render slider component: Component has correctl
             >
               0
             </div>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </StyledTick>
+          <StyledTick
             $currentThumb={-1}
             $index={1}
             $isRange={false}
@@ -185,10 +185,10 @@ exports[`Stateless slider should render slider component: Component has correctl
             >
               100
             </div>
-          </MockStyledComponent>
+          </StyledTick>
         </div>
-      </MockStyledComponent>
+      </StyledTickBar>
     </div>
-  </MockStyledComponent>
+  </StyledRoot>
 </Slider>
 `;

--- a/src/slider/styled-components.js
+++ b/src/slider/styled-components.js
@@ -14,6 +14,7 @@ export const Root = styled('div', props => {
     position: 'relative',
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const Axis = styled('div', props => {
   const {$theme} = props;
@@ -29,6 +30,7 @@ export const Axis = styled('div', props => {
     height: sizing.scale100,
   };
 });
+Axis.displayName = 'StyledAxis';
 
 export const AxisRange = styled('div', props => {
   const {$max, $min, $index, $isRange, $value, $theme} = props;
@@ -59,10 +61,12 @@ export const AxisRange = styled('div', props => {
     width: width,
   };
 });
+AxisRange.displayName = 'StyledAxisRange';
 
 export const Tick = styled('div', props => {
   return {};
 });
+Tick.displayName = 'StyledTick';
 
 export const TickBar = styled('div', props => {
   const {$theme} = props;
@@ -77,6 +81,7 @@ export const TickBar = styled('div', props => {
     marginLeft: sizing.scale400,
   };
 });
+TickBar.displayName = 'StyledTickBar';
 
 export const Thumb = styled('div', props => {
   const {
@@ -127,6 +132,7 @@ export const Thumb = styled('div', props => {
     },
   };
 });
+Thumb.displayName = 'StyledThumb';
 
 function getThumbColor(props) {
   const {

--- a/src/spinner/styled-components.js
+++ b/src/spinner/styled-components.js
@@ -32,3 +32,4 @@ export const Svg = styled('svg', props => {
     animationTimingFunction: 'linear',
   };
 });
+Svg.displayName = 'StyledSvg';

--- a/src/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -9,7 +9,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
   onActionClick={[MockFunction]}
   overrides={Object {}}
 >
-  <MockStyledComponent
+  <StyledRoot
     $disabled={false}
     $isFocused={false}
     $isHovered={false}
@@ -19,7 +19,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
       styled-component="true"
     >
       Some tag
-      <MockStyledComponent
+      <StyledAction
         $disabled={false}
         $isFocused={false}
         $isHovered={false}
@@ -30,7 +30,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
           onClick={[Function]}
           styled-component="true"
         >
-          <MockStyledComponent
+          <StyledActionIcon
             fill="none"
             height="8"
             viewBox="0 0 8 8"
@@ -52,10 +52,10 @@ exports[`Stateless tag should render component: Component has correct render 1`]
                 fillRule="evenodd"
               />
             </svg>
-          </MockStyledComponent>
+          </StyledActionIcon>
         </span>
-      </MockStyledComponent>
+      </StyledAction>
     </span>
-  </MockStyledComponent>
+  </StyledRoot>
 </Tag>
 `;

--- a/src/tag/styled-components.js
+++ b/src/tag/styled-components.js
@@ -56,10 +56,12 @@ export const Action = styled('span', props => {
     },
   };
 });
+Action.displayName = 'StyledAction';
 
 export const ActionIcon = styled('svg', () => {
   return {};
 });
+ActionIcon.displayName = 'StyledActionIcon';
 
 export const Root = styled('span', props => {
   const {$color, $disabled, $kind, $theme} = props;
@@ -97,3 +99,4 @@ export const Root = styled('span', props => {
     },
   };
 });
+Root.displayName = 'StyledRoot';

--- a/src/template-component/styled-components.js
+++ b/src/template-component/styled-components.js
@@ -18,3 +18,4 @@ export const Root = styled('div', (props: SharedStylePropsT) => {
     cursor: 'pointer',
   };
 });
+Root.displayName = 'StyledRoot';

--- a/src/textarea/styled-components.js
+++ b/src/textarea/styled-components.js
@@ -12,6 +12,7 @@ import {
 } from '../input/styled-components';
 
 export const TextareaContainer = styled('div', props => {});
+TextareaContainer.displayName = 'StyledTextareaContainer';
 
 export const Textarea = styled('textarea', props => {
   return {
@@ -19,3 +20,4 @@ export const Textarea = styled('textarea', props => {
     ...getInputContainerStyles(props),
   };
 });
+Textarea.displayName = 'StyledTextarea';

--- a/src/toast/styled-components.js
+++ b/src/toast/styled-components.js
@@ -103,6 +103,7 @@ export const Root = styled('div', (props: ToasterSharedStylePropsT) => {
     ...getPlacement($placement),
   };
 });
+Root.displayName = 'StyledRoot';
 
 export const Body = styled('div', (props: SharedStylePropsT) => {
   const {$isVisible, $kind, $type, $theme} = props;
@@ -131,6 +132,7 @@ export const Body = styled('div', (props: SharedStylePropsT) => {
     transitionTimingFunction: $theme.animation.easeInOutCurve,
   };
 });
+Body.displayName = 'StyledBody';
 
 /**
  * DeleteAlt icon overrides
@@ -142,3 +144,4 @@ export const CloseIconSvg = styled('svg', props => {
     float: 'right',
   };
 });
+CloseIconSvg.displayName = 'StyledCloseIconSvg';

--- a/src/tooltip/styled-components.js
+++ b/src/tooltip/styled-components.js
@@ -35,6 +35,7 @@ export const Body = styled('div', props => ({
   transitionProperty: 'opacity',
   transform: getEndPosition(props.$popoverOffset),
 }));
+Body.displayName = 'StyledBody';
 
 export const Inner = styled('div', props => ({
   ...getInnerStyles(props),
@@ -47,8 +48,10 @@ export const Inner = styled('div', props => ({
   ...props.$theme.typography.font250,
   color: props.$theme.colors.background,
 }));
+Inner.displayName = 'StyledInner';
 
 export const Arrow = styled('div', props => ({
   ...getArrowStyles(props),
   backgroundColor: props.$theme.tooltip.backgroundColor,
 }));
+Arrow.displayName = 'StyledArrow';


### PR DESCRIPTION
after merging this, both the storybook source viewer and the chrome react devtools will show the real name of the component, instead of names like `Styled(div)`