### PR TITLE
chore: remove styletron-standard peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@ Add `baseui` and it's peer dependencies to your project:
 
 ```bash
 # using yarn
-yarn add baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
+yarn add baseui styletron-react styletron-react-core styletron-engine-atomic
 
 # using npm
-npm install baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
+npm install baseui styletron-react styletron-react-core styletron-engine-atomic
 ```
 
 ```javascript

--- a/package.json
+++ b/package.json
@@ -133,8 +133,7 @@
     "react": ">= 16.4.0 < 17",
     "react-dom": ">= 16.4.0 < 17",
     "styletron-react": "^4.3.6",
-    "styletron-react-core": "^1.3.3",
-    "styletron-standard": "^1.0.7"
+    "styletron-react-core": "^1.3.3"
   },
   "engines": {
     "node": ">=8.11.0",


### PR DESCRIPTION

#### Fixed Issues?

N/A

#### Patch: Bug Fix?

Yes

#### Major: Breaking Change?

No

#### Minor: New Feature?

No

#### Tests Added + Pass?

No code changes

#### Documentation PR Link

README updated

#### Any Dependency Changes?

Only for consumers (removed peer dependency)

#### License

MIT

styletron-standard is a utility package that developers using BaseUI should never interact with directly. There's no reason this should be a peer dependency so it can be removed.