### PR TITLE
fix(popover): fix onOpen/onClose callbacks

### DIFF
--- a/src/popover/__tests__/stateful-container.test.js
+++ b/src/popover/__tests__/stateful-container.test.js
@@ -233,6 +233,29 @@ describe('StatefulPopoverContainer', () => {
     expect(component).toHaveState('isOpen', true);
   });
 
+  test('onOpen/onClose callbacks', () => {
+    const props = {
+      onOpen: jest.fn(),
+      onClose: jest.fn(),
+    };
+    const children = jest.fn();
+
+    const component = shallow(
+      <StatefulContainer {...props}>{children}</StatefulContainer>,
+    );
+
+    component.instance().onMouseEnter();
+    expect(props.onOpen).toHaveBeenCalledTimes(1);
+    expect(props.onClose).toHaveBeenCalledTimes(0);
+
+    props.onOpen.mockClear();
+    props.onClose.mockClear();
+
+    component.instance().onMouseLeave();
+    expect(props.onOpen).toHaveBeenCalledTimes(0);
+    expect(props.onClose).toHaveBeenCalledTimes(1);
+  });
+
   test('null stateReducer', () => {
     const props = {
       content: jest.fn(),

--- a/src/popover/stateful-container.js
+++ b/src/popover/stateful-container.js
@@ -74,12 +74,18 @@ class StatefulContainer extends React.Component<
     this.internalSetState(STATE_CHANGE_TYPE.open, {
       isOpen: true,
     });
+    if (this.props.onOpen) {
+      this.props.onOpen();
+    }
   }
 
   close() {
     this.internalSetState(STATE_CHANGE_TYPE.close, {
       isOpen: false,
     });
+    if (this.props.onClose) {
+      this.props.onClose();
+    }
   }
 
   internalSetState(type: StateChangeTypeT, changes: StateT) {


### PR DESCRIPTION
Correctly wires up the `onOpen` `onClose` callbacks for StatefulPopover that exist in the docs but not in the implementation.

#### Patch: Bug Fix?

Yes

#### Major: Breaking Change?

No

#### Minor: New Feature?

No

#### Tests Added + Pass?

Yes
