### PR TITLE
Change default type ramp to be consistent with Uber move theme

### DIFF
--- a/src/input/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/input/__tests__/__snapshots__/styled-components.test.js.snap
@@ -239,7 +239,7 @@ Object {
   "boxSizing": "border-box",
   "color": "#B3B3B3",
   "display": "flex",
-  "fontFamily": "\\"Helvetica Neue\\", arial, sans-serif",
+  "fontFamily": "system-ui, \\"Helvetica Neue\\", arial, sans-serif",
   "fontSize": "12px",
   "fontWeight": "normal",
   "lineHeight": "20px",

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -222,25 +222,25 @@ export default function createTheme(
         fontFamily: primitives.primaryFontFamily,
         fontSize: '14px',
         fontWeight: 'normal',
-        lineHeight: '24px',
+        lineHeight: '20px',
       },
       font350: {
         fontFamily: primitives.primaryFontFamily,
         fontSize: '14px',
         fontWeight: 'bold',
-        lineHeight: '24px',
+        lineHeight: '20px',
       },
       font400: {
         fontFamily: primitives.primaryFontFamily,
         fontSize: '16px',
         fontWeight: 'normal',
-        lineHeight: '28px',
+        lineHeight: '24px',
       },
       font450: {
         fontFamily: primitives.primaryFontFamily,
         fontSize: '16px',
         fontWeight: 'bold',
-        lineHeight: '28px',
+        lineHeight: '24px',
       },
       font500: {
         fontFamily: primitives.primaryFontFamily,
@@ -256,27 +256,33 @@ export default function createTheme(
       },
       font700: {
         fontFamily: primitives.primaryFontFamily,
-        fontSize: '28px',
-        fontWeight: 'bold',
-        lineHeight: '40px',
-      },
-      font800: {
-        fontFamily: primitives.primaryFontFamily,
         fontSize: '32px',
         fontWeight: 'bold',
         lineHeight: '48px',
       },
-      font900: {
+      font800: {
         fontFamily: primitives.primaryFontFamily,
         fontSize: '40px',
         fontWeight: 'bold',
         lineHeight: '56px',
       },
+      font900: {
+        fontFamily: primitives.primaryFontFamily,
+        fontSize: '52px',
+        fontWeight: 'bold',
+        lineHeight: '68px',
+      },
       font1000: {
         fontFamily: primitives.primaryFontFamily,
-        fontSize: '56px',
+        fontSize: '72px',
         fontWeight: 'normal',
-        lineHeight: '80px',
+        lineHeight: '96px',
+      },
+      font1100: {
+        fontFamily: primitives.primaryFontFamily,
+        fontSize: '96px',
+        fontWeight: 'normal',
+        lineHeight: '116px',
       },
     },
     sizing: {

--- a/src/themes/light-theme-primitives.js
+++ b/src/themes/light-theme-primitives.js
@@ -59,5 +59,5 @@ export const primitives: PrimitivesT = {
   rating200: '#FFE1A5',
   rating400: '#FFC043',
 
-  primaryFontFamily: '"Helvetica Neue", arial, sans-serif',
+  primaryFontFamily: 'system-ui, "Helvetica Neue", arial, sans-serif',
 };


### PR DESCRIPTION
Hi all!

There's a few small PRs I want to open to help sync type styles with what designers currently use. The first step is to get both the internal and external type ramps consistent with each other.

This way we can tweak type styles without any negative side effects to the OS version of baseui and vice versa. In addition, fixes #226 so the metrics of the type we use match up better.

I suppose this is technically a breaking change...but I'd rather rip the bandaid off sooner so we can keep things in sync.

#### Fixed Issues?

#226 

#### License

MIT
