### PR TITLE
fix: organize unstable components in storybook

### DIFF
--- a/.storybook-base/loadStories.js
+++ b/.storybook-base/loadStories.js
@@ -1,0 +1,27 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// automatically import all files ending in *.stories.js
+const req = require.context(
+  '../src',
+  true,
+  /^((?!template-component\/).)*.stories.js$/,
+);
+
+function isUnstable(filename) {
+  const unstableComponents = ['file-uploader'];
+  return unstableComponents.some(c => filename.includes(c));
+}
+
+export default function loadStories() {
+  require('../docs/pages/pages.js');
+
+  const stable = req.keys().filter(c => !isUnstable(c));
+  const unstable = req.keys().filter(isUnstable);
+
+  stable.concat(unstable).forEach(filename => req(filename));
+}

--- a/.storybook-dark/config.js
+++ b/.storybook-dark/config.js
@@ -2,13 +2,15 @@ import React from 'react';
 import {configure, addDecorator} from '@storybook/react';
 import {themes} from '@storybook/components';
 import {withOptions, setOptions} from '@storybook/addon-options';
-import {Provider as StyletronProvider} from 'styletron-react';
-import {Client as Styletron} from 'styletron-engine-atomic';
-import {ThemeProvider} from '../src/styles';
-import {DarkTheme} from '../src/themes';
 import {withInfo} from '@storybook/addon-info';
 import {checkA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
+import {Provider as StyletronProvider} from 'styletron-react';
+import {Client as Styletron} from 'styletron-engine-atomic';
+
+import loadStories from '../.storybook-base/loadStories.js';
+import {ThemeProvider} from '../src/styles';
+import {DarkTheme} from '../src/themes';
 
 withOptions({
   name: 'baseui',
@@ -30,17 +32,6 @@ setOptions({
 });
 
 const engine = new Styletron();
-
-// automatically import all files ending in *.stories.js
-const req = require.context(
-  '../src',
-  true,
-  /^((?!template-component\/).)*.stories.js$/,
-);
-function loadStories() {
-  require('../docs/pages/pages.js');
-  req.keys().forEach(filename => req(filename));
-}
 
 // this should be first decorator to avoid extra code to be parsed here
 addDecorator(withInfo);

--- a/.storybook-move/config.js
+++ b/.storybook-move/config.js
@@ -2,13 +2,15 @@ import React from 'react';
 import {configure, addDecorator} from '@storybook/react';
 import {themes} from '@storybook/components';
 import {withOptions, setOptions} from '@storybook/addon-options';
-import {Provider as StyletronProvider} from 'styletron-react';
-import {Client as Styletron} from 'styletron-engine-atomic';
-import {ThemeProvider} from '../src/styles';
-import {LightThemeMove} from '../src/themes';
 import {withInfo} from '@storybook/addon-info';
 import {checkA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
+import {Provider as StyletronProvider} from 'styletron-react';
+import {Client as Styletron} from 'styletron-engine-atomic';
+
+import loadStories from '../.storybook-base/loadStories.js';
+import {ThemeProvider} from '../src/styles';
+import {LightThemeMove} from '../src/themes';
 
 withOptions({
   name: 'baseui',
@@ -26,17 +28,6 @@ setOptions({
 });
 
 const engine = new Styletron();
-
-// automatically import all files ending in *.stories.js
-const req = require.context(
-  '../src',
-  true,
-  /^((?!template-component\/).)*.stories.js$/,
-);
-function loadStories() {
-  require('../docs/pages/pages.js');
-  req.keys().forEach(filename => req(filename));
-}
 
 // this should be first decorator to avoid extra code to be parsed here
 addDecorator(withInfo);

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -2,13 +2,15 @@ import React from 'react';
 import {configure, addDecorator} from '@storybook/react';
 import {themes} from '@storybook/components';
 import {withOptions, setOptions} from '@storybook/addon-options';
-import {Provider as StyletronProvider} from 'styletron-react';
-import {Client as Styletron} from 'styletron-engine-atomic';
-import {ThemeProvider} from '../src/styles';
-import {LightTheme} from '../src/themes';
 import {withInfo} from '@storybook/addon-info';
 import {checkA11y} from '@storybook/addon-a11y';
 import {withKnobs} from '@storybook/addon-knobs';
+import {Provider as StyletronProvider} from 'styletron-react';
+import {Client as Styletron} from 'styletron-engine-atomic';
+
+import loadStories from '../.storybook-base/loadStories.js';
+import {ThemeProvider} from '../src/styles';
+import {LightTheme} from '../src/themes';
 
 withOptions({
   name: 'baseui',
@@ -26,17 +28,6 @@ setOptions({
 });
 
 const engine = new Styletron();
-
-// automatically import all files ending in *.stories.js
-const req = require.context(
-  '../src',
-  true,
-  /^((?!template-component\/).)*.stories.js$/,
-);
-function loadStories() {
-  require('../docs/pages/pages.js');
-  req.keys().forEach(filename => req(filename));
-}
 
 // this should be first decorator to avoid extra code to be parsed here
 addDecorator(withInfo);

--- a/src/file-uploader/stories.js
+++ b/src/file-uploader/stories.js
@@ -14,7 +14,7 @@ import readme from './README.md';
 import examples from './examples.js';
 
 Object.entries(examples).forEach(([description, example]) =>
-  storiesOf('File Uploader', module)
+  storiesOf('Unstable_FileUploader', module)
     .addDecorator(withReadme(readme))
     // $FlowFixMe
     .add(description, example),


### PR DESCRIPTION
updates the storybook site to sort 'unstable' components to the end. 