### PR TITLE
fix(header-navigation): optionals

### DIFF
--- a/src/header-navigation/styled-components.js
+++ b/src/header-navigation/styled-components.js
@@ -40,8 +40,8 @@ export const NavigationItem = styled('div', props => {
 NavigationItem.displayName = 'StyledNavigationItem';
 
 export const NavigationList: React.ComponentType<{
-  align: string,
-  children: React$Node,
+  align?: string,
+  children?: React.Node,
 }> = (asPrimaryExport(
   styled('div', props => {
     const {$align, $theme} = props;

--- a/src/header-navigation/styled-components.js
+++ b/src/header-navigation/styled-components.js
@@ -5,6 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+import * as React from 'react';
 import {styled, asPrimaryExport} from '../styles/index.js';
 import {ALIGN} from './index.js';
 


### PR DESCRIPTION
While trying to use this component, flow was complaining about undefined `React`. Also `React$Node` is a typo + both props should be optional?