### PR TITLE
feat(select): scroll to the selected option

### DIFF
--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -43,6 +43,13 @@ export default class MenuStatefulContainer extends React.Component<
     if (__BROWSER__) {
       // TODO(#185): perhaps only bind event listener on focus
       document.addEventListener('keydown', this.onKeyDown);
+      this.state.highlightedIndex > -1 &&
+        scrollItemIntoView({
+          node: this.refList[this.state.highlightedIndex],
+          parentNode: this.rootRef,
+          isFirst: this.state.highlightedIndex === 0,
+          isLast: this.state.highlightedIndex === this.props.items.length - 1,
+        });
     }
   }
 

--- a/src/menu/utils.js
+++ b/src/menu/utils.js
@@ -46,6 +46,7 @@ export function scrollItemIntoView({
 }) {
   const nodeDOM = node.current;
   const parentNodeDOM = parentNode.current;
+  if (!nodeDOM) return;
   const nodeRect = nodeDOM.getBoundingClientRect();
   const parentNodeRect = parentNodeDOM.getBoundingClientRect();
   // while scrolling down, if element is below view

--- a/src/select/dropdown.js
+++ b/src/select/dropdown.js
@@ -84,6 +84,7 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
       onItemSelect,
       options = [],
       overrides = {},
+      value,
       size,
     } = this.props;
     const [DropdownContainer, dropdownContainerProps] = getOverrides(
@@ -96,6 +97,12 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
           onItemSelect={onItemSelect}
           items={options}
           size={size}
+          initialState={{
+            highlightedIndex:
+              Array.isArray(value) && value.length === 1
+                ? options.findIndex(opt => opt.id === value[0].id)
+                : -1,
+          }}
           overrides={mergeOverrides(
             {
               List: {


### PR DESCRIPTION
Resolves #658 

When you select an item and re-open the select you should be scrolled to it.

**Before**
![before](https://user-images.githubusercontent.com/1387913/50125013-e1f7d980-021b-11e9-9613-4d7c5596f92d.gif)

**After**
![after](https://user-images.githubusercontent.com/1387913/50125018-e58b6080-021b-11e9-9cb7-f2f3449d0ac8.gif)