### PR TITLE
fix(header-navigation): use normal cursor

### DIFF
--- a/src/header-navigation/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/header-navigation/__tests__/__snapshots__/styled-components.test.js.snap
@@ -28,7 +28,6 @@ Array [
 exports[`Header Navigation styled components StyledRoot Root: StyledRoot has correct styles 1`] = `
 Object {
   "borderBottom": "1px solid $theme.colors.border",
-  "cursor": "pointer",
   "display": "flex",
   "fontFamily": "$theme.typography.font400.fontFamily",
   "fontSize": "$theme.typography.font400.fontSize",

--- a/src/header-navigation/styled-components.js
+++ b/src/header-navigation/styled-components.js
@@ -18,7 +18,6 @@ export const Root = styled('nav', props => {
   } = $theme;
   return {
     ...font400,
-    cursor: 'pointer',
     display: 'flex',
     paddingBottom: scale500,
     paddingTop: scale500,


### PR DESCRIPTION
#### Patch: Bug Fix?

Yes

#### Description

For some reason the root header navigation element has `cursor: pointer`. This is unnecessary and misleading, and the interactive elements _within_ a header should be the ones controlling cursor behavior.
