### PR TITLE
fix(build): use the public folder

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -6,3 +6,4 @@ coverage
 docs
 webpack.e2e.config.js
 documentation-site/.next
+public

--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,4 @@ vrt/latest
 vrt/diff
 .cache
 documentation-site/.next
-beta
+public

--- a/documentation-site/next.config.js
+++ b/documentation-site/next.config.js
@@ -10,9 +10,12 @@ LICENSE file in the root directory of this source tree.
 
 const {resolve} = require('path');
 
+const isProd = process.env.BUILD_ENV === 'production';
+
 module.exports = {
   webpack: (config, {buildId, dev, isServer, defaultLoaders}) => {
     config.resolve.alias.baseui = resolve(__dirname, '../dist');
     return config;
   },
+  assetPrefix: isProd ? '/beta' : '',
 };

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build]
+  publish = "public/"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "storybook": "start-storybook -p 6006",
     "storybook:move": "start-storybook -c .storybook-move -p 6006",
     "storybook:dark": "start-storybook -c .storybook-dark -p 6006",
-    "build-storybook": "build-storybook -o docs && build-storybook -c .storybook-move -o docs/move && build-storybook -c .storybook-dark -o docs/dark",
+    "build-storybook": "build-storybook -o public && build-storybook -c .storybook-move -o public/move && build-storybook -c .storybook-dark -o public/dark",
     "storybook:screener": "screener-storybook --conf screener.config.js",
     "storybook:screener:ngrok": "node ./node_modules/screener-ngrok/postinstall.js",
     "storybook:screener:ci": "yarn storybook:screener:ngrok && yarn storybook:screener",
@@ -39,7 +39,7 @@
     "prepublish": "npm run build",
     "icon:generate": "./src/icon/build-icons.js",
     "documentation:dev": "yarn build:es2015 && next documentation-site",
-    "documentation:build": "yarn build:es2015 && next build documentation-site && next export documentation-site -o beta"
+    "documentation:build": "yarn build:es2015 && next build documentation-site && next export documentation-site -o public/beta"
   },
   "devDependencies": {
     "@babel/cli": "^7.0.0",


### PR DESCRIPTION
we use the docs folder to keep source files, but also as an output folder for generate static sites - this PR introduces a new folder that's exclusively used for building static sites

once merged, I'll update the netlify config