### PR TITLE
Spelling mistake in example

### DIFF
--- a/src/header-navigation/examples-list.js
+++ b/src/header-navigation/examples-list.js
@@ -13,5 +13,5 @@ module.exports = {
   HEADER_NAVIGATION_WITH_OVERRIDES: 'With changed styles',
   HEADER_NAVIGATION_DIFFERENT_ALIGNMENTS: 'With alignments',
   HEADER_NAVIGATION_SEARCH_BAR: 'With search bar',
-  HEADER_NAVIGATION_STYLED_NAV_LIST: 'With different styled Navigstion List',
+  HEADER_NAVIGATION_STYLED_NAV_LIST: 'With different styled Navigation List',
 };


### PR DESCRIPTION
Caught a minor spelling mistake: https://baseui.netlify.com/?selectedKind=Header%20Navigation&selectedStory=With%20different%20styled%20Navigstion%20List&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel