### PR TITLE
chore: simplify github templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/1.bug.md
+++ b/.github/ISSUE_TEMPLATE/1.bug.md
@@ -5,30 +5,16 @@ about: Create a bug report for Base UI
 
 <!--- Provide a general summary of the issue in the Title above -->
 
-<!--
-    Thank you very much for contributing to Base UI by creating an issue! ❤️
-    To avoid duplicate issues we ask you to check off the following list.
--->
-
-* [ ] I have searched the [issues](https://github.com/uber-web/baseui/issues) of this repository and believe that this is not a duplicate.
-
-## Expected Behavior
-
-<!---
-    Describe what should happen.
--->
-
 ## Current Behavior
 
 <!---
     Describe what happens instead of the expected behavior.
 -->
 
-## Context
+## Expected Behavior
 
 <!---
-    What are you trying to accomplish? How has this issue affected you?
-    Providing context helps us come up with a solution that is most useful in the real world.
+    Describe what should happen.
 -->
 
 ## Your Environment
@@ -37,25 +23,8 @@ about: Create a bug report for Base UI
 
 | Tech    | Version |
 | ------- | ------- |
-| Base UI | v1.?.?  |
+| Base UI | v?.?.?  |
 | React   |         |
 | browser |         |
-| node.js |         |
-| etc.    |         |
 
-## Steps to Reproduce
-
-<!---
-    Provide a link to a live example (you can use codesandbox.io) and an unambiguous set of steps to reproduce this bug.
-    Include code to reproduce, if relevant (which it most likely is).
--->
-
-Link:
-
-1.
-
-2.
-
-3.
-
-4.
+- [ ] I have searched the [issues](https://github.com/uber-web/baseui/issues) of this repository and believe that this is not a duplicate.

--- a/.github/ISSUE_TEMPLATE/2.feature.md
+++ b/.github/ISSUE_TEMPLATE/2.feature.md
@@ -5,30 +5,4 @@ about: Create feature request for Base UI
 
 <!--- Provide a general summary of the feature in the Title above -->
 
-<!--
-    Thank you very much for contributing to Base UI by creating an issue! ❤️
-    To avoid duplicate issues we ask you to check off the following list.
--->
-
-<!-- Checked checkbox should look like this: [x] -->
-
-* [ ] I have searched the [issues](https://github.com/uber-web/baseui/issues) of this repository and believe that this is not a duplicate.
-
-## Expected Behavior
-
-<!---
-    Describe how it should work.
--->
-
-## Current Behavior
-
-<!---
-    Explain the difference from current behavior.
--->
-
-## Context
-
-<!---
-    What are you trying to accomplish? How has the lack of this feature affected you?
-    Providing context helps us come up with a solution that is most useful in the real world.
--->
+## Feature description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,27 +1,11 @@
-<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
-
-#### Fixed Issues?
-
 `Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->
 
-#### Patch: Bug Fix?
-
-#### Major: Breaking Change?
-
-#### Minor: New Feature?
-
-#### Tests Added + Pass?
-
-Yes
-
-#### Documentation PR Link
-
-<!-- If only readme change, add `[skip ci]` to your commits -->
-
-#### Any Dependency Changes?
-
-#### License
-
-MIT
+#### Description
 
 <!-- Describe your changes below in as much detail as possible -->
+
+#### Scope
+
+- [ ] Patch: Bug Fix
+- [ ] Minor: New Feature
+- [ ] Major: Breaking Change


### PR DESCRIPTION
It simplifies all GitHub templates (especially the one for PRs). Feedback appreciated! 

The idea is to make them more detailed again if needed (once the contributor base is much larger). For now, let's keep it as minimal as possible?