### PR TITLE
fix(flow): use correct export for React Context type

### DIFF
--- a/src/styles/theme-provider.js
+++ b/src/styles/theme-provider.js
@@ -10,7 +10,7 @@ import {LightTheme} from '../themes/index.js';
 
 import type {ThemeT} from './types.js';
 
-export const ThemeContext: React.Context<ThemeT> = React.createContext(
+export const ThemeContext: React.createContext<ThemeT> = React.createContext(
   LightTheme,
 );
 


### PR DESCRIPTION
Running Flow in a project that uses baseui results in the following error:

```
Cannot get React.Context because property Context is missing in module react [1].

 [1]  8│ import * as React from 'react';
      9│ import {LightTheme} from '../themes/index.js';
     10│
     11│ import type {ThemeT} from './types.js';
     12│
     13│ export const ThemeContext: React.Context<ThemeT> = React.createContext(
     14│   LightTheme,
     15│ );
     16│

```
