### PR TITLE
fix(checkbox): change checkbox typography style from bold to regular

### DIFF
--- a/src/checkbox/styled-components.js
+++ b/src/checkbox/styled-components.js
@@ -239,7 +239,7 @@ export const Label = styled('div', props => {
     verticalAlign: 'middle',
     ...getLabelPadding(props),
     color: getLabelColor(props),
-    ...typography.font350,
+    ...typography.font300,
     lineHeight: '24px',
   };
 });


### PR DESCRIPTION
Change typography font weight from `350` to `300` to remove the bold look.

**Before**:
<img width="142" alt="screen shot 2019-01-07 at 5 11 49 pm" src="https://user-images.githubusercontent.com/6504944/50803798-19e4c080-12a0-11e9-99b1-034b8ed37be7.png">

**After**:
<img width="131" alt="screen shot 2019-01-07 at 5 11 36 pm" src="https://user-images.githubusercontent.com/6504944/50803799-19e4c080-12a0-11e9-9242-a23223388725.png">


#### Scope
- [ ] Patch: Style Fix
