### PR TITLE
fix(Select): fix select search icon z-index

### DIFF
--- a/src/select/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/select/__tests__/__snapshots__/styled-components.test.js.snap
@@ -522,7 +522,6 @@ Object {
   "left": "$theme.sizing.scale500",
   "position": "absolute",
   "width": "$theme.sizing.scale600",
-  "zIndex": 1,
 }
 `;
 
@@ -536,7 +535,6 @@ Object {
   "left": "$theme.sizing.scale500",
   "position": "absolute",
   "width": "$theme.sizing.scale600",
-  "zIndex": 1,
 }
 `;
 
@@ -550,7 +548,6 @@ Object {
   "left": "$theme.sizing.scale500",
   "position": "absolute",
   "width": "$theme.sizing.scale600",
-  "zIndex": 1,
 }
 `;
 
@@ -564,7 +561,6 @@ Object {
   "left": "$theme.sizing.scale500",
   "position": "absolute",
   "width": "$theme.sizing.scale600",
-  "zIndex": 1,
 }
 `;
 

--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -369,7 +369,6 @@ export const StyledSearchIcon = styled('svg', (props: SharedStylePropsT) => {
     left: sizing.scale500,
     display: 'inline-block',
     height: '100%',
-    zIndex: 1,
   };
 });
 StyledSearchIcon.displayName = 'StyledSearchIcon';


### PR DESCRIPTION
<img width="821" alt="screen shot 2019-01-14 at 11 42 23 am" src="https://user-images.githubusercontent.com/5317799/51136498-7c364780-17f1-11e9-9e9a-e9a5d469fc08.png">

search icon is no longer above an overlapping dropdown menu