### PR TITLE
docs(Checkbox): adds toggle example

### DIFF
--- a/documentation-site/pages/components/checkbox.mdx
+++ b/documentation-site/pages/components/checkbox.mdx
@@ -18,6 +18,7 @@ import Alignment from 'examples/checkbox/alignment.js';
 import Overrides from 'examples/checkbox/overrides.js';
 import ComponentOverrides from 'examples/checkbox/component-overrides.js';
 import Focus from 'examples/checkbox/focus.js';
+import Toggle from 'examples/checkbox/toggle.js';
 
 export default Layout;
 
@@ -70,6 +71,10 @@ Allows users to make a selection of available options, or toggle options on/off.
 
 <Example title="Focus with button" path="examples/checkbox/focus.js">
   <Focus />
+</Example>
+
+<Example title="Toggle checkmark type" path="examples/checkbox/toggle.js">
+  <Toggle />
 </Example>
 
 <API

--- a/documentation-site/static/examples/checkbox/toggle.js
+++ b/documentation-site/static/examples/checkbox/toggle.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import {StatefulCheckbox, STYLE_TYPE} from 'baseui/checkbox';
+
+export default () => (
+  <React.Fragment>
+    <StatefulCheckbox onChange={console.log} checkmarkType={STYLE_TYPE.toggle}>
+      toggle me
+    </StatefulCheckbox>
+    <StatefulCheckbox
+      disabled
+      onChange={console.log}
+      checkmarkType={STYLE_TYPE.toggle}
+    >
+      disabled toggle
+    </StatefulCheckbox>
+  </React.Fragment>
+);


### PR DESCRIPTION
currently, this is its own section in storybook but I find it a bit misleading since we are re-using the same Checkbox import. Happy to change to it's own page if others feel strongly