### PR TITLE
docs(menu): adds menu to docs site

### DIFF
--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -18,6 +18,8 @@ import Check from 'baseui/icon/check';
 import {StyledLink} from 'baseui/link';
 import {styled} from 'baseui/styles';
 
+import {version} from '../../package.json';
+
 const Link = styled(StyledLink, {cursor: 'pointer'});
 
 const index = `
@@ -61,6 +63,7 @@ function Source(props: {children: ?React.Node}) {
 }
 
 type PropsT = {
+  additionalPackages: {[string]: string},
   children: React.Node,
   path: string, // required to fetch the uncompiled source code
   title: string,
@@ -73,6 +76,7 @@ type StateT = {
 };
 
 class Example extends React.Component<PropsT, StateT> {
+  static defaultProps = {additionalPackages: {}};
   state = {
     isCopied: false,
     isSourceOpen: false,
@@ -178,13 +182,13 @@ class Example extends React.Component<PropsT, StateT> {
                 example={this.state.source}
                 name={this.props.title}
                 dependencies={{
-                  baseui: '5.1.0',
+                  baseui: version,
                   react: '16.5.2',
                   'react-dom': '16.5.2',
                   'react-scripts': '2.0.3',
                   'styletron-engine-atomic': '1.0.9',
-                  'styletron-react': '4.3.6',
-                  'styletron-react-core': '1.3.3',
+                  'styletron-react': '4.4.4',
+                  ...this.props.additionalPackages,
                 }}
                 providedFiles={{'index.js': {content: index}}}
                 template="create-react-app"

--- a/documentation-site/pages/components/menu.mdx
+++ b/documentation-site/pages/components/menu.mdx
@@ -1,0 +1,83 @@
+<!--
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+import Example from '../../components/example';
+import API from '../../components/api';
+import Layout from '../../components/layout';
+
+import Basic from 'examples/menu/basic.js';
+import Compact from 'examples/menu/compact.js';
+import Profile from 'examples/menu/profile.js';
+import Stateful from 'examples/menu/stateful.js';
+import Child from 'examples/menu/child.js';
+import VirtualList from 'examples/menu/virtual-list.js';
+
+export default Layout;
+
+# Menu
+
+Renders a list of elements.
+
+### When to use
+
+- When you want to display a navigational list.
+- When you want to display a list of actions.
+
+## Examples
+
+<Example title="Basic Usage" path="examples/menu/basic.js">
+  <Basic />
+</Example>
+
+<Example title="Compact Menu Items" path="examples/menu/compact.js">
+  <Compact />
+</Example>
+
+<Example title="Profile Menu" path="examples/menu/profile.js">
+  <Profile />
+</Example>
+
+<Example title="Stateful Menu" path="examples/menu/stateful.js">
+  <Stateful />
+</Example>
+
+<Example title="Child Menu" path="examples/menu/child.js">
+  <Child />
+</Example>
+
+<Example
+  title="Long Items List"
+  path="examples/menu/virtual-list.js"
+  additionalPackages={{'react-virtualized': '^9.21.0'}}
+>
+  <VirtualList />
+</Example>
+
+<API
+  heading="Menu API"
+  api={require('!!extract-react-types-loader!../../../src/menu/menu.js')}
+/>
+
+<API
+  heading="Stateful Menu API"
+  api={require('!!extract-react-types-loader!../../../src/menu/stateful-menu.js')}
+/>
+
+<API
+  heading="Stateful Container API"
+  api={require('!!extract-react-types-loader!../../../src/menu/stateful-container.js')}
+/>
+
+<API
+  heading="Menu Item Api"
+  api={require('!!extract-react-types-loader!../../../src/menu/option-list.js')}
+/>
+
+<API
+  heading="Profile Menu Item Api"
+  api={require('!!extract-react-types-loader!../../../src/menu/option-profile.js')}
+/>

--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -26,18 +26,34 @@ The select and search controls allow the user to select an option or options.
   <SelectBasic />
 </Example>
 
-<Example title="Select Single Pick Search" path="examples/select/search-single-pick.js">
+<Example
+  title="Select Single Pick Search"
+  path="examples/select/search-single-pick.js"
+>
   <SelectSinglePickSearch />
 </Example>
 
-<Example title="Select Multi Pick Search" path="examples/select/search-multi-pick.js">
+<Example
+  title="Select Multi Pick Search"
+  path="examples/select/search-multi-pick.js"
+>
   <SelectMultiPickSearch />
 </Example>
 
-<Example title="Select With Many Options" path="examples/select/with-many-options.js">
+<Example
+  title="Select With Many Options"
+  path="examples/select/with-many-options.js"
+  additionalPackages={{'react-virtualized': '^9.21.0'}}
+>
   <SelectWithManyOptions />
 </Example>
 
-<API heading="Select API" api={require('!!extract-react-types-loader!../../../src/select/select.js')}/>
+<API
+  heading="Select API"
+  api={require('!!extract-react-types-loader!../../../src/select/select.js')}
+/>
 
-<API heading="StatefulSelectContainer API" api={require('!!extract-react-types-loader!../../../src/select/stateful-select-container.js')}/>
+<API
+  heading="StatefulSelectContainer API"
+  api={require('!!extract-react-types-loader!../../../src/select/stateful-select-container.js')}
+/>

--- a/documentation-site/routes.js
+++ b/documentation-site/routes.js
@@ -106,6 +106,10 @@ const routes = [
         text: 'Pickers',
         children: [
           {
+            text: 'Menu',
+            path: getPath('/components/menu'),
+          },
+          {
             text: 'Select',
             path: getPath('/components/select'),
           },

--- a/documentation-site/static/examples/menu/basic.js
+++ b/documentation-site/static/examples/menu/basic.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import {Menu} from 'baseui/menu';
+
+const ITEMS = [
+  {label: 'Item One'},
+  {label: 'Item Two'},
+  {label: 'Item Three'},
+  {label: 'Item Four'},
+  {label: 'Item Five'},
+  {label: 'Item Six'},
+  {label: 'Item Seven'},
+  {label: 'Item Eight'},
+  {label: 'Item Nine'},
+  {label: 'Item Ten'},
+  {label: 'Item Eleven'},
+  {label: 'Item Twelve'},
+];
+
+export default () => (
+  <Menu
+    items={ITEMS}
+    rootRef={React.createRef()}
+    overrides={{
+      List: {
+        style: {
+          width: '200px',
+        },
+      },
+      Option: {
+        props: {
+          getItemLabel: item => item.label,
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/static/examples/menu/child.js
+++ b/documentation-site/static/examples/menu/child.js
@@ -1,0 +1,50 @@
+import React from 'react';
+import {Menu, StatefulMenu} from 'baseui/menu';
+
+const ITEMS = [
+  {label: 'Item One'},
+  {label: 'Item Two'},
+  {label: 'Item Three'},
+  {label: 'Item Four'},
+  {label: 'Item Five'},
+  {label: 'Item Six'},
+  {label: 'Item Seven'},
+  {label: 'Item Eight'},
+  {label: 'Item Nine'},
+  {label: 'Item Ten'},
+  {label: 'Item Eleven'},
+  {label: 'Item Twelve'},
+];
+
+const ThirdMenu = () => (
+  <Menu
+    items={ITEMS}
+    overrides={{List: {style: {width: '200px'}}}}
+    rootRef={React.createRef()}
+  />
+);
+
+const SecondMenu = () => (
+  <Menu
+    items={ITEMS}
+    overrides={{
+      List: {style: {width: '200px'}},
+      Option: {props: {getChildMenu: ThirdMenu}},
+    }}
+    rootRef={React.createRef()}
+  />
+);
+
+export default () => (
+  <StatefulMenu
+    items={ITEMS}
+    overrides={{
+      List: {style: {width: '350px', overflow: 'auto'}},
+      Option: {
+        props: {
+          getChildMenu: SecondMenu,
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/static/examples/menu/compact.js
+++ b/documentation-site/static/examples/menu/compact.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {Menu} from 'baseui/menu';
+
+const ITEMS = [
+  {label: 'Item One'},
+  {label: 'Item Two'},
+  {label: 'Item Three'},
+  {label: 'Item Four'},
+  {label: 'Item Five'},
+  {label: 'Item Six'},
+  {label: 'Item Seven'},
+  {label: 'Item Eight'},
+  {label: 'Item Nine'},
+  {label: 'Item Ten'},
+  {label: 'Item Eleven'},
+  {label: 'Item Twelve'},
+];
+
+export default () => (
+  <Menu
+    items={ITEMS}
+    rootRef={React.createRef()}
+    overrides={{
+      List: {
+        style: {
+          width: '500px',
+        },
+      },
+      Option: {
+        props: {
+          getItemLabel: item => item.label,
+          size: 'compact',
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/static/examples/menu/profile.js
+++ b/documentation-site/static/examples/menu/profile.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import {Menu, OptionProfile} from 'baseui/menu';
+
+const ITEMS = [...new Array(4)].map(() => ({
+  title: 'David Smith',
+  subtitle: 'Senior Engineering Manager',
+  body: 'Uber Everything',
+  imgUrl: 'https://via.placeholder.com/60x60',
+}));
+
+export default () => (
+  <Menu
+    items={ITEMS}
+    rootRef={React.createRef()}
+    overrides={{
+      List: {
+        style: {
+          width: '350px',
+        },
+      },
+      Option: {
+        component: OptionProfile,
+        props: {
+          getProfileItemLabels: ({title, subtitle, body}) => ({
+            title,
+            subtitle,
+            body,
+          }),
+          getProfileItemImg: item => item.imgUrl,
+          getProfileItemImgText: item => item.title,
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/static/examples/menu/stateful.js
+++ b/documentation-site/static/examples/menu/stateful.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import {StatefulMenu} from 'baseui/menu';
+
+const ITEMS = [
+  {label: 'Item One'},
+  {label: 'Item Two'},
+  {label: 'Item Three', disabled: true},
+  {label: 'Item Four', disabled: true},
+  {label: 'Item Five'},
+  {label: 'Item Six'},
+  {label: 'Item Seven'},
+  {label: 'Item Eight'},
+  {label: 'Item Nine'},
+  {label: 'Item Ten'},
+  {label: 'Item Eleven'},
+  {label: 'Item Twelve'},
+];
+
+export default () => (
+  <StatefulMenu
+    items={ITEMS}
+    onItemSelect={console.log}
+    overrides={{
+      List: {
+        style: {
+          height: '150px',
+          width: '350px',
+        },
+      },
+      Option: {
+        props: {
+          getItemLabel: item => item.label,
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/static/examples/menu/virtual-list.js
+++ b/documentation-site/static/examples/menu/virtual-list.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import {styled} from 'baseui';
+import {StatefulMenu, OptionList, StyledList} from 'baseui/menu';
+import List from 'react-virtualized/dist/commonjs/List';
+import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
+
+const ITEMS = [...new Array(1500)].map((_, index) => ({
+  label: `item number: ${index + 1}`,
+}));
+
+const Container = styled(StyledList, {height: '500px'});
+
+const VirtualList = props => (
+  <Container $ref={props.$ref}>
+    <AutoSizer>
+      {({width}) => (
+        <List
+          role={props.role}
+          height={500}
+          rowCount={props.children.length}
+          rowHeight={36}
+          rowRenderer={({index, key, style}) => (
+            <OptionList
+              key={key}
+              style={style}
+              {...props.children[index].props}
+              overrides={{
+                ListItem: {
+                  style: {
+                    paddingTop: 0,
+                    paddingBottom: 0,
+                    display: 'flex',
+                    alignItems: 'center',
+                  },
+                },
+              }}
+            />
+          )}
+          width={width}
+        />
+      )}
+    </AutoSizer>
+  </Container>
+);
+
+export default () => (
+  <StatefulMenu items={ITEMS} overrides={{List: {component: VirtualList}}} />
+);

--- a/src/menu/README.md
+++ b/src/menu/README.md
@@ -121,7 +121,7 @@ export default () => (
 * `items: Array<any>` - Required.
   * List of items.
 * `initialState?: {highlightedIndex: number} = {highlightedIndex: -1}`
-  * Initial state of an uncontrolled popover component.
+  * Initial state of the stateful menu.
     * `highlightedIndex` - Determines which menu item should render highlighted.
 * `stateReducer?: (changeType: STATE_CHANGE_TYPES[string], changes: {highlightedIndex: number}, currentState: {highlightedIndex: number}) => {highlightedIndex: number}`
   * State reducer to intercept state changes and return new internal state

--- a/src/menu/stateful-menu.js
+++ b/src/menu/stateful-menu.js
@@ -11,14 +11,24 @@ import * as React from 'react';
 import Menu from './menu.js';
 import StatefulContainer from './stateful-container.js';
 
-import type {StatefulMenuPropsT} from './types.js';
+import type {StatefulMenuPropsT, StateReducerFnT} from './types.js';
 
 export default class StatefulMenu extends React.PureComponent<
   StatefulMenuPropsT,
 > {
   static defaultProps = {
     // Mostly to satisfy flow
-    ...StatefulContainer.defaultProps,
+    initialState: {
+      // We start the index at -1 to indicate that no highlighting exists initially
+      highlightedIndex: -1,
+    },
+    stateReducer: (
+      changeType: ?$PropertyType<StateReducerFnT, 'changeType'>,
+      changes: $PropertyType<StateReducerFnT, 'changes'>,
+    ) => changes,
+    onItemSelect: () => {},
+    getRequiredItemProps: () => ({}),
+    children: () => null,
     overrides: {},
   };
 

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -87,11 +87,19 @@ export type RenderPropsT = StatefulContainerStateT & {
  */
 
 export type StatefulContainerPropsT = {
+  /** List of menu items. */
   items: ItemsT,
+  /** Initial state of the stateful menu. */
   initialState: StatefulContainerStateT,
+  /** State reducer to intercept state changes and return new internal state */
   stateReducer: StateReducerFnT,
+  /** Function to get props for each rendered item. This will have some defaults needed for keyboard
+   * bindings to work properly. Every rendered item should call this.
+   */
   getRequiredItemProps: GetRequiredItemPropsFnT,
+  /** Callback executed on menu item clicks. */
   onItemSelect: OnItemSelectFnT,
+  /** Child as function pattern. */
   children: RenderPropsT => React.Node,
 };
 
@@ -103,18 +111,27 @@ export type MenuPropsT = {
 };
 
 export type MenuProfilePropsT = {
+  /** Returns an object consisting of title, subtitle, and body to render menu item */
   getProfileItemLabels: GetProfileItemLabelsFnT,
+  /** Returns either an image source url, or a full React component to render as the image. */
   getProfileItemImg: GetProfileItemImgFnT,
+  /** Returns the alt text for the image */
   getProfileItemImgText: GetProfileItemImgTextFnT,
   overrides?: ProfileOverridesT,
 };
 
 export type SharedStatelessPropsT = {
+  /** Function to get props for each rendered item. This will have some defaults needed for keyboard
+   * bindings to work properly. Every rendered item should call this.
+   */
   getRequiredItemProps?: GetRequiredItemPropsFnT,
+  /** Index of highlighted menu item. */
   highlightedIndex?: number,
+  /** List of menu items. */
   items: ItemsT,
   onBlur?: (event: SyntheticFocusEvent<HTMLElement>) => mixed,
   onFocus?: (event: SyntheticFocusEvent<HTMLElement>) => mixed,
+  /** Ref for the menu container element. Used to capture key events for navigation */
   rootRef: RootRefT,
 };
 
@@ -129,21 +146,31 @@ export type StatelessMenuProfilePropsT = SharedStatelessPropsT &
   MenuProfilePropsT;
 
 export type OptionListPropsT = {
+  /** Item to parse and render. */
   item: ItemT,
+  /** Function used to get the string label for each item. */
   getItemLabel: GetItemLabelFnT,
+  /** Used to render a sub menu at this menu item. You'll often render another menu from this function. */
   getChildMenu?: (item: ItemT) => React.Node,
+  /** Renders UI in defined scale. */
   size: $Keys<typeof OPTION_LIST_SIZE>,
   overrides: {
     ListItem?: OverrideT<*>,
   },
+  /** Renders UI in 'highlighted' state. */
   $isHighlighted?: boolean,
 };
 
 export type OptionProfilePropsT = {
+  /** Item to parse and render. */
   item: ItemT,
+  /** Used to render a sub menu at this menu item. You'll often render another menu from this function. */
   getChildMenu?: (item: ItemT) => React.Node,
+  /** Returns an object consisting of title, subtitle, and body to render menu item */
   getProfileItemLabels: GetProfileItemLabelsFnT,
+  /** Returns either an image source url, or a full React component to render as the image. */
   getProfileItemImg: GetProfileItemImgFnT,
+  /** Returns the alt text for the image */
   getProfileItemImgText: GetProfileItemImgTextFnT,
   overrides?: {
     ListItemProfile?: OverrideT<*>,


### PR DESCRIPTION
adds a new prop to the `Example` component to pass additional npm packages. This ensures that the `react-virtualized` example works correctly in the code sandbox