### PR TITLE
fix(theme-provider): update flow type for ThemeContext

### DIFF
--- a/src/styles/theme-provider.js
+++ b/src/styles/theme-provider.js
@@ -10,9 +10,7 @@ import {LightTheme} from '../themes/index.js';
 
 import type {ThemeT} from './types.js';
 
-export const ThemeContext: React.Context<ThemeT> = React.createContext(
-  LightTheme,
-);
+export const ThemeContext = React.createContext < ThemeT > LightTheme;
 
 const ThemeProvider = (props: {theme: ThemeT, children: ?React.Node}) => {
   const {theme, children} = props;


### PR DESCRIPTION
Bugfix: Change flow type for ThemeContext
#### Description
In some versions of flow and flow-bin, flow throws an error on the theme provider type. This fix makes the type compatible for users using flow-bin version ^0.74.0.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
