### PR TITLE
doc(align-layout): propose align layout (Row / Column) components based on CSS grid.

### DIFF
--- a/src/layout/README.md
+++ b/src/layout/README.md
@@ -32,7 +32,7 @@ import {Row, Column} from '@uber/layout-align';
 * `Row`
 * `Column`
 
-## `Button` API
+## `Row` & `Column`API
 
 * `items: string`
 

--- a/src/layout/README.md
+++ b/src/layout/README.md
@@ -1,0 +1,72 @@
+# Align Layout Components
+
+## Usage
+
+```javascript
+import {Row, Column} from '@uber/layout-align';
+
+// "1fr" is similar to flex-grow: 1 on the target item
+<Row items="100px 1fr 20%">
+  <Item>100px</Item>
+  <Item>Rest</Item>
+  <Item>20%</Item>
+</Row>
+
+// automatically translate gap to row-gap or column-gap
+<Column items="100px 1fr 20%" gap="24px">
+  <Item>100px</Item>
+  <Item>Rest</Item>
+  <Item>20%</Item>
+</Row>
+
+// support common CSS properties
+<Column items="100px 1fr 20%" width="360px" height="240px" color="primary200">
+  <Item>100px</Item>
+  <Item>Rest</Item>
+  <Item>20%</Item>
+</Row>
+```
+
+## Exports
+
+* `Row`
+* `Column`
+
+## `Button` API
+
+* `items: string`
+
+  * Expression to specify child space allocation. [CSS grid row and column templates](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-rows).
+
+* `gap?: string`
+
+  * Specifies item gaps. The value translates to [grid-gap / row-gap](https://developer.mozilla.org/en-US/docs/Web/CSS/row-gap).
+
+* `center: boolean`
+
+  * Whether the child nodes should be aligned in the middle along the row / column axis.
+This translates either to `align-item: center` or `justify-items: center`.
+
+* `color: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/color
+
+* `font: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/font
+
+* `width: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/width
+
+* `height: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/height
+
+* `padding / paddingTop / paddingRight / paddingBottom / paddingLeft: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/padding
+
+* `margin / marginTop / marginRight / marginBottom / marginLeft: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/margin
+
+* `overflow: string`
+  * https://developer.mozilla.org/en-US/docs/Web/CSS/overflow
+
+  > These attributes specify respective css properties.
+


### PR DESCRIPTION
This PR proposes a new set of layout components that align child components in a line (row or column).

It uses CSS grid underneath that provides a simpler yet more powerful layout syntax compared to Flex Box:

1. All layout styles can be configured on the container element without flex-grow on respective child nodes.
2. Support CSS grid gap instead of margins on child nodes.
3. Supports many CSS property shortcuts like color, font, width, height, padding, margin, etc ...

Some comparison with Block component:

These layout components focus on providing simpler styling for layout containers while Block component serves as a lower construct for other styling needs. The align-layout components can use Block component underneath.

In terms of syntactical difference:

```js
// A simple column layout with Block
<Block
  display="grid"
  gridTemplateRows="repeat(3, 1fr)"
  gridAutoFlow="column"
  alignItems="center"
  gridColumnGap="scale1000"
>
  // children
</Block>

// A simple column layout with align Column
<Column items="repeat(3, 1fr)" gap="scale1000" center>
  // children
</Column
```

While css Grid is superior than flex-box in many ways, it poses a lot of syntactical complexities to us. And we'd always need to lookup the property names every time we do layout. Since most of our layout needs are Row and Column layouts, we create these React components with simpler property names that are easier to remember.

