### PR TITLE
fix(pagination): dropdown z-index bug

### DIFF
--- a/src/pagination/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/pagination/__tests__/__snapshots__/styled-components.test.js.snap
@@ -24,6 +24,7 @@ Object {
   "position": "absolute",
   "right": 0,
   "top": "auto",
+  "zIndex": 1,
 }
 `;
 

--- a/src/pagination/styled-components.js
+++ b/src/pagination/styled-components.js
@@ -34,6 +34,7 @@ export const DropdownMenu = styled(StyledList, ({$theme}) => ({
   marginTop: $theme.sizing.scale300,
   left: 0,
   right: 0,
+  zIndex: 1,
 }));
 
 export const DropdownButton = styled(StyledBaseButton, ({$theme}) => ({


### PR DESCRIPTION
`Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->

#### Description

before:
<img width="792" alt="screen shot 2019-01-22 at 11 16 24 am" src="https://user-images.githubusercontent.com/5317799/51638608-a4b9f200-1f13-11e9-99e7-dcca755825c0.png">

after:
<img width="552" alt="screen shot 2019-01-23 at 1 32 00 pm" src="https://user-images.githubusercontent.com/5317799/51638618-abe10000-1f13-11e9-9485-2ec2268f4af7.png">


#### Scope

- [x] Patch: Bug Fix