### PR TITLE
feat(docs): add github links and simplify spacing in the sidebar

### DIFF
--- a/documentation-site/components/component-menu.js
+++ b/documentation-site/components/component-menu.js
@@ -54,7 +54,11 @@ export default () => (
       </Card>
     )}
   >
-    <Button kind={KIND.secondary} endEnhancer={() => <TriangleDown />}>
+    <Button
+      kind={KIND.secondary}
+      endEnhancer={() => <TriangleDown />}
+      $style={{height: '40px'}}
+    >
       Components
     </Button>
   </StatefulPopover>

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -19,7 +19,6 @@ import {StyledLink} from 'baseui/link';
 import {styled} from 'baseui/styles';
 
 import {version} from '../../package.json';
-import GithubLogo from './github-logo';
 
 const Link = styled(StyledLink, {cursor: 'pointer'});
 

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -152,28 +152,6 @@ class Example extends React.Component<PropsT, StateT> {
             >
               {this.state.isSourceOpen ? 'Hide' : 'Show'} Source
             </Button>
-            <Block
-              $as="a"
-              href={`https://github.com/uber-web/baseui/tree/master/documentation-site/static/${
-                this.props.path
-              }`}
-              marginLeft="scale600"
-              marginRight="scale200"
-              $style={{textDecoration: 'none'}}
-              target="_blank"
-            >
-              <Button
-                kind={KIND.secondary}
-                overrides={{
-                  EndEnhancer: {
-                    style: {
-                      marginLeft: 0,
-                    },
-                  },
-                }}
-                endEnhancer={() => <GithubLogo size={24} color="#276EF1" />}
-              />
-            </Block>
           </Block>
         </Block>
 
@@ -199,7 +177,7 @@ class Example extends React.Component<PropsT, StateT> {
               <Source>{this.state.source}</Source>
             </Block>
 
-            <Block paddingLeft="scale800">
+            <Block paddingLeft="scale800" display="flex" alignItems="center">
               <CodeSandboxer
                 examplePath="/"
                 example={this.state.source}
@@ -218,6 +196,20 @@ class Example extends React.Component<PropsT, StateT> {
               >
                 {() => <Link>Open in CodeSandbox</Link>}
               </CodeSandboxer>
+              <Block
+                $as="a"
+                href={`https://github.com/uber-web/baseui/tree/master/documentation-site/static/${
+                  this.props.path
+                }`}
+                marginLeft="scale600"
+                marginRight="scale200"
+                $style={{textDecoration: 'none'}}
+                target="_blank"
+                display="flex"
+                alignItems="center"
+              >
+                <GithubLogo size={18} color="#276EF1" />
+              </Block>
             </Block>
           </React.Fragment>
         )}

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -196,20 +196,6 @@ class Example extends React.Component<PropsT, StateT> {
               >
                 {() => <Link>Open in CodeSandbox</Link>}
               </CodeSandboxer>
-              <Block
-                $as="a"
-                href={`https://github.com/uber-web/baseui/tree/master/documentation-site/static/${
-                  this.props.path
-                }`}
-                marginLeft="scale600"
-                marginRight="scale200"
-                $style={{textDecoration: 'none'}}
-                target="_blank"
-                display="flex"
-                alignItems="center"
-              >
-                <GithubLogo size={18} color="#276EF1" />
-              </Block>
             </Block>
           </React.Fragment>
         )}

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -19,6 +19,7 @@ import {StyledLink} from 'baseui/link';
 import {styled} from 'baseui/styles';
 
 import {version} from '../../package.json';
+import GithubLogo from './github-logo';
 
 const Link = styled(StyledLink, {cursor: 'pointer'});
 
@@ -123,7 +124,7 @@ class Example extends React.Component<PropsT, StateT> {
           </Block>
           <Block display="flex" alignItems="center">
             {this.state.isSourceOpen && (
-              <Block marginRight="scale400">
+              <Block marginRight="scale600">
                 <CopyToClipboard
                   onCopy={this.handleCopy}
                   text={this.state.source}
@@ -151,6 +152,28 @@ class Example extends React.Component<PropsT, StateT> {
             >
               {this.state.isSourceOpen ? 'Hide' : 'Show'} Source
             </Button>
+            <Block
+              $as="a"
+              href={`https://github.com/uber-web/baseui/tree/master/documentation-site/static/${
+                this.props.path
+              }`}
+              marginLeft="scale600"
+              marginRight="scale200"
+              $style={{textDecoration: 'none'}}
+              target="_blank"
+            >
+              <Button
+                kind={KIND.secondary}
+                overrides={{
+                  EndEnhancer: {
+                    style: {
+                      marginLeft: 0,
+                    },
+                  },
+                }}
+                endEnhancer={() => <GithubLogo size={24} color="#276EF1" />}
+              />
+            </Block>
           </Block>
         </Block>
 

--- a/documentation-site/components/github-logo.js
+++ b/documentation-site/components/github-logo.js
@@ -1,0 +1,32 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+type PropT = {
+  size: number,
+  color: string,
+};
+
+const GithubLogo = (props: PropT) => (
+  <svg
+    width={props.size}
+    height={props.size}
+    className="prefix__octicon prefix__octicon-mark-github"
+    viewBox="0 0 16 16"
+    aria-hidden="true"
+  >
+    <path
+      fillRule="evenodd"
+      fill={props.color}
+      d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"
+    />
+  </svg>
+);
+
+export default GithubLogo;

--- a/documentation-site/components/layout.js
+++ b/documentation-site/components/layout.js
@@ -73,10 +73,15 @@ export default (props: PropsT) => (
         >
           <Button
             kind={ButtonKind.secondary}
-            endEnhancer={() => <GithubLogo size={22} color="#276EF1" />}
-          >
-            GitHub
-          </Button>
+            overrides={{
+              EndEnhancer: {
+                style: {
+                  marginLeft: 0,
+                },
+              },
+            }}
+            endEnhancer={() => <GithubLogo size={24} color="#276EF1" />}
+          />
         </Block>
         <Block marginLeft="scale600">
           <Link href="/getting-started" prefetch>

--- a/documentation-site/components/layout.js
+++ b/documentation-site/components/layout.js
@@ -23,6 +23,7 @@ import ComponentMenu from './component-menu';
 import MarkdownElements from './markdown-elements';
 import Sidebar from './sidebar';
 import Logo from '../images/Logo.png';
+import GithubLogo from './github-logo';
 
 type PropsT = {
   children: React.Node,
@@ -62,14 +63,25 @@ export default (props: PropsT) => (
       </NavigationList>
       <NavigationList align={ALIGN.center} />
       <NavigationList align={ALIGN.right}>
-        <Block display="flex" marginRight="scale800">
-          <ComponentMenu />
+        <ComponentMenu />
+        <Block
+          $as="a"
+          href="https://github.com/uber-web/baseui"
+          marginLeft="scale600"
+          $style={{textDecoration: 'none'}}
+          target="_blank"
+        >
+          <Button
+            kind={ButtonKind.secondary}
+            endEnhancer={() => <GithubLogo size={22} color="#276EF1" />}
+          >
+            GitHub
+          </Button>
         </Block>
-        <Link href="/getting-started" prefetch>
-          <Button>Get Started</Button>
-        </Link>
-        <Block $as="a" href="/legacy" marginLeft="scale800">
-          <Button kind={ButtonKind.tertiary}>Storybook (legacy)</Button>
+        <Block marginLeft="scale600">
+          <Link href="/getting-started" prefetch>
+            <Button>Get Started</Button>
+          </Link>
         </Block>
       </NavigationList>
     </HeaderNavigation>

--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -17,8 +17,8 @@ import Routes from '../routes';
 
 const levelToPadding = {
   1: 'scale400',
-  2: 'scale600',
-  3: 'scale800',
+  2: 'scale500',
+  3: 'scale600',
 };
 
 const levelToFont = {
@@ -40,7 +40,7 @@ const List = styled(Block, ({$theme}) => ({
 
 const NavigationLink = props => {
   return (
-    <Block paddingBottom="scale300">
+    <Block>
       <Link passHref={true} href={props.path} prefetch>
         <NavLink tabIndex="0">{props.text}</NavLink>
       </Link>
@@ -49,9 +49,14 @@ const NavigationLink = props => {
 };
 
 const NavigationItem = props => {
-  const {route, level = 1} = props;
+  const {route, index, level = 1} = props;
   return (
-    <Block font={levelToFont[level]} paddingLeft={levelToPadding[level]}>
+    <Block
+      font={levelToFont[level]}
+      paddingLeft={levelToPadding[level]}
+      paddingBottom={level !== 3 ? 'scale100' : 0}
+      paddingTop={index === 0 && level === 3 ? 'scale100' : 0}
+    >
       {route.path ? (
         <NavigationLink path={route.path} text={route.text} />
       ) : (
@@ -61,7 +66,11 @@ const NavigationItem = props => {
         ? route.children.map((childRoute, index) => {
             return (
               <React.Fragment key={index}>
-                <NavigationItem level={level + 1} route={childRoute} />
+                <NavigationItem
+                  level={level + 1}
+                  route={childRoute}
+                  index={index}
+                />
               </React.Fragment>
             );
           })
@@ -73,7 +82,7 @@ const NavigationItem = props => {
 export default () => (
   <List as="ul">
     {Routes.map((route, index) => {
-      return <NavigationItem key={index} route={route} />;
+      return <NavigationItem key={index} route={route} index={index} />;
     })}
   </List>
 );

--- a/documentation-site/routes.js
+++ b/documentation-site/routes.js
@@ -21,6 +21,10 @@ const routes = [
         text: 'Versioning policy',
         path: '/versioning-policy',
       },
+      {
+        text: 'Storybook (legacy)',
+        path: '/legacy',
+      },
     ],
   },
   {


### PR DESCRIPTION
## Some minor visual adjustments
- add github link to the header
- remove `Storybook (legacy)` link, mostly because it doesn't fit and it also doesn't seem that useful? If so we could add it to the sidebar
- add github links to all code examples
- make sidebar spacing more condensed and even

## Before
<img width="1105" alt="screen shot 2019-01-23 at 5 14 26 pm" src="https://user-images.githubusercontent.com/1387913/51647829-25d4b180-1f33-11e9-8515-bd4a0e5fc51a.png">

## After
<img width="1174" alt="screen shot 2019-01-24 at 11 12 55 am" src="https://user-images.githubusercontent.com/1387913/51702721-5e26cf00-1fc9-11e9-969f-048973c0c8cb.png">

Let me know what you think!