### PR TITLE
fix(compat): use create-react-context for compatibility with React 15.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,6 +142,7 @@
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {
+    "create-react-context": "^0.2.3",
     "date-fns": "2.0.0-alpha.27",
     "memoize-one": "^5.0.0",
     "popper.js": "^1.14.3",

--- a/src/styles/theme-provider.js
+++ b/src/styles/theme-provider.js
@@ -6,13 +6,12 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 import * as React from 'react';
+import createReactContext, {type Context} from 'create-react-context';
 import {LightTheme} from '../themes/index.js';
 
 import type {ThemeT} from './types.js';
 
-export const ThemeContext: React.Context<ThemeT> = React.createContext(
-  LightTheme,
-);
+export const ThemeContext: Context<ThemeT> = createReactContext(LightTheme);
 
 const ThemeProvider = (props: {theme: ThemeT, children: ?React.Node}) => {
   const {theme, children} = props;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5410,6 +5410,14 @@ create-react-context@^0.2.2:
     fbjs "^0.8.0"
     gud "^1.0.0"
 
+create-react-context@^0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/create-react-context/-/create-react-context-0.2.3.tgz#9ec140a6914a22ef04b8b09b7771de89567cb6f3"
+  integrity sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==
+  dependencies:
+    fbjs "^0.8.0"
+    gud "^1.0.0"
+
 cross-env@^5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.2.0.tgz#6ecd4c015d5773e614039ee529076669b9d126f2"


### PR DESCRIPTION
#### Description

Use `create-react-context` polyfill to support React v15.x.
Styletron uses it under the hood to have support of older versions. At the same time, `baseui` doesn't use any of React 16 features, except for `createContext`.

#### Scope
- [x] Patch: Bug Fix
