### PR TITLE
feat(toast): add autoHideDuration to ToasterContainer

### DIFF
--- a/src/toast/examples.js
+++ b/src/toast/examples.js
@@ -105,6 +105,19 @@ class ToasterExample extends React.Component<{}, {toasts: []}> {
         >
           Negative toast
         </Button>
+        <Space />
+        <Button
+          onClick={() => {
+            toaster.positive('hi');
+          }}
+          overrides={{
+            BaseButton: {
+              style: getBtnStyle('positive'),
+            },
+          }}
+        >
+          Use ToasterContainer autoHideDuration
+        </Button>
       </div>
     );
   }
@@ -205,7 +218,10 @@ export default {
   [examples.TOASTER_EXAMPLE]: function Story2() {
     return (
       <Centered>
-        <ToasterContainer placement={PLACEMENT.bottomRight} />
+        <ToasterContainer
+          placement={PLACEMENT.bottomRight}
+          autoHideDuration={500}
+        />
         <ToasterExample />
       </Centered>
     );

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -32,6 +32,7 @@ export class ToasterContainer extends React.Component<
     placement: PLACEMENT.top,
     usePortal: true,
     overrides: {},
+    autoHideDuration: 0,
   };
 
   constructor(props: ToasterPropsT) {
@@ -55,8 +56,9 @@ export class ToasterContainer extends React.Component<
   getToastProps = (
     props: ToastPropsT,
   ): $Shape<ToastPropsT> & {key: React.Key} => {
+    const {autoHideDuration} = this.props;
     const key: React.Key = props.key || `toast-${this.toastId++}`;
-    return {...props, key};
+    return {autoHideDuration, ...props, key};
   };
 
   show = (props: $Shape<ToastPropsT> = {}): React.Key => {

--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -88,6 +88,9 @@ export type ToasterPropsT = {
   overrides: ToasterOverridesT,
   placement: PlacementTypeT,
   usePortal: boolean,
+  /** The number of milliseconds to wait before automatically dismissing a
+   * notification. This behavior is disabled when the value is set to 0.*/
+  autoHideDuration: number,
 };
 export type ToasterContainerStateT = {
   isMounted: boolean,


### PR DESCRIPTION
Based on the [API doc](https://github.com/uber-web/baseui/tree/master/src/toast#toastercontainer-api), ToasterContainer API states there is `autoHideDuration` but it isn't implemented

#### Description

To test this is working, I added an example in storybook:

<img width="1041" alt="screen shot 2019-01-30 at 8 47 12 am" src="https://user-images.githubusercontent.com/262105/51997486-afbcd700-246b-11e9-91b4-d3c97cdb675d.png">

The right most button will be dismissed after 0.5 seconds as the ToasterContainer has the following property set:

        <ToasterContainer
          placement={PLACEMENT.bottomRight}
          autoHideDuration={500}
        />

The `toaster` props `autoHideDuration` overrides the `ToasterContainer`'s `autoHideDuration` if present.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
