### PR TITLE
feat(docs): integrate google analytics

### DIFF
--- a/documentation-site/components/component-menu.js
+++ b/documentation-site/components/component-menu.js
@@ -13,6 +13,7 @@ import {Card} from 'baseui/card';
 import {Button, KIND} from 'baseui/button';
 import TriangleDown from 'baseui/icon/triangle-down';
 import {StatefulPopover} from 'baseui/popover';
+import {trackEvent} from '../helpers/ga';
 
 import NavLink from './nav-link';
 
@@ -40,6 +41,7 @@ const categories = Routes.find(r => r.components);
 export default () => (
   <StatefulPopover
     placement="bottom"
+    onOpen={() => trackEvent('component_top_popover', 'open')}
     content={({close}) => (
       <Card>
         <Block display="flex">

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -19,6 +19,7 @@ import {styled} from 'baseui/styles';
 
 import {version} from '../../package.json';
 import Code from './code';
+import {trackEvent} from '../helpers/ga';
 
 const Link = styled(StyledLink, {cursor: 'pointer'});
 
@@ -113,11 +114,12 @@ class Example extends React.Component<PropsT, StateT> {
           <Block display="flex" alignItems="center">
             <Button
               kind={KIND.secondary}
-              onClick={() =>
+              onClick={() => {
                 this.setState(prevState => ({
                   isSourceOpen: !prevState.isSourceOpen,
-                }))
-              }
+                }));
+                trackEvent('show_source', this.props.title);
+              }}
             >
               {this.state.isSourceOpen ? 'Hide' : 'Show'} Source
             </Button>
@@ -152,7 +154,10 @@ class Example extends React.Component<PropsT, StateT> {
             >
               <Block marginRight="scale600">
                 <CopyToClipboard
-                  onCopy={this.handleCopy}
+                  onCopy={() => {
+                    this.handleCopy();
+                    trackEvent('copy_to_clipboard', this.props.title);
+                  }}
                   text={this.state.source}
                 >
                   {this.state.isCopied ? (
@@ -171,6 +176,12 @@ class Example extends React.Component<PropsT, StateT> {
                 examplePath="/"
                 example={this.state.source}
                 name={this.props.title}
+                afterDeploy={() => {
+                  trackEvent('codesandbox_deployed', this.props.title);
+                }}
+                afterDeployError={() => {
+                  trackEvent('codesandbox_deployed_error', this.props.title);
+                }}
                 dependencies={{
                   baseui: version,
                   react: '16.5.2',

--- a/documentation-site/components/overrides.js
+++ b/documentation-site/components/overrides.js
@@ -12,6 +12,7 @@ import {Block} from 'baseui/block';
 import {Card, StyledBody} from 'baseui/card';
 import {StyledRadio, RadioGroup} from 'baseui/radio';
 import Link from 'next/link';
+import {trackEvent} from '../helpers/ga';
 
 const isStyledExport = exportName => exportName.startsWith('Styled');
 const getOverrideName = exportName => exportName.replace('Styled', '');
@@ -70,7 +71,10 @@ class Overrides extends React.Component {
           <RadioGroup
             name="highlight an override"
             value={this.state.highlighted}
-            onChange={e => this.setState({highlighted: e.target.value})}
+            onChange={e => {
+              this.setState({highlighted: e.target.value});
+              trackEvent('overrides_inspector', `${name}:${e.target.value}`);
+            }}
           >
             {overrides.map(override => (
               <StyledRadio key={override} value={override}>

--- a/documentation-site/components/search.js
+++ b/documentation-site/components/search.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 import * as React from 'react';
 import {styled} from 'baseui/styles';
 import {default as SearchIcon} from 'baseui/icon/search';
+import {trackEvent} from '../helpers/ga';
 
 const SEARCH_INPUT_ID = 'algolia-doc-search';
 
@@ -79,6 +80,7 @@ class DocSearch extends React.Component<{}, State> {
           type="search"
           placeholder="Search documentation"
           aria-label="Search documentation"
+          onChange={e => trackEvent('algolia_search', e.target.value)}
         />
       </React.Fragment>
     ) : null;

--- a/documentation-site/helpers/ga.js
+++ b/documentation-site/helpers/ga.js
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+export const GA_ID = 'UA-133544678-2';
+
+export const trackPageView = url => {
+  try {
+    // eslint-disable-next-line
+    window.gtag('config', GA_ID, {
+      page_location: url,
+    });
+  } catch (error) {
+    // silence possible errors
+  }
+};
+
+export const trackEvent = (eventName, label) => {
+  try {
+    // eslint-disable-next-line
+    window.gtag('event', eventName, {
+      send_to: GA_ID,
+      event_category: 'general',
+      event_label: label,
+    });
+  } catch (error) {
+    // silence possible errors
+  }
+};

--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -12,11 +12,18 @@ import {LightTheme, ThemeProvider} from 'baseui';
 import App, {Container} from 'next/app';
 import {Provider as StyletronProvider} from 'styletron-react';
 import {Block} from 'baseui/block';
+import Router from 'next/router';
 
 import {styletron} from '../helpers/styletron';
+import {trackPageView} from '../helpers/ga';
 import '../prism-coy.css';
 
 export default class MyApp extends App {
+  componentDidMount() {
+    Router.onRouteChangeComplete = url => {
+      trackPageView(url);
+    };
+  }
   render() {
     const {Component, pageProps} = this.props;
     return (

--- a/documentation-site/pages/_document.js
+++ b/documentation-site/pages/_document.js
@@ -13,6 +13,7 @@ import {Provider as StyletronProvider} from 'styletron-react';
 
 import Meta from '../components/meta';
 import {styletron} from '../helpers/styletron';
+import {GA_ID} from '../helpers/ga';
 
 export default class MyDocument extends Document {
   static getInitialProps(props) {
@@ -22,8 +23,22 @@ export default class MyDocument extends Document {
       </StyletronProvider>
     ));
     const stylesheets = styletron.getStylesheets() || [];
-    return {...page, stylesheets};
+    // eslint-disable-next-line cup/no-undef
+    const isProduction = process.env.NODE_ENV === 'production';
+    return {...page, stylesheets, isProduction};
   }
+
+  setGoogleTags() {
+    return {
+      __html: `
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', '${GA_ID}');
+      `,
+    };
+  }
+
   render() {
     return (
       <html lang="en">
@@ -49,6 +64,15 @@ export default class MyDocument extends Document {
         <body>
           <Main />
           <NextScript />
+          {this.props.isProduction && (
+            <React.Fragment>
+              <script
+                async
+                src={`https://www.googletagmanager.com/gtag/js?id=${GA_ID}`}
+              />
+              <script dangerouslySetInnerHTML={this.setGoogleTags()} />
+            </React.Fragment>
+          )}
         </body>
       </html>
     );


### PR DESCRIPTION
This PR adds Google Analytics tracking to the **baseui.design** property. It tracks:

- page views
- when user opens the top component popover
- when user clicks "Show source" + what example it is
- when user clicks "Copy to clipboard" + what example it is
- when CodeSandbox example is deployed + what example it is + did it error out?
- when user inspects overrides + what component + sub-component is being tested
- when algolia search is being made

enabled only in production build.