### PR TITLE
test(e2e): adds accordion a11y test

### DIFF
--- a/src/accordion/styled-components.js
+++ b/src/accordion/styled-components.js
@@ -20,7 +20,7 @@ export const PanelContainer = styled('div', (props: SharedStylePropsT) => {
   return {width: '100%'};
 });
 
-export const Header = styled('h3', (props: SharedStylePropsT) => {
+export const Header = styled('div', (props: SharedStylePropsT) => {
   const {
     $disabled,
     $expanded,


### PR DESCRIPTION
#### Description

Adds a11y test for accordion. This required changing an element from an `h3` to a `div` because `button` is not an appropriate `role` for an `h3` element.

