### PR TITLE
react-movable v2 upgrade

### DIFF
--- a/documentation-site/pages/components/dnd-list.mdx
+++ b/documentation-site/pages/components/dnd-list.mdx
@@ -30,21 +30,40 @@ Allows users to create vertically sortable lists supporting drag and drop, touch
 
 - When a user wants to change a collection order.
 
+### Accessibility
+
+- `tab` and `shift+tab` to focus items
+- `space` to `lift` or drop the item
+- `j` or `arrow down` to move the lifted item down
+- `k` or `arrow up` to move the lifted item up
+- `escape` to cancel the lift and return the item to its initial position
+
+This component also supports iOS and Android browsers and screen readers.
+
 ## Examples
 
 <Example title="Drag and Drop basic usage" path="examples/dnd-list/basic.js">
   <Basic />
 </Example>
 
-<Example title="Drag and Drop stateless usage" path="examples/dnd-list/stateless.js">
+<Example
+  title="Drag and Drop stateless usage"
+  path="examples/dnd-list/stateless.js"
+>
   <Stateless />
 </Example>
 
-<Example title="Drag and Drop with removable items" path="examples/dnd-list/removable.js">
+<Example
+  title="Drag and Drop with removable items"
+  path="examples/dnd-list/removable.js"
+>
   <Removable />
 </Example>
 
-<Example title="Drag and Drop with varying heights" path="examples/dnd-list/varyingHeights.js">
+<Example
+  title="Drag and Drop with varying heights"
+  path="examples/dnd-list/varyingHeights.js"
+>
   <VaryingHeights />
 </Example>
 
@@ -55,7 +74,10 @@ Allows users to create vertically sortable lists supporting drag and drop, touch
   <CustomDragHandle />
 </Example>
 
-<Example title="Drag and Drop with label override" path="examples/dnd-list/overrideLabel.js">
+<Example
+  title="Drag and Drop with label override"
+  path="examples/dnd-list/overrideLabel.js"
+>
   <OverrideLabel />
 </Example>
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "popper.js": "^1.14.3",
     "react-dropzone": "^8.0.0",
     "react-input-mask": "^2.0.4",
-    "react-movable": "^1.0.1",
+    "react-movable": "^2.0.0",
     "react-range": "^1.0.4",
     "smoothscroll-polyfill": "^0.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "popper.js": "^1.14.3",
     "react-dropzone": "^8.0.0",
     "react-input-mask": "^2.0.4",
-    "react-movable": "^2.0.0",
+    "react-movable": "^2.0.1",
     "react-range": "^1.0.4",
     "smoothscroll-polyfill": "^0.4.3"
   },

--- a/src/dnd-list/list.js
+++ b/src/dnd-list/list.js
@@ -79,8 +79,6 @@ class StatelessList extends React.Component<ListPropsT> {
                 tabIndex={props.tabIndex}
                 aria-roledescription={props['aria-roledescription']}
                 onKeyDown={props.onKeyDown}
-                onMouseDown={props.onMouseDown}
-                onTouchStart={props.onTouchStart}
                 onWheel={props.onWheel}
                 {...itemProps}
                 style={{...props.style, display: 'flex'}}
@@ -94,10 +92,12 @@ class StatelessList extends React.Component<ListPropsT> {
                 {removable && (
                   <CloseHandle
                     {...sharedProps}
-                    onMouseDown={e => e.stopPropagation()}
-                    onTouchStart={e => e.stopPropagation()}
                     onClick={() =>
-                      onChange && onChange({oldIndex: index, newIndex: -1})
+                      onChange &&
+                      onChange({
+                        oldIndex: typeof index !== 'undefined' ? index : 0,
+                        newIndex: -1,
+                      })
                     }
                     {...closeHandleProps}
                   >

--- a/src/dnd-list/types.js
+++ b/src/dnd-list/types.js
@@ -40,7 +40,7 @@ export type ListPropsT = {|
   /** Items (labels) to be rendered */
   items: Array<React.Node>,
   /** Handler for when drag and drop is finished and order changed or item is deleted (newIndex would be -1 in that case) */
-  onChange?: ({oldIndex: number, newIndex: number}) => mixed,
+  onChange: ({oldIndex: number, newIndex: number}) => void,
   overrides?: OverridesT,
 |};
 

--- a/src/dnd-list/types.js
+++ b/src/dnd-list/types.js
@@ -40,7 +40,7 @@ export type ListPropsT = {|
   /** Items (labels) to be rendered */
   items: Array<React.Node>,
   /** Handler for when drag and drop is finished and order changed or item is deleted (newIndex would be -1 in that case) */
-  onChange: ({oldIndex: number, newIndex: number}) => void,
+  onChange: ({oldIndex: number, newIndex: number}) => mixed,
   overrides?: OverridesT,
 |};
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -12031,10 +12031,10 @@ react-modal@^3.6.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-movable@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/react-movable/-/react-movable-1.0.1.tgz#b9a967a90e9f51d3bbe9e83047e5e336dbd94735"
-  integrity sha512-rebw6Q4uagXSG53o03+39pHQEfgGgJvVtsAj1DoXAHkBObswGhJELITaRGRuz00Myvj2AiP1YPgVePLM66LdNA==
+react-movable@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-movable/-/react-movable-2.0.0.tgz#b433aa8aa7ae1d06353361ba26d5707f65cff549"
+  integrity sha512-dkbOlLpDPTjOCzWrM90NG5U87BVbLpQdTljiwzaXzxa9O/yO0UsI9nEqx5DG0U62h9/YRVwjncv/NSsHKzsX5Q==
 
 react-node-resolver@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -12031,10 +12031,10 @@ react-modal@^3.6.1:
     react-lifecycles-compat "^3.0.0"
     warning "^3.0.0"
 
-react-movable@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-movable/-/react-movable-2.0.0.tgz#b433aa8aa7ae1d06353361ba26d5707f65cff549"
-  integrity sha512-dkbOlLpDPTjOCzWrM90NG5U87BVbLpQdTljiwzaXzxa9O/yO0UsI9nEqx5DG0U62h9/YRVwjncv/NSsHKzsX5Q==
+react-movable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-movable/-/react-movable-2.0.1.tgz#0293bef67854cc22e288d245d813963451476663"
+  integrity sha512-zOW/K7iXcJyKF0+D54R6fJCHyDfXPRWwk2H9W/N9YCGBrK/Nw/QWxQBn8AynupBikY0J+HMSlqs8cqIwjiZWzQ==
 
 react-node-resolver@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
It brings much better [support for iOS Safari](https://github.com/tajo/react-movable/releases/tag/v2.0.0) and there is no need to `stopPropagation` for remove handle.

Also, underlying flow types are now correctly linked, so some updates were necessary to fix it for baseui.