### PR TITLE
chore(button-group): deprecate kind prop

### DIFF
--- a/docs/migrations/00874.md
+++ b/docs/migrations/00874.md
@@ -1,0 +1,12 @@
+# Purpose
+
+The button-group now only supports one 'kind' value (tertiary). 'kind' is no longer an available prop
+on the `ButtonGroup` component. Alternate kinds had coloring issues where users were unable to distinguish
+between the focused and selected states when operating as a radio group.
+
+## ButtonGroup
+
+```diff
+- <ButtonGroup kind="primary" />
++ <ButtonGroup  />
+```

--- a/src/button-group/README.md
+++ b/src/button-group/README.md
@@ -91,9 +91,6 @@ export default class MyCustomLogic extends React.Component {
 * `shape?: SHAPE[string] = 'default'`
   * Reference [`SHAPE` constant](https://github.com/uber-web/baseui/blob/master/src/button/constants.js)
   * Defines the shape of the buttons in the button group.
-* `kind?: KIND[string] = 'secondary'`
-  * Reference [`KIND` constant](https://github.com/uber-web/baseui/blob/master/src/button/constants.js)
-  * Defines the kind (purpose) of the buttons in the button group.
 * `onClick?: (event: Event, index: number) => mixed`
   * Called with click events from children. If a child button has its own click handler, the local handler will be called first, then this handler will trigger.
 

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -53,17 +53,6 @@ export default function ButtonGroup(props: PropsT) {
   const {overrides = {}} = props;
   const [Root, rootProps] = getOverrides(overrides.Root, StyledRoot);
 
-  if (__DEV__) {
-    if (props.kind !== KIND.tertiary) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `ButtonGroup kind prop will no longer be supported in future major versions of base ui
-         because only a single color variant is supported in designs. Please update your code
-         to remove the kind prop.`,
-      );
-    }
-  }
-
   return (
     <Root aria-label={props.ariaLabel} {...rootProps}>
       {React.Children.map(props.children, (child, index) => {
@@ -74,7 +63,7 @@ export default function ButtonGroup(props: PropsT) {
         return React.cloneElement(child, {
           disabled: props.disabled ? true : child.props.disabled,
           isSelected: isSelected(props.selected, index),
-          kind: props.kind,
+          kind: KIND.tertiary,
           onClick: event => {
             if (props.disabled) {
               return;
@@ -103,7 +92,6 @@ export default function ButtonGroup(props: PropsT) {
 ButtonGroup.defaultProps = {
   ariaLabel: 'button group',
   disabled: false,
-  kind: KIND.tertiary,
   onClick: () => {},
   shape: SHAPE.default,
   size: SIZE.default,

--- a/src/button-group/types.js
+++ b/src/button-group/types.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 
-import {KIND, SIZE, SHAPE} from '../button/index.js';
+import {SIZE, SHAPE} from '../button/index.js';
 import type {OverrideT} from '../helpers/overrides.js';
 import type {ThemeT} from '../styles/index.js';
 
@@ -27,8 +27,6 @@ export type PropsT = {|
   children: Array<React.Node>,
   /** Defines if the button group is disabled. */
   disabled?: boolean,
-  /** Defines the kind (purpose) of the buttons in the button group. */
-  kind?: $Values<typeof KIND>,
   /**
    * Use the `mode` prop to render toggleable Buttons:
    * the value `radio` will cause Buttons to behave like radio buttons,


### PR DESCRIPTION
#### Description

deprecates the `kind` prop from `button-group`. design only wants a single option here

#### Scope

- [x] Major: Breaking Change
