### PR TITLE
chore(table): removes styledcontent component

### DIFF
--- a/docs/migrations/00875.md
+++ b/docs/migrations/00875.md
@@ -1,0 +1,31 @@
+# Purpose
+
+The `StyledContent` component caused issues when only a few rows were rendered in the table. The Table
+component was refactored in a way that no longer uses the `StyledContent` compnent. Your code may have previously
+depended on this component, but should be changed to the pattern outlined below.
+
+## Table
+
+```diff
+<StyledTable>
+  <StyledHead>
+    {columns.map((column, index) => (
+      <StyledHeadCell key={index}>
+        {column}
+      </StyledHeadCell>
+    ))}
+  </StyledHead>
+
+- <StyledContent>
+  <StyledBody>
+    {filteredData.map((row, index) => (
+      <StyledRow key={index}>
+        {row.map((cell, cellIndex) => (
+          <StyledCell key={cellIndex}>{cell}</StyledCell>
+        ))}
+      </StyledRow>
+    ))}
+   </StyledBody>
+-  </StyledContent>
+</StyledTable>
+```

--- a/src/table/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/table/__tests__/__snapshots__/styled-components.test.js.snap
@@ -23,8 +23,6 @@ Object {
 }
 `;
 
-exports[`Table styled components $width property: StyledContent has expected styles when $width property defined 1`] = `Object {}`;
-
 exports[`Table styled components $width property: StyledHead has expected styles when $width property defined 1`] = `
 Object {
   "backgroundColor": "$theme.colors.tableHeadBackgroundColor",
@@ -101,8 +99,6 @@ Object {
   "paddingTop": "$theme.sizing.scale300",
 }
 `;
-
-exports[`Table styled components default properties: StyledContent has expected default styles 1`] = `Object {}`;
 
 exports[`Table styled components default properties: StyledHead has expected default styles 1`] = `
 Object {

--- a/src/table/__tests__/styled-components.test.js
+++ b/src/table/__tests__/styled-components.test.js
@@ -10,7 +10,6 @@ import React from 'react';
 import {shallow} from 'enzyme';
 import {
   StyledTable,
-  StyledContent,
   StyledHead,
   StyledHeadCell,
   StyledBody,
@@ -21,7 +20,6 @@ import {
 describe('Table styled components', () => {
   const styledComponents = [
     [StyledTable, 'StyledTable'],
-    [StyledContent, 'StyledContent'],
     [StyledHead, 'StyledHead'],
     [StyledHeadCell, 'StyledHeadCell'],
     [StyledBody, 'StyledBody'],

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -9,7 +9,6 @@ export {default as Table} from './table.js';
 // Styled elements
 export {
   StyledTable,
-  StyledContent, // remove StyledContent in the next major version
   StyledHead,
   StyledHeadCell,
   StyledBody,

--- a/src/table/styled-components.js
+++ b/src/table/styled-components.js
@@ -24,8 +24,6 @@ type HorizontalStyleProps = {
   $width?: string,
 };
 
-export const StyledContent = styled('div');
-
 export const StyledHead = styled(
   'div',
   ({$theme, $width}: HorizontalStyleProps) => {


### PR DESCRIPTION
#### Description

this `styled` component is no longer used

#### Scope

- [x] Major: Breaking Change
