### PR TITLE
fix(datepicker): remove padding in the select dropdown container

### DIFF
--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -194,6 +194,14 @@ export default class CalendarHeader extends React.Component<HeaderPropsT> {
           paddingRight: '0',
         }),
       },
+      DropdownContainer: {
+        style: {
+          paddingTop: '0',
+          paddingBottom: '0',
+          paddingLeft: '0',
+          paddingRight: '0',
+        },
+      },
     };
   }
 


### PR DESCRIPTION
<img width="272" alt="screen shot 2019-02-14 at 10 15 15 am" src="https://user-images.githubusercontent.com/1920399/52807835-75456380-3041-11e9-98e4-c3dec3139d0b.png">
