### PR TITLE
fix: ensures consistent date in calendar screener

### DIFF
--- a/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
@@ -37,7 +37,7 @@ const arrowBtnOverrides = ({$theme}) => ({
 
 export const component = () => (
   <StatefulCalendar
-    initialState={{value: new Date('2018-02-14T10:00:00Z')}}
+    initialState={{value: new Date('2019-02-14T10:00:00Z')}}
     overrides={{
       CalendarHeader: {
         style: ({$theme}) => ({

--- a/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
@@ -37,7 +37,7 @@ const arrowBtnOverrides = ({$theme}) => ({
 
 export const component = () => (
   <StatefulCalendar
-    initialState={{value: new Date()}}
+    initialState={{value: new Date('2018-02-14T10:00:00Z')}}
     overrides={{
       CalendarHeader: {
         style: ({$theme}) => ({

--- a/src/datepicker/__tests__/stateful-calendar.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar.scenario.js
@@ -13,5 +13,5 @@ import {Unstable_StatefulCalendar as StatefulCalendar} from '../index.js';
 export const name = 'Stateful calendar';
 
 export const component = () => (
-  <StatefulCalendar highlightedDate={new Date('2018-02-14T10:00:00Z')} />
+  <StatefulCalendar highlightedDate={new Date('2019-02-14T10:00:00Z')} />
 );

--- a/src/datepicker/__tests__/stateful-calendar.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar.scenario.js
@@ -12,4 +12,6 @@ import {Unstable_StatefulCalendar as StatefulCalendar} from '../index.js';
 
 export const name = 'Stateful calendar';
 
-export const component = () => <StatefulCalendar />;
+export const component = () => (
+  <StatefulCalendar highlightedDate={new Date('2018-02-14T10:00:00Z')} />
+);

--- a/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
@@ -13,7 +13,7 @@ import {addDays} from '../utils/index.js';
 
 export const name = 'Stateful datepicker quick select';
 
-const now = new Date('2018-02-14T10:00:00Z');
+const now = new Date('2019-02-14T10:00:00Z');
 
 export const component = () => (
   <StatefulDatepicker

--- a/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
@@ -13,10 +13,14 @@ import {addDays} from '../utils/index.js';
 
 export const name = 'Stateful datepicker quick select';
 
+const now = new Date('2018-02-14T10:00:00Z');
+
 export const component = () => (
   <StatefulDatepicker
     isRange
-    initialState={{value: [new Date(), addDays(new Date(), 3)]}}
+    initialState={{
+      value: [now, addDays(now, 3)],
+    }}
     enableQuickSelect
   />
 );

--- a/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
@@ -12,4 +12,10 @@ import {Unstable_StatefulCalendar as StatefulCalendar} from '../index.js';
 
 export const name = 'Stateful range quick select';
 
-export const component = () => <StatefulCalendar isRange enableQuickSelect />;
+export const component = () => (
+  <StatefulCalendar
+    isRange
+    enableQuickSelect
+    highlightedDate={new Date('2018-02-14T10:00:00Z')}
+  />
+);

--- a/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
@@ -16,6 +16,6 @@ export const component = () => (
   <StatefulCalendar
     isRange
     enableQuickSelect
-    highlightedDate={new Date('2018-02-14T10:00:00Z')}
+    highlightedDate={new Date('2019-02-14T10:00:00Z')}
   />
 );


### PR DESCRIPTION
#### Description

screener was failing on mismatched dates (the scenarios were running based on the current date)
<img width="1656" alt="screen shot 2019-02-15 at 10 15 49 am" src="https://user-images.githubusercontent.com/5317799/52876037-c3726980-310a-11e9-80a7-3b9ff12915c0.png">

#### Scope

- [x] Patch: Bug Fix

