### PR TITLE
feat(docs-site): adds an alias mapping to commit hash

### DIFF
--- a/scripts/now-deploy.sh
+++ b/scripts/now-deploy.sh
@@ -9,9 +9,6 @@ this_commit=$(echo $BUILDKITE_COMMIT | tr -d '"')
 tags=$(curl https://api.github.com/repos/uber-web/baseui/git/refs/tags?access_token=${GITHUB_AUTH_TOKEN})
 latest_tagged_commit=$(echo $tags | jq '.[-1].object.sha' | tr -d '"')
 
-echo this commit: $this_commit
-echo latest tagged commit: $latest_tagged_commit
-
 if [ "$this_commit" = "$latest_tagged_commit" ]; then
   echo current commit matches latest tagged commit
   echo deploying to now...
@@ -19,7 +16,9 @@ if [ "$this_commit" = "$latest_tagged_commit" ]; then
   yarn documentation:build &&
   yarn now --team=baseui --token=$ZEIT_NOW_TOKEN &&
   yarn now alias --team=baseui --token=$ZEIT_NOW_TOKEN &&
-  yarn now rm baseui-documentation --safe --team=baseui --token=$ZEIT_NOW_TOKEN  --yes
+
+  # sets an alias based on the commit hash so that we have a snapshot of what the docs site looked like at this version.
+  yarn now alias --team=baseui --token=$ZEIT_NOW_TOKEN "${latest_tagged_commit}-baseui-documentation"
 else
   echo current commit does not match latest tagged commit
   echo exited without deploying to now


### PR DESCRIPTION
#### Description

_Developers using the project find it hard to know what features are unavailable in older package versions based on the documentation site. This is because we only publish the most up to date documentation._

Idea for how to keep a log of docs site versions. 

In addition to updating the alias to the most up-to-date site, we can maintain an alias to older deployments based on commit hash. To map releases to deployments, we can first request from github the [list of tags](https://developer.github.com/v3/git/refs/#get-all-references)  (which include the commit hash). On zeit's side we can request for [aliases](https://zeit.co/docs/api#endpoints/aliases) we have, then do a merge on matches. I looked at the way react handles keeping docs around and it seems like they are doing something similar with netlify. Check out the list on their [docs site](https://reactjs.org/versions/) and notice the url for an [older site](https://5c54aa429e16c80007af3cd2--reactjs.netlify.com/).

This PR in particular edits the deployment script so that it will also add the hash alias, updates to the docs site will need to be made so that we can render the information