### PR TITLE
fix(accordion): now accepts expanded props per API (#945)

### DIFF
--- a/src/accordion/stateful-panel-container.js
+++ b/src/accordion/stateful-panel-container.js
@@ -50,8 +50,8 @@ class StatefulPanelContainer extends React.Component<
     const {children, initialState, stateReducer, ...rest} = this.props;
 
     return this.props.children({
-      ...rest,
       ...this.state,
+      ...rest,
       onChange: this.onChange,
     });
   }


### PR DESCRIPTION
Fixes #945  <!-- remove the (`) quotes to link the issues -->

#### Description
Expanded props when passed to StatefulPanel did not behave according to the API docs.
<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
