### PR TITLE
docs: update the installation page

### DIFF
--- a/documentation-site/pages/getting-started/installation.mdx
+++ b/documentation-site/pages/getting-started/installation.mdx
@@ -11,23 +11,25 @@ export default Layout;
 
 # Installing Base UI
 
-Base UI is available on [npm](https://npmjs.com/package/baseui).
+Base UI is available on [npm](https://npmjs.com/package/baseui). This single package contains all Base UI components.
 
 ```bash
 # using yarn
-yarn add baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
+yarn add baseui styletron-engine-atomic styletron-react
 
 # using npm
-npm install baseui styletron-react styletron-react-core styletron-standard styletron-engine-atomic
+npm install baseui styletron-engine-atomic styletron-react
 ```
 
-[Styletron](https://styletron.js.org/) is a toolkit for component-oriented styling, part of the CSS in JS family. Base UI uses
-Styletron as a peer dependency to style all the elements, so you need to add them as dependencies too.
+[Styletron](https://styletron.js.org/) is a toolkit for component-oriented styling, part of the CSS in JS family. Base UI uses Styletron as a peer dependency to style all the elements, so you need to add them as dependencies too.
+
+**The next step is to setup Styletron in your application.** There are [detailed guides](https://styletron.js.org/getting-started/) for Fusion.js, Next.js, Gatsby and general React applications.
 
 ## With Fusion.js
 
-If you are building a web application on top of [Fusion.js](https://fusionjs.com/), all you have to install is the
-`fusion-plugin-styletron-react` plugin, and register the plugin.
+If you are building a web application on top of [Fusion.js](https://fusionjs.com/), you have to install `fusion-plugin-styletron-react` and `styletron-react`, and register the `fusion-plugin-styletron-react` plugin. It might be installed already if you bootstrapped your Fusion application.
+
+### Adding dependencies
 
 ```bash
 # using yarn
@@ -37,24 +39,24 @@ yarn add baseui fusion-plugin-styletron-react styletron-react
 npm install baseui fusion-plugin-styletron-react styletron-react
 ```
 
+### Registering the plugin
+
 ```javascript
 // src/main.js
 import App from 'fusion-react';
 import Styletron from 'fusion-plugin-styletron-react';
-
 import root from './components/root';
 
 export default () => {
   const app = new App(root);
-
   app.register(Styletron);
-
   return app;
-}
+};
 ```
 
-For more information, check out the documentation site for
-[fusion-plugin-styletron-react](https://fusionjs.com/api/fusion-plugin-styletron-react).
+For more information, check out the documentation site for [fusion-plugin-styletron-react](https://fusionjs.com/api/fusion-plugin-styletron-react).
+
+Do you want to learn more about Styletron? Go to [styletron.js.org](https://styletron.js.org/).
 
 # Next step
 


### PR DESCRIPTION
- `styletron-react-core` is a legacy version of `styletron-react`, should not be installed
- `styletron-standard` is a dep of `styletron-react`, no need to install separately
- adding links to styletron.js.org

**DON'T merge until styletron.js.org goes alive**