### PR TITLE
fix(avatar): handle transparent avatar images

### DIFF
--- a/src/avatar/__tests__/__snapshots__/styled-components.test.js.snap
+++ b/src/avatar/__tests__/__snapshots__/styled-components.test.js.snap
@@ -23,7 +23,7 @@ Object {
 
 exports[`Avatar styled components default properties: StyledRoot has expected default styles 1`] = `
 Object {
-  "backgroundColor": "$theme.colors.primary",
+  "backgroundColor": null,
   "borderRadius": "50%",
   "boxSizing": "border-box",
   "display": "inline-block",
@@ -44,7 +44,7 @@ Object {
 
 exports[`Avatar styled components non-default size: StyledRoot has expected styles with non-default size 1`] = `
 Object {
-  "backgroundColor": "$theme.colors.primary",
+  "backgroundColor": null,
   "borderRadius": "50%",
   "boxSizing": "border-box",
   "display": "inline-block",

--- a/src/avatar/styled-components.js
+++ b/src/avatar/styled-components.js
@@ -43,7 +43,7 @@ export const Root = styled('div', (props: StylePropsT) => {
   const themedSize = getSize(props);
 
   return {
-    backgroundColor: props.$theme.colors.primary,
+    backgroundColor: $didImageFailToLoad ? props.$theme.colors.primary : null,
     borderRadius: '50%',
     boxSizing: 'border-box',
     display: 'inline-block',


### PR DESCRIPTION
handles the transparent image issue that was apparent in the contributors list

<img width="764" alt="screen shot 2019-02-26 at 5 05 58 pm" src="https://user-images.githubusercontent.com/5317799/53457924-dcbbc580-39e8-11e9-9ad2-70b0fb26539b.png">
