### PR TITLE
docs: fix API doc headings and StatefulTab examples

### DIFF
--- a/documentation-site/components/api.js
+++ b/documentation-site/components/api.js
@@ -10,17 +10,17 @@ import React from 'react';
 import Props from 'pretty-proptypes';
 
 import {Block} from 'baseui/block';
-import {Button, SIZE as ButtonSize} from 'baseui/button';
-import {Paragraph1, H4} from 'baseui/typography';
-import Anchor from './anchor';
+import {Button, SIZE as ButtonSize, KIND as ButtonKind} from 'baseui/button';
+import {Paragraph1} from 'baseui/typography';
+import {Heading} from './markdown-elements';
 
 const API = props => {
   const {heading, api} = props;
   return (
     <React.Fragment>
-      <H4>
-        <Anchor>{heading}</Anchor>
-      </H4>
+      <Heading element="h3" fontType="font600">
+        {heading}
+      </Heading>
       <Props
         props={api}
         heading={' '}
@@ -31,7 +31,11 @@ const API = props => {
           },
           Button: props => {
             return (
-              <Button {...props} size={ButtonSize.compact}>
+              <Button
+                {...props}
+                size={ButtonSize.compact}
+                kind={ButtonKind.tertiary}
+              >
                 {props.children}
               </Button>
             );

--- a/documentation-site/pages/components/tabs.mdx
+++ b/documentation-site/pages/components/tabs.mdx
@@ -50,7 +50,7 @@ The Tab component is used for navigating frequently accessed, but distinct categ
   name="Tabs"
   component={TabsExports}
   renderExample={props => (
-    <StatefulTabs activeKey="1" overrides={props.overrides}>
+    <StatefulTabs initialState={{activeKey: '0'}} overrides={props.overrides}>
       <TabPanel overrides={props.overrides} title="Tab Link 1">
         Tab 1 content
       </TabPanel>

--- a/documentation-site/static/examples/tabs/basic.js
+++ b/documentation-site/static/examples/tabs/basic.js
@@ -2,7 +2,7 @@ import React from 'react';
 import {StatefulTabs, TabPanel} from 'baseui/tabs';
 
 export default () => (
-  <StatefulTabs activeKey="1">
+  <StatefulTabs initialState={{activeKey: '0'}}>
     <TabPanel title="Tab Link 1">Tab 1 content</TabPanel>
     <TabPanel title="Tab Link 2">Tab 2 content</TabPanel>
     <TabPanel title="Tab Link 3">Tab 3 content</TabPanel>

--- a/documentation-site/static/examples/tabs/vertical.js
+++ b/documentation-site/static/examples/tabs/vertical.js
@@ -2,7 +2,10 @@ import React from 'react';
 import {StatefulTabs, TabPanel, ORIENTATION} from 'baseui/tabs';
 
 export default () => (
-  <StatefulTabs orientation={ORIENTATION.vertical} activeKey="1">
+  <StatefulTabs
+    orientation={ORIENTATION.vertical}
+    initialState={{activeKey: '2'}}
+  >
     <TabPanel title="Tab Link 1">Tab 1 content</TabPanel>
     <TabPanel title="Tab Link 2">Tab 2 content</TabPanel>
     <TabPanel title="Tab Link 3">Tab 3 content</TabPanel>


### PR DESCRIPTION
## API Docs

Fix to use the new `Heading` component. I've also changed the expand buttons from `primary` to `tertiary` since they were too "loud".

<img width="513" alt="screen shot 2019-02-28 at 11 23 37 am" src="https://user-images.githubusercontent.com/1387913/53592807-e3168280-3b4b-11e9-9816-6f5f1847fef2.png">

## StatefulTab examples

`activeKey` doesn't exist, `initialState={{ activeKey }}` is the right way.
