### PR TITLE
fix(menu): add marginBottom: 0 for list items

### DIFF
--- a/src/menu/styled-components.js
+++ b/src/menu/styled-components.js
@@ -56,6 +56,7 @@ export const ListItem = styled(
     ':hover': {
       backgroundColor: $theme.colors.menuFillHover,
     },
+    marginBottom: '0',
     paddingTop:
       $size === OPTION_LIST_SIZE.compact
         ? $theme.sizing.scale100


### PR DESCRIPTION
#### Description

Some CSS libraries/UI kits add a bottom margin to list items by default (I know it's a bad practice).
Set this up so the menu items don't look wonky when using it with those libraries, to aid users who are migrating off other UI kits.

#### Scope

- [X] Patch: Bug Fix
