### PR TITLE
fix(breadcrumbs): key prop

### DIFF
--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
@@ -10,7 +10,7 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
     Parent Page
   </MockStyledComponent>
   <MockStyledComponent
-    key="0"
+    key="separator-0"
   >
     <MockStyledComponent />
   </MockStyledComponent>
@@ -20,7 +20,7 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
     Sub-Parent Page
   </MockStyledComponent>
   <MockStyledComponent
-    key="1"
+    key="separator-1"
   >
     <MockStyledComponent />
   </MockStyledComponent>

--- a/src/breadcrumbs/breadcrumbs.js
+++ b/src/breadcrumbs/breadcrumbs.js
@@ -33,7 +33,7 @@ export function BreadcrumbsRoot(props: {|...BreadcrumbsPropsT, ...LocaleT|}) {
 
     if (index !== numChildren - 1) {
       childrenWithSeparators.push(
-        <Separator {...baseSeparatorProps} key={index}>
+        <Separator {...baseSeparatorProps} key={`separator-${index}`}>
           <Icon {...baseIconProps} />
         </Separator>,
       );


### PR DESCRIPTION
closes  https://github.com/uber-web/baseui/issues/969

fixes https://medium.com/@robinpokorny/index-as-a-key-is-an-anti-pattern-e0349aece318