### PR TITLE
docs: spacing improvements

### DIFF
--- a/documentation-site/components/api.js
+++ b/documentation-site/components/api.js
@@ -19,77 +19,79 @@ const API = props => {
   return (
     <React.Fragment>
       <H2>{heading}</H2>
-      <Props
-        props={api}
-        heading={' '}
-        shouldCollapseProps={true}
-        components={{
-          Description: props => {
-            return <Paragraph1>{props.children}</Paragraph1>;
-          },
-          Button: props => {
-            return (
-              <Button
-                {...props}
-                size={ButtonSize.compact}
-                kind={ButtonKind.tertiary}
-              >
-                {props.children}
-              </Button>
-            );
-          },
-          Indent: props => {
-            return (
-              <Block
-                overrides={{
-                  Block: {
-                    style: ({$theme}) => ({
-                      paddingLeft: $theme.sizing.scale600,
-                    }),
-                  },
-                }}
-              >
-                {props.children}
-              </Block>
-            );
-          },
-          Required: props => {
-            return (
-              <Block as="span" color="negative">
-                {props.children}
-              </Block>
-            );
-          },
-          Type: props => {
-            return (
-              <Block as="span" color="primary">
-                {props.children}
-              </Block>
-            );
-          },
-          TypeMeta: props => {
-            return (
-              <Block as="span" color="warning400">
-                {props.children}
-              </Block>
-            );
-          },
-          FunctionType: props => {
-            return (
-              <Block as="span" color="positive700">
-                {props.children}
-              </Block>
-            );
-          },
-          StringType: props => {
-            return (
-              <Block as="span" color="positive">
-                {props.children}
-              </Block>
-            );
-          },
-        }}
-      />
+      <Block marginTop="-24px">
+        <Props
+          props={api}
+          heading={' '}
+          shouldCollapseProps={true}
+          components={{
+            Description: props => {
+              return <Paragraph1>{props.children}</Paragraph1>;
+            },
+            Button: props => {
+              return (
+                <Button
+                  {...props}
+                  size={ButtonSize.compact}
+                  kind={ButtonKind.secondary}
+                >
+                  {props.children}
+                </Button>
+              );
+            },
+            Indent: props => {
+              return (
+                <Block
+                  overrides={{
+                    Block: {
+                      style: ({$theme}) => ({
+                        paddingLeft: $theme.sizing.scale600,
+                      }),
+                    },
+                  }}
+                >
+                  {props.children}
+                </Block>
+              );
+            },
+            Required: props => {
+              return (
+                <Block as="span" color="negative">
+                  {props.children}
+                </Block>
+              );
+            },
+            Type: props => {
+              return (
+                <Block as="span" color="primary">
+                  {props.children}
+                </Block>
+              );
+            },
+            TypeMeta: props => {
+              return (
+                <Block as="span" color="warning400">
+                  {props.children}
+                </Block>
+              );
+            },
+            FunctionType: props => {
+              return (
+                <Block as="span" color="positive700">
+                  {props.children}
+                </Block>
+              );
+            },
+            StringType: props => {
+              return (
+                <Block as="span" color="positive">
+                  {props.children}
+                </Block>
+              );
+            },
+          }}
+        />
+      </Block>
     </React.Fragment>
   );
 };

--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 import CodeSandboxer from 'react-codesandboxer';
-import {Button, KIND} from 'baseui/button';
+import {Button, KIND, SIZE} from 'baseui/button';
 import {Card} from 'baseui/card';
 import {Block} from 'baseui/block';
 import {StyledLink} from 'baseui/link';
@@ -97,7 +97,8 @@ class Example extends React.Component<PropsT, StateT> {
 
         <Block paddingTop="scale400">
           <Button
-            kind={KIND.tertiary}
+            kind={KIND.secondary}
+            size={SIZE.compact}
             onClick={() => {
               this.setState(prevState => ({
                 isSourceOpen: !prevState.isSourceOpen,
@@ -139,7 +140,9 @@ class Example extends React.Component<PropsT, StateT> {
             >
               {() => (
                 <Link>
-                  <Button kind={KIND.tertiary}>Edit on CodeSandbox</Button>
+                  <Button kind={KIND.secondary} size={SIZE.compact}>
+                    Edit on CodeSandbox
+                  </Button>
                 </Link>
               )}
             </CodeSandboxer>

--- a/documentation-site/prism-coy.css
+++ b/documentation-site/prism-coy.css
@@ -7,7 +7,7 @@ https://prismjs.com/download.html#themes=prism-coy&languages=markup+css+clike+ja
  */
 
 h2 {
-  margin-top: 32px;
+  margin-top: 38px;
 }
 
 code[class*='language-'],


### PR DESCRIPTION
- increase the top margin of `<h2>`
- use the size compact, kind secondary for all action buttons (Show source code, CodeSandbox, Expand Prop Shape)
- Prop API docs should have the same spacing after their title as all other elements
