### PR TITLE
docs: fix typos and remove broken link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ This document helps you navigate the process.
 
 ## Contributing new components
 
-1.  Write a mini-RFC on the component you'd like to add, and send a PR. You can find [an example here](https://github.com/uber-web/baseui/tree/master/src/template-component/README.md).
+1.  Write a mini-RFC on the component you'd like to add, and send a PR.
 
 - It is ok, if your new component just implements the features you need, we may extend that later
 
@@ -31,7 +31,7 @@ This document helps you navigate the process.
 
 - You can find the component template in `src/template-component`
 - To make the review process fast, please try to send small PRs, if you can
-- All T0D0s in the code have to have a corresponding issue created. Refer to the created issue in the T0D0s following the format `// TOD0(#44): Something`
+- All TODOs in the code have to have a corresponding issue created. Refer to the created issue in the TODOs following the format `// TODO(#44): Something`
 
 3.  Once your implementation is merged, the baseui team will release it
 

--- a/documentation-site/pages/getting-started/learn.mdx
+++ b/documentation-site/pages/getting-started/learn.mdx
@@ -19,7 +19,7 @@ You can find the simple Base Web application example in the [Usage](/getting-sta
 
 ## Your next Base Web example
 
-A more complex application using Base Web can be found [here](https://github.com/tajo/fusion-baseui). It helps you build an applicatio
+A more complex application using Base Web can be found [here](https://github.com/tajo/fusion-baseui). It helps you build an application
 on top of Base Web, step by step.
 
 ## Next steps


### PR DESCRIPTION
#### Description
- fix typo in `learn.mdx`.
- fix typos in `CONTRIBUTING.md`. Not sure if `T0D0` is intentional though for CI.
- remove dead link in `CONTRIBUTING.md`.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
