### PR TITLE
fix(datepicker): safari stacked buttons

### DIFF
--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -424,6 +424,10 @@ export default class Calendar extends React.Component<
                     flexBasis: 0,
                     flexGrow: 1,
                     marginBottom: '8px',
+                    paddingLeft: 0,
+                    paddingRight: 0,
+                    marginLeft: 0,
+                    marginRight: 0,
                     minWidth: '142px',
                     ':nth-of-type(odd)': {
                       marginRight: '8px',


### PR DESCRIPTION
<img width="1792" alt="Screen Shot 2019-03-12 at 10 37 27 AM" src="https://user-images.githubusercontent.com/2174968/54222784-55c02000-44b3-11e9-92c7-62e5b3d04090.png">
