### PR TITLE
docs: add notes about longhand vs shorthand props

### DIFF
--- a/documentation-site/components/overrides.js
+++ b/documentation-site/components/overrides.js
@@ -84,6 +84,14 @@ class Overrides extends React.Component {
             },
           })}
         </Block>
+        <Block as="p" font="font400" marginTop="scale900">
+          <b>Note:</b> You should always use longhand CSS properties. Mixing
+          shorthands and longhands will lead into{' '}
+          <DocLink href="https://www.styletron.org/concepts/#shorthand-and-longhand-properties">
+            strange behaviors
+          </DocLink>
+          !
+        </Block>
       </React.Fragment>
     );
   }

--- a/documentation-site/pages/theming/understanding-overrides.mdx
+++ b/documentation-site/pages/theming/understanding-overrides.mdx
@@ -83,6 +83,8 @@ We defined `overrides.Label.style` and `overrides.Label.props` properties and th
 
 The `overrides.Label.style` property accepts a [style object](https://www.styletron.org/concepts/#style-object) or [style function](https://www.styletron.org/concepts/#style-function) since [Styletron](https://www.styletron.org) manages all Base Web styles.
 
+> **Caveat:** When using `overrides.foo.style`, you are overriding a set of existing CSS properties. **Our components always use longhand CSS properties and so should yours!** If you [mix shorthand and longhand properties](https://www.styletron.org/concepts/#shorthand-and-longhand-properties), you will see a warning and can run into strange behaviors!
+
 ## `$theme`
 
 If you opt-in for the [style function](https://www.styletron.org/concepts/#style-function), `overrides` provides a special prop called **`$theme`** that you can use. The `$theme` prop includes all Base Web [design constants](/theming/theming-values). So instead of the hard-coded value `#892C21`, you can use the theme:


### PR DESCRIPTION
There was some confusion about shorthand vs longhand CSS properties so I've added some description into the Understanding Overrides page and overrides inspector.