### PR TITLE
fix(table): updates example in table so smaller width works

### DIFF
--- a/documentation-site/static/examples/table/fixed-width-column.js
+++ b/documentation-site/static/examples/table/fixed-width-column.js
@@ -35,8 +35,7 @@ const SmallerHeadCell = styled(StyledHeadCell, {
 });
 
 const SmallerCell = styled(StyledCell, {
-  width: '30px',
-  flex: 0,
+  maxWidth: '30px',
 });
 
 export default () => (


### PR DESCRIPTION
Related Codesandbox https://codesandbox.io/s/p7zpq9qo7

#### Description

Fix example to show smaller width for cell in Documentation website

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
