### PR TITLE
feat(docs): add dark theme switcher

### DIFF
--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -87,6 +87,7 @@ class Example extends React.Component<PropsT, StateT> {
               marginBottom: 0,
               boxShadow: 'none',
               borderWidth: 0,
+              backgroundColor: $theme.colors.background,
             }),
           },
           Contents: {style: {margin: 0}},

--- a/documentation-site/components/layout.js
+++ b/documentation-site/components/layout.js
@@ -58,7 +58,19 @@ class Layout extends React.Component<PropsT, {sidebarOpen: boolean}> {
             this.setState(prevState => ({sidebarOpen: !prevState.sidebarOpen}))
           }
         />
-        <Block display="flex" paddingTop="scale400">
+        <Block
+          overrides={{
+            Block: {
+              style: ({$theme}) => ({
+                backgroundColor: $theme.colors.background,
+                color: $theme.colors.foreground,
+                marginTop: '8px',
+              }),
+            },
+          }}
+          display="flex"
+          paddingTop="scale400"
+        >
           <SidebarWrapper
             $isOpen={sidebarOpen}
             onClick={() => sidebarOpen && this.setState({sidebarOpen: false})}

--- a/documentation-site/components/markdown-elements.js
+++ b/documentation-site/components/markdown-elements.js
@@ -57,7 +57,7 @@ export const Heading = ({
       font={fontType}
       $ref={hoverRef}
       id={slug}
-      color="mono1000"
+      color="foreground"
     >
       <React.Fragment>
         {children}{' '}

--- a/documentation-site/components/nav-link.js
+++ b/documentation-site/components/nav-link.js
@@ -11,9 +11,9 @@ import {styled} from 'baseui';
 export default styled('a', ({$theme}) => ({
   textDecoration: 'none',
   cursor: 'pointer',
-  color: $theme.colors.black,
+  color: $theme.colors.foreground,
   ':visited': {
-    color: $theme.colors.black,
+    color: $theme.colors.foreground,
   },
   ':hover': {
     color: $theme.colors.primary,

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ export {LocaleProvider};
 export {
   createTheme,
   lightThemePrimitives,
+  DarkTheme,
+  DarkThemeMove,
   LightTheme,
   LightThemeMove,
 } from './themes/index.js';

--- a/src/themes/dark-theme-colors.js
+++ b/src/themes/dark-theme-colors.js
@@ -1,0 +1,132 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import {primitives} from './dark-theme-primitives.js';
+
+const WHITE = '#FFFFFF';
+
+export default {
+  colors: {
+    // Semantic Colors
+
+    // Font Color
+    colorPrimary: primitives.mono100,
+    colorSecondary: primitives.mono200,
+
+    // Background
+    background: primitives.mono800,
+    backgroundAlt: primitives.mono700,
+    backgroundInv: primitives.mono100,
+
+    // Foreground
+    foreground: primitives.mono100,
+    foregroundAlt: primitives.mono300,
+    foregroundInv: primitives.mono1000,
+
+    // Borders
+    border: primitives.mono600,
+    borderAlt: primitives.mono700,
+    borderFocus: primitives.primary400,
+    borderError: primitives.negative400,
+
+    // Buttons
+    buttonPrimaryFill: primitives.primary400,
+    buttonPrimaryText: '#FFFFFF',
+    buttonPrimaryHover: primitives.primary500,
+    buttonPrimaryActive: primitives.primary600,
+    buttonSecondaryFill: primitives.mono500,
+    buttonSecondaryText: primitives.mono100,
+    buttonSecondaryHover: primitives.mono400,
+    buttonSecondaryActive: primitives.mono300,
+    buttonTertiaryFill: primitives.mono700,
+    buttonTertiaryText: primitives.mono100,
+    buttonTertiaryHover: primitives.mono600,
+    buttonTertiaryActive: primitives.mono500,
+    buttonTertiarySelectedText: primitives.mono100,
+    buttonTertiarySelectedFill: primitives.primary400,
+    buttonMinimalFill: 'transparent',
+    buttonMinimalText: primitives.primary400,
+    buttonMinimalHover: primitives.mono600,
+    buttonMinimalActive: primitives.mono500,
+    buttonDisabledFill: primitives.mono700,
+    buttonDisabledText: primitives.mono500,
+
+    // Breadcrumbs
+    breadcrumbsText: primitives.mono100,
+    breadcrumbsSeparatorFill: primitives.mono200,
+
+    // FileUploader
+    fileUploaderBackgroundColor: primitives.mono700,
+    fileUploaderBackgroundColorActive: primitives.mono600,
+    fileUploaderBorderColorActive: primitives.primary400,
+    fileUploaderBorderColorDefault: primitives.mono500,
+    fileUploaderMessageColor: primitives.mono100,
+
+    // Links
+    linkText: primitives.primary300,
+    linkVisited: primitives.primary300,
+    linkHover: primitives.primary400,
+
+    // List
+    listHeaderFill: primitives.mono600,
+    listBodyFill: primitives.mono700,
+    listIconFill: primitives.mono100,
+    listBorder: primitives.mono500,
+
+    // Tag
+    tagBackground: primitives.mono1000,
+    tagNeutralBackground: primitives.mono600,
+    tagPrimaryBackground: primitives.primary500,
+    tagPositiveBackground: primitives.positive500,
+    tagWarningBackground: primitives.warning500,
+    tagNegativeBackground: primitives.negative500,
+
+    // Tick
+    tickFill: 'transparent',
+    tickFillHover: primitives.mono200,
+    tickFillActive: primitives.mono300,
+    tickFillSelected: primitives.primary400,
+    tickFillSelectedHover: primitives.primary500,
+    tickFillSelectedHoverActive: primitives.primary600,
+    tickFillDisabled: primitives.mono600,
+    tickBorder: primitives.mono400,
+    tickMarkFill: WHITE,
+
+    // Slider
+    sliderTrackFill: primitives.mono500,
+    sliderTrackFillHover: primitives.mono600,
+    sliderTrackFillActive: primitives.mono700,
+    sliderTrackFillSelected: primitives.primary700,
+    sliderTrackFillSelectedActive: primitives.primary700,
+    sliderTrackFillSelectedHover: primitives.primary700,
+    sliderTrackFillDisabled: primitives.mono600,
+    sliderHandleFill: primitives.mono300,
+    sliderHandleFillHover: primitives.mono300,
+    sliderHandleFillActive: primitives.mono300,
+    sliderHandleFillSelected: primitives.primary500,
+    sliderHandleFillSelectedHover: primitives.primary600,
+    sliderHandleFillSelectedActive: primitives.primary700,
+    sliderHandleFillDisabled: primitives.mono600,
+    sliderBorder: WHITE,
+    sliderBorderHover: WHITE,
+    sliderBorderDisabled: primitives.mono400,
+
+    // Input
+    inputFill: primitives.mono600,
+    inputFillEnhancer: primitives.mono500,
+    inputFillError: primitives.mono600,
+    inputFillDisabled: primitives.mono700,
+    inputTextDisabled: primitives.mono500,
+
+    // Menu
+    menuFillHover: primitives.mono600,
+  },
+  tooltip: {
+    backgroundColor: primitives.mono200,
+  },
+};

--- a/src/themes/dark-theme-with-move.js
+++ b/src/themes/dark-theme-with-move.js
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import createTheme from './creator.js';
+import {primitives as darkThemePrimitives} from './dark-theme-primitives.js';
+import colors from './dark-theme-colors.js';
+
+const primaryFontFamily =
+  'UberMoveText, system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif';
+
+const secondaryFontFamily =
+  'UberMove, UberMoveText, system-ui, "Helvetica Neue", Helvetica, Arial, sans-serif';
+
+export const DarkThemeMove = createTheme(
+  {
+    ...darkThemePrimitives,
+    primaryFontFamily,
+  },
+  {
+    ...colors,
+    typography: {
+      font250: {
+        fontWeight: 500,
+      },
+      font350: {
+        fontWeight: 500,
+      },
+      font450: {
+        fontWeight: 500,
+      },
+      font500: {
+        fontWeight: 500,
+      },
+      font600: {
+        fontWeight: 500,
+      },
+      font700: {
+        fontWeight: 500,
+      },
+      font800: {
+        fontWeight: 500,
+      },
+      font900: {
+        fontWeight: 500,
+      },
+      font1100: {
+        fontFamily: secondaryFontFamily,
+      },
+    },
+  },
+);

--- a/src/themes/dark-theme.js
+++ b/src/themes/dark-theme.js
@@ -7,131 +7,13 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import createTheme from './creator.js';
 import {primitives} from './dark-theme-primitives.js';
-
-const WHITE = '#FFFFFF';
+import colors from './dark-theme-colors.js';
 
 export const DarkTheme = createTheme(
   {
     ...primitives,
   },
   {
-    colors: {
-      // Semantic Colors
-
-      // Font Color
-      colorPrimary: primitives.mono100,
-      colorSecondary: primitives.mono200,
-
-      // Background
-      background: primitives.mono800,
-      backgroundAlt: primitives.mono700,
-      backgroundInv: primitives.mono100,
-
-      // Foreground
-      foreground: primitives.mono100,
-      foregroundAlt: primitives.mono300,
-      foregroundInv: primitives.mono1000,
-
-      // Borders
-      border: primitives.mono600,
-      borderAlt: primitives.mono700,
-      borderFocus: primitives.primary400,
-      borderError: primitives.negative400,
-
-      // Buttons
-      buttonPrimaryFill: primitives.primary400,
-      buttonPrimaryText: '#FFFFFF',
-      buttonPrimaryHover: primitives.primary500,
-      buttonPrimaryActive: primitives.primary600,
-      buttonSecondaryFill: primitives.mono500,
-      buttonSecondaryText: primitives.mono100,
-      buttonSecondaryHover: primitives.mono400,
-      buttonSecondaryActive: primitives.mono300,
-      buttonTertiaryFill: primitives.mono700,
-      buttonTertiaryText: primitives.mono100,
-      buttonTertiaryHover: primitives.mono600,
-      buttonTertiaryActive: primitives.mono500,
-      buttonTertiarySelectedText: primitives.mono100,
-      buttonTertiarySelectedFill: primitives.primary400,
-      buttonMinimalFill: 'transparent',
-      buttonMinimalText: primitives.primary400,
-      buttonMinimalHover: primitives.mono600,
-      buttonMinimalActive: primitives.mono500,
-      buttonDisabledFill: primitives.mono700,
-      buttonDisabledText: primitives.mono500,
-
-      // Breadcrumbs
-      breadcrumbsText: primitives.mono100,
-      breadcrumbsSeparatorFill: primitives.mono200,
-
-      // FileUploader
-      fileUploaderBackgroundColor: primitives.mono700,
-      fileUploaderBackgroundColorActive: primitives.mono600,
-      fileUploaderBorderColorActive: primitives.primary400,
-      fileUploaderBorderColorDefault: primitives.mono500,
-      fileUploaderMessageColor: primitives.mono100,
-
-      // Links
-      linkText: primitives.primary300,
-      linkVisited: primitives.primary300,
-      linkHover: primitives.primary400,
-
-      // List
-      listHeaderFill: primitives.mono600,
-      listBodyFill: primitives.mono700,
-      listIconFill: primitives.mono100,
-      listBorder: primitives.mono500,
-
-      // Tag
-      tagBackground: primitives.mono1000,
-      tagNeutralBackground: primitives.mono600,
-      tagPrimaryBackground: primitives.primary500,
-      tagPositiveBackground: primitives.positive500,
-      tagWarningBackground: primitives.warning500,
-      tagNegativeBackground: primitives.negative500,
-
-      // Tick
-      tickFill: 'transparent',
-      tickFillHover: primitives.mono200,
-      tickFillActive: primitives.mono300,
-      tickFillSelected: primitives.primary400,
-      tickFillSelectedHover: primitives.primary500,
-      tickFillSelectedHoverActive: primitives.primary600,
-      tickFillDisabled: primitives.mono600,
-      tickBorder: primitives.mono400,
-      tickMarkFill: WHITE,
-
-      // Slider
-      sliderTrackFill: primitives.mono500,
-      sliderTrackFillHover: primitives.mono600,
-      sliderTrackFillActive: primitives.mono700,
-      sliderTrackFillSelected: primitives.primary700,
-      sliderTrackFillSelectedActive: primitives.primary700,
-      sliderTrackFillSelectedHover: primitives.primary700,
-      sliderTrackFillDisabled: primitives.mono600,
-      sliderHandleFill: primitives.mono300,
-      sliderHandleFillHover: primitives.mono300,
-      sliderHandleFillActive: primitives.mono300,
-      sliderHandleFillSelected: primitives.primary500,
-      sliderHandleFillSelectedHover: primitives.primary600,
-      sliderHandleFillSelectedActive: primitives.primary700,
-      sliderHandleFillDisabled: primitives.mono600,
-      sliderBorder: WHITE,
-      sliderBorderHover: WHITE,
-      sliderBorderDisabled: primitives.mono400,
-
-      // Input
-      inputFill: primitives.mono600,
-      inputFillEnhancer: primitives.mono500,
-      inputFillError: primitives.mono600,
-      inputFillDisabled: primitives.mono700,
-      inputTextDisabled: primitives.mono500,
-
-      // Menu
-      menuFillHover: primitives.mono600,
-    },
-    tooltip: {
-      backgroundColor: primitives.mono200,
-    },
+    ...colors,
   },
 );

--- a/src/themes/index.js
+++ b/src/themes/index.js
@@ -8,10 +8,17 @@ LICENSE file in the root directory of this source tree.
 import createTheme from './creator.js';
 import {primitives as lightThemePrimitives} from './light-theme-primitives.js';
 import {LightThemeMove} from './light-theme-with-move.js';
+import {DarkThemeMove} from './dark-theme-with-move.js';
 import {DarkTheme} from './dark-theme.js';
 
 export const LightTheme = createTheme(lightThemePrimitives);
 
-export {createTheme, LightThemeMove, lightThemePrimitives, DarkTheme};
+export {
+  createTheme,
+  LightThemeMove,
+  lightThemePrimitives,
+  DarkTheme,
+  DarkThemeMove,
+};
 
 export * from './types';


### PR DESCRIPTION
This PR just enables the development of the Dark Theme - the look and feel will be off for the time being!

If you'd like to try it out, just visit any url using the `theme=dark` query string - once you want to change back to the light theme, use `theme=light`

<img width="1433" alt="Screen Shot 2019-03-13 at 1 47 03 PM" src="https://user-images.githubusercontent.com/2174968/54313435-93e24000-4596-11e9-85c7-0af1119c716d.png">
