### PR TITLE
fix(popover): ensure priority event timing

### DIFF
--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -178,7 +178,7 @@ describe('Popover', () => {
     );
 
     const calls = document.addEventListener.mock.calls;
-    expect(calls[0][0]).toBe('click');
+    expect(calls[0][0]).toBe('mousedown');
     expect(calls[1][0]).toBe('keyup');
 
     calls[1][1]({

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -276,14 +276,15 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
 
   addDomEvents() {
     if (__BROWSER__) {
-      document.addEventListener('click', this.onDocumentClick);
+      // using mousedown event so that callback runs before events on children inside of the popover
+      document.addEventListener('mousedown', this.onDocumentClick);
       document.addEventListener('keyup', this.onKeyPress);
     }
   }
 
   removeDomEvents() {
     if (__BROWSER__) {
-      document.removeEventListener('click', this.onDocumentClick);
+      document.removeEventListener('mousedown', this.onDocumentClick);
       document.removeEventListener('keyup', this.onKeyPress);
     }
   }


### PR DESCRIPTION
#### Description

[reproducing example](https://codesandbox.io/s/91x3noq55o) (click a couple times and the popover should close without clicking outside of popover content)

This bug was caused by the change [here](https://github.com/uber-web/baseui/pull/1008/files#diff-7ec0bdc9296aa57a335fbcb29c2a0dfeR279). Reasoning for the change was to cause a failing test for the bug fix in related PR.

Issues surfaced because popover's `onDocumentClick` method was now called after click events on child elements. Once `onDocumentClick` was called (_after_ the popover component updated its children) it sees the updated tree and finds false-positive clicks outside of the popover.

**with `click` event listener**
<img width="1920" alt="Screen Shot 2019-03-14 at 1 10 31 PM" src="https://user-images.githubusercontent.com/5317799/54390310-6614fe00-465f-11e9-9349-1a3fe2ddda9e.png">

**with `mousedown` event listener**
<img width="1920" alt="Screen Shot 2019-03-14 at 1 20 47 PM" src="https://user-images.githubusercontent.com/5317799/54390289-5a293c00-465f-11e9-8d70-d2f3784f4280.png">


#### Scope

- [x] Patch: Bug Fix
