### PR TITLE
feat: add data-baseweb attribute

### DIFF
--- a/src/accordion/accordion.js
+++ b/src/accordion/accordion.js
@@ -107,7 +107,7 @@ export default class Accordion extends React.Component<
     const {Root: RootOverride} = overrides;
     const [Root, rootProps] = getOverrides(RootOverride, StyledRoot);
     return (
-      <Root {...sharedProps} {...rootProps}>
+      <Root data-baseweb="accordion" {...sharedProps} {...rootProps}>
         {this.getItems()}
       </Root>
     );

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -54,6 +54,7 @@ export default class Avatar extends React.Component<PropsT, StateT> {
         role={didImageFailToLoad ? 'img' : null}
         $didImageFailToLoad={didImageFailToLoad}
         $size={size}
+        data-baseweb="avatar"
         {...rootProps}
       >
         {didImageFailToLoad ? (

--- a/src/block/block.js
+++ b/src/block/block.js
@@ -135,6 +135,7 @@ function Block({
       $top={top}
       $right={right}
       $bottom={bottom}
+      data-baseweb="block"
       {...other}
       {...baseBlockProps}
     >

--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Breadcrumbs displays separators in correct positions 1`] = `
-<StyledRoot
+<MockStyledComponent
   aria-label=""
   data-baseweb="breadcrumbs"
 >
@@ -10,23 +10,23 @@ exports[`Breadcrumbs displays separators in correct positions 1`] = `
   >
     Parent Page
   </StyledLink>
-  <StyledSeparator
+  <MockStyledComponent
     key="separator-0"
   >
-    <StyledIcon />
-  </StyledSeparator>
+    <MockStyledComponent />
+  </MockStyledComponent>
   <StyledLink
     href="#"
   >
     Sub-Parent Page
   </StyledLink>
-  <StyledSeparator
+  <MockStyledComponent
     key="separator-1"
   >
-    <StyledIcon />
-  </StyledSeparator>
+    <MockStyledComponent />
+  </MockStyledComponent>
   <span>
     Current Page
   </span>
-</StyledRoot>
+</MockStyledComponent>
 `;

--- a/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
+++ b/src/breadcrumbs/__tests__/__snapshots__/breadcrumbs.test.js.snap
@@ -1,31 +1,32 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Breadcrumbs displays separators in correct positions 1`] = `
-<MockStyledComponent
+<StyledRoot
   aria-label=""
+  data-baseweb="breadcrumbs"
 >
-  <MockStyledComponent
+  <StyledLink
     href="#"
   >
     Parent Page
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledLink>
+  <StyledSeparator
     key="separator-0"
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledIcon />
+  </StyledSeparator>
+  <StyledLink
     href="#"
   >
     Sub-Parent Page
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledLink>
+  <StyledSeparator
     key="separator-1"
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
+    <StyledIcon />
+  </StyledSeparator>
   <span>
     Current Page
   </span>
-</MockStyledComponent>
+</StyledRoot>
 `;

--- a/src/breadcrumbs/breadcrumbs.js
+++ b/src/breadcrumbs/breadcrumbs.js
@@ -45,6 +45,7 @@ export function BreadcrumbsRoot(props: {|...BreadcrumbsPropsT, ...LocaleT|}) {
       aria-label={
         props.ariaLabel || (props.locale ? props.locale.ariaLabel : '')
       }
+      data-baseweb="breadcrumbs"
       {...baseRootProps}
     >
       {childrenWithSeparators}

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -61,6 +61,7 @@ export function ButtonGroupRoot(props: {|...PropsT, ...LocaleT|}) {
       aria-label={
         props.ariaLabel || (props.locale ? props.locale.ariaLabel : '')
       }
+      data-baseweb="button-group"
       {...rootProps}
     >
       {React.Children.map(props.children, (child, index) => {

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -70,6 +70,7 @@ export default class Button extends React.Component<ButtonPropsT> {
     const sharedProps = getSharedProps(this.props);
     return (
       <BaseButton
+        data-baseweb="button"
         {...sharedProps}
         {...restProps}
         {...baseButtonProps}

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -57,7 +57,11 @@ function Card(props: CardsPropsT) {
 
   const $hasThumbnail = hasThumbnail(props);
   return (
-    <Root {...otherProps} {...getOverrideProps(RootOverride)}>
+    <Root
+      data-baseweb="card"
+      {...otherProps}
+      {...getOverrideProps(RootOverride)}
+    >
       {headerImage && (
         <HeaderImage
           src={headerImage}

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -152,6 +152,7 @@ class StatelessCheckbox extends React.Component<PropsT, StatelessStateT> {
     );
     return (
       <Root
+        data-baseweb="checkbox"
         $labelPlacement={labelPlacement}
         {...sharedProps}
         {...mouseEvents}

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -450,6 +450,7 @@ export default class Calendar extends React.Component<
 
     return (
       <Root
+        data-baseweb="calendar"
         $ref={root => {
           this.root = root;
         }}

--- a/src/dnd-list/list.js
+++ b/src/dnd-list/list.js
@@ -51,7 +51,7 @@ class StatelessList extends React.Component<ListPropsT> {
     const [Label, labelProps] = getOverrides(LabelOverride, StyledLabel);
     const isRemovable = this.props.removable || false;
     return (
-      <Root $isRemovable={isRemovable} {...rootProps}>
+      <Root $isRemovable={isRemovable} data-baseweb="dnd-list" {...rootProps}>
         <MovableList
           values={items}
           onChange={onChange}

--- a/src/file-uploader/file-uploader.js
+++ b/src/file-uploader/file-uploader.js
@@ -81,7 +81,11 @@ function FileUploader(props: PropsT) {
         return (
           <LocaleContext.Consumer>
             {locale => (
-              <Root {...prefixedStyledProps} {...rootProps}>
+              <Root
+                data-baseweb="file-uploader"
+                {...prefixedStyledProps}
+                {...rootProps}
+              >
                 <FileDragAndDrop
                   {...getRootProps(getRootPropsArgs)}
                   {...prefixedStyledProps}

--- a/src/form-control/form-control.js
+++ b/src/form-control/form-control.js
@@ -59,6 +59,7 @@ export default class FormControl extends React.Component<FormControlPropsT> {
       <React.Fragment>
         {label && (
           <Label
+            data-baseweb="form-control-label"
             htmlFor={onlyChildProps.id}
             {...sharedProps}
             {...getOverrideProps(LabelOverride)}
@@ -67,6 +68,7 @@ export default class FormControl extends React.Component<FormControlPropsT> {
           </Label>
         )}
         <ControlContainer
+          data-baseweb="form-control-container"
           {...sharedProps}
           {...getOverrideProps(ControlContainerOverride)}
         >

--- a/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
+++ b/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
@@ -4,15 +4,17 @@ exports[`Stateless header navigation should render component: Component has corr
 <HeaderNavigation
   overrides={Object {}}
 >
-  <MockStyledComponent
+  <Root
+    data-baseweb="header-navigation"
     role="navigation"
   >
     <nav
+      data-baseweb="header-navigation"
       role="navigation"
       styled-component="true"
     >
       Some tag
     </nav>
-  </MockStyledComponent>
+  </Root>
 </HeaderNavigation>
 `;

--- a/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
+++ b/src/header-navigation/__tests__/__snapshots__/header-navigation.test.js.snap
@@ -4,7 +4,7 @@ exports[`Stateless header navigation should render component: Component has corr
 <HeaderNavigation
   overrides={Object {}}
 >
-  <Root
+  <MockStyledComponent
     data-baseweb="header-navigation"
     role="navigation"
   >
@@ -15,6 +15,6 @@ exports[`Stateless header navigation should render component: Component has corr
     >
       Some tag
     </nav>
-  </Root>
+  </MockStyledComponent>
 </HeaderNavigation>
 `;

--- a/src/header-navigation/header-navigation.js
+++ b/src/header-navigation/header-navigation.js
@@ -26,7 +26,14 @@ class HeaderNavigation extends React.Component<PropsT, {}> {
   render() {
     const {overrides, ...restProps} = this.props;
     const [Root, rootProps] = getOverrides(overrides.Root, StyledRoot);
-    return <Root role="navigation" {...restProps} {...rootProps} />;
+    return (
+      <Root
+        data-baseweb="header-navigation"
+        role="navigation"
+        {...restProps}
+        {...rootProps}
+      />
+    );
   }
 }
 

--- a/src/icon/__tests__/__snapshots__/icon.test.js.snap
+++ b/src/icon/__tests__/__snapshots__/icon.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
-<Svg
+<MockStyledComponent
   data-baseweb="icon"
   viewBox="0 0 23px 23px"
 >
@@ -13,5 +13,5 @@ exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
     d="M6 12C6 11.4477 6.44772 11 7 11H17C17.5523 11 18 11.4477 18 12C18 12.5523 17.5523 13 17 13H7C6.44772 13 6 12.5523 6 12Z"
     fillRule="evenodd"
   />
-</Svg>
+</MockStyledComponent>
 `;

--- a/src/icon/__tests__/__snapshots__/icon.test.js.snap
+++ b/src/icon/__tests__/__snapshots__/icon.test.js.snap
@@ -1,7 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
-<MockStyledComponent
+<Svg
+  data-baseweb="icon"
   viewBox="0 0 23px 23px"
 >
   <title>
@@ -12,5 +13,5 @@ exports[`Icon renders an icon with viewbox and title: Icon basic render 1`] = `
     d="M6 12C6 11.4477 6.44772 11 7 11H17C17.5523 11 18 11.4477 18 12C18 12.5523 17.5523 13 17 13H7C6.44772 13 6 12.5523 6 12Z"
     fillRule="evenodd"
   />
-</MockStyledComponent>
+</Svg>
 `;

--- a/src/icon/icon.js
+++ b/src/icon/icon.js
@@ -21,7 +21,7 @@ export default function Icon(props: IconPropsT) {
   const [Svg, overrideProps] = getOverrides(overrides.Svg, StyledSvg);
 
   return (
-    <Svg {...restProps} {...sharedProps} {...overrideProps}>
+    <Svg data-baseweb="icon" {...restProps} {...sharedProps} {...overrideProps}>
       {title ? <title>{title}</title> : null}
       {children}
     </Svg>

--- a/src/input/__tests__/__snapshots__/input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/input.test.js.snap
@@ -41,7 +41,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <Input
+    <MockStyledComponent
       $adjoined="right"
       $disabled={false}
       $error={false}
@@ -99,7 +99,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <Input
+    <MockStyledComponent
       $adjoined="both"
       $disabled={false}
       $error={false}
@@ -157,7 +157,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <Input
+    <MockStyledComponent
       $adjoined="left"
       $disabled={false}
       $error={false}

--- a/src/input/__tests__/__snapshots__/input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/input.test.js.snap
@@ -41,7 +41,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <Input
       $adjoined="right"
       $disabled={false}
       $error={false}
@@ -78,6 +78,7 @@ Object {
       $size="default"
     />,
   ],
+  "data-baseweb": "base-input",
 }
 `;
 
@@ -98,7 +99,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <Input
       $adjoined="both"
       $disabled={false}
       $error={false}
@@ -135,6 +136,7 @@ Object {
       $size="default"
     />,
   ],
+  "data-baseweb": "base-input",
 }
 `;
 
@@ -155,7 +157,7 @@ Object {
       $required={false}
       $size="default"
     />,
-    <MockStyledComponent
+    <Input
       $adjoined="left"
       $disabled={false}
       $error={false}
@@ -192,5 +194,6 @@ Object {
       $size="default"
     />,
   ],
+  "data-baseweb": "base-input",
 }
 `;

--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -132,7 +132,11 @@ class BaseInput<T: EventTarget> extends React.Component<
     const [Before, beforeProps] = getOverrides(BeforeOverride, NullComponent);
     const [After, afterProps] = getOverrides(AfterOverride, NullComponent);
     return (
-      <InputContainer {...sharedProps} {...inputContainerProps}>
+      <InputContainer
+        data-baseweb={this.props['data-baseweb'] || 'base-input'}
+        {...sharedProps}
+        {...inputContainerProps}
+      >
         <Before {...sharedProps} {...beforeProps} />
         <Input {...sharedProps} {...this.getInputProps()} {...inputProps}>
           {type === CUSTOM_INPUT_TYPE.textarea ? value : null}

--- a/src/input/input.js
+++ b/src/input/input.js
@@ -71,7 +71,7 @@ class Input extends React.Component<InputPropsT, InternalStateT> {
     const sharedProps = getSharedProps(this.props, this.state);
 
     return (
-      <Root {...sharedProps} {...rootProps}>
+      <Root data-baseweb="input" {...sharedProps} {...rootProps}>
         {startEnhancer && (
           <StartEnhancer
             {...sharedProps}

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -80,6 +80,7 @@ export type BaseInputPropsT<T> = {
   error: boolean,
   /** Id attribute value to be added to the input element and as a label's for attribute value. */
   id: string,
+  'data-baseweb'?: string,
   $ref: {current: ?HTMLInputElement},
   /** A ref to access an input element. */
   inputRef: {current: ?HTMLInputElement},

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -6,4 +6,8 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 // Styled elements
-export {Link as StyledLink} from './styled-components.js';
+import * as React from 'react';
+import {Link} from './styled-components.js';
+
+//$FlowFixMe
+export const StyledLink = props => <Link data-baseweb="link" {...props} />;

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -36,6 +36,7 @@ export default function Menu(props: StatelessMenuPropsT) {
       onFocus={focusMenu}
       onBlur={unfocusMenu}
       tabIndex={0}
+      data-baseweb="menu"
       {...listProps}
     >
       {items.map((item, index) => {

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -13,7 +13,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
   <Portal
     key="portal"
   >
-    <Root
+    <MockStyledComponent
       $animate={true}
       $closeable={true}
       $isOpen={true}
@@ -28,7 +28,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
       data-baseweb="modal"
     >
       <Portal>
-        <Backdrop
+        <MockStyledComponent
           $animate={true}
           $closeable={true}
           $isOpen={true}
@@ -38,8 +38,8 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
           onClick={[Function]}
         >
           <Portal />
-        </Backdrop>
-        <DialogContainer
+        </MockStyledComponent>
+        <MockStyledComponent
           $animate={true}
           $closeable={true}
           $isOpen={true}
@@ -48,7 +48,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
           $size="default"
         >
           <Portal>
-            <Dialog
+            <MockStyledComponent
               $animate={true}
               $closeable={true}
               $isOpen={true}
@@ -65,7 +65,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
               tabIndex="-1"
             >
               <Portal>
-                <Close
+                <MockStyledComponent
                   $animate={true}
                   $closeable={true}
                   $isOpen={true}
@@ -82,22 +82,22 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                       </Portal>
                     </CloseIcon>
                   </Portal>
-                </Close>
-                <ModalHeader>
+                </MockStyledComponent>
+                <MockStyledComponent>
                   <Portal />
-                </ModalHeader>
-                <ModalBody>
+                </MockStyledComponent>
+                <MockStyledComponent>
                   <Portal />
-                </ModalBody>
-                <ModalFooter>
+                </MockStyledComponent>
+                <MockStyledComponent>
                   <Portal />
-                </ModalFooter>
+                </MockStyledComponent>
               </Portal>
-            </Dialog>
+            </MockStyledComponent>
           </Portal>
-        </DialogContainer>
+        </MockStyledComponent>
       </Portal>
-    </Root>
+    </MockStyledComponent>
   </Portal>
 </Modal>
 `;

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -13,7 +13,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
   <Portal
     key="portal"
   >
-    <MockStyledComponent
+    <Root
       $animate={true}
       $closeable={true}
       $isOpen={true}
@@ -25,9 +25,10 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
       }
       $role="dialog"
       $size="default"
+      data-baseweb="modal"
     >
       <Portal>
-        <MockStyledComponent
+        <Backdrop
           $animate={true}
           $closeable={true}
           $isOpen={true}
@@ -37,8 +38,8 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
           onClick={[Function]}
         >
           <Portal />
-        </MockStyledComponent>
-        <MockStyledComponent
+        </Backdrop>
+        <DialogContainer
           $animate={true}
           $closeable={true}
           $isOpen={true}
@@ -47,7 +48,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
           $size="default"
         >
           <Portal>
-            <MockStyledComponent
+            <Dialog
               $animate={true}
               $closeable={true}
               $isOpen={true}
@@ -64,7 +65,7 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
               tabIndex="-1"
             >
               <Portal>
-                <MockStyledComponent
+                <Close
                   $animate={true}
                   $closeable={true}
                   $isOpen={true}
@@ -81,22 +82,22 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                       </Portal>
                     </CloseIcon>
                   </Portal>
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </Close>
+                <ModalHeader>
                   <Portal />
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </ModalHeader>
+                <ModalBody>
                   <Portal />
-                </MockStyledComponent>
-                <MockStyledComponent>
+                </ModalBody>
+                <ModalFooter>
                   <Portal />
-                </MockStyledComponent>
+                </ModalFooter>
               </Portal>
-            </MockStyledComponent>
+            </Dialog>
           </Portal>
-        </MockStyledComponent>
+        </DialogContainer>
       </Portal>
-    </MockStyledComponent>
+    </Root>
   </Portal>
 </Modal>
 `;

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -279,6 +279,7 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
       <LocaleContext.Consumer>
         {locale => (
           <Root
+            data-baseweb="modal"
             $ref={this.getRef('Root')}
             {...sharedProps}
             {...getOverrideProps(RootOverride)}

--- a/src/notification/notification.js
+++ b/src/notification/notification.js
@@ -17,6 +17,6 @@ export default class Notification extends React.Component<ToastPropsT> {
   };
 
   render() {
-    return <Toast {...this.props} />;
+    return <Toast data-baseweb="notification" {...this.props} />;
   }
 }

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -132,7 +132,7 @@ export default class Pagination extends React.PureComponent<
     return (
       <LocaleContext.Consumer>
         {locale => (
-          <Root {...rootProps}>
+          <Root data-baseweb="pagination" {...rootProps}>
             <Button
               onClick={this.onPrevClick}
               startEnhancer={() => <ChevronLeft title={''} size={24} />}

--- a/src/popover/__tests__/__snapshots__/popover.test.js.snap
+++ b/src/popover/__tests__/__snapshots__/popover.test.js.snap
@@ -37,6 +37,7 @@ Object {
     "current": null,
   },
   "$showArrow": true,
+  "data-baseweb": "popover",
   "id": "bui-mock-id",
   "onMouseEnter": [Function],
   "onMouseLeave": [Function],

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -86,7 +86,7 @@ describe('Popover', () => {
 
     // Portal should have the popover body and content
     let popoverBody = portal.childAt(0);
-    expect(popoverBody).toMatchSelector('MockStyledComponent');
+    expect(popoverBody).toMatchSelector('[data-baseweb="popover"]');
     expect(popoverBody).toHaveProp({
       $showArrow: false,
       $placement: 'auto',

--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -473,6 +473,7 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
       <Body
         key="popover-body"
         $ref={this.popperRef}
+        data-baseweb={this.props['data-baseweb'] || 'popover'}
         {...bodyProps}
         {...sharedProps}
         {...getOverrideProps(BodyOverride)}

--- a/src/popover/types.js
+++ b/src/popover/types.js
@@ -56,6 +56,7 @@ export type BasePopoverPropsT = {
    * See the A11Y section at the bottom of this document for more details.
    */
   accessibilityType?: AccessibilityTypeT,
+  'data-baseweb'?: string,
   id?: string,
   /** If true, popover element will not avoid element boundaries. */
   ignoreBoundary?: boolean,

--- a/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
+++ b/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
@@ -8,33 +8,35 @@ exports[`Stateless progress bar should render component: Component has correct r
   successValue={100}
   value={75}
 >
-  <MockStyledComponent
+  <Root
     $successValue={100}
     $value={75}
+    data-baseweb="progress-bar"
     role="progressbar"
   >
     <div
+      data-baseweb="progress-bar"
       role="progressbar"
       styled-component="true"
     >
-      <MockStyledComponent
+      <Bar
         $successValue={100}
         $value={75}
       >
         <div
           styled-component="true"
         >
-          <MockStyledComponent
+          <BarProgress
             $successValue={100}
             $value={75}
           >
             <div
               styled-component="true"
             />
-          </MockStyledComponent>
+          </BarProgress>
         </div>
-      </MockStyledComponent>
+      </Bar>
     </div>
-  </MockStyledComponent>
+  </Root>
 </ProgressBar>
 `;

--- a/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
+++ b/src/progress-bar/__tests__/__snapshots__/progressbar.test.js.snap
@@ -8,7 +8,7 @@ exports[`Stateless progress bar should render component: Component has correct r
   successValue={100}
   value={75}
 >
-  <Root
+  <MockStyledComponent
     $successValue={100}
     $value={75}
     data-baseweb="progress-bar"
@@ -19,24 +19,24 @@ exports[`Stateless progress bar should render component: Component has correct r
       role="progressbar"
       styled-component="true"
     >
-      <Bar
+      <MockStyledComponent
         $successValue={100}
         $value={75}
       >
         <div
           styled-component="true"
         >
-          <BarProgress
+          <MockStyledComponent
             $successValue={100}
             $value={75}
           >
             <div
               styled-component="true"
             />
-          </BarProgress>
+          </MockStyledComponent>
         </div>
-      </Bar>
+      </MockStyledComponent>
     </div>
-  </Root>
+  </MockStyledComponent>
 </ProgressBar>
 `;

--- a/src/progress-bar/progressbar.js
+++ b/src/progress-bar/progressbar.js
@@ -46,7 +46,12 @@ class ProgressBar extends React.Component<ProgressBarPropsT> {
       $successValue: successValue,
     };
     return (
-      <Root role="progressbar" {...sharedProps} {...rootProps}>
+      <Root
+        data-baseweb="progress-bar"
+        role="progressbar"
+        {...sharedProps}
+        {...rootProps}
+      >
         <Bar {...sharedProps} {...barProps}>
           <BarProgress {...sharedProps} {...barProgressProps} />
         </Bar>

--- a/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
@@ -1,143 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NumberedStep applies isActive prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies isCompleted prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={true}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={true}
   >
     <Check
       size={12}
     />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={true}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={true}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies isLast prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep applies title prop correctly 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </MockStyledComponent>
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentTitle>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledNumberStep>
 `;
 
 exports[`NumberedStep renders children correctly if isActive is provided 1`] = `
-<MockStyledComponent
+<StyledNumberStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledNumberIcon
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </MockStyledComponent>
-  <MockStyledComponent
+  </StyledNumberIcon>
+  <StyledNumberContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent>
+    <StyledContentDescription>
       Content
-    </MockStyledComponent>
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentDescription>
+  </StyledContent>
+</StyledNumberStep>
 `;

--- a/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/numbered-step.test.js.snap
@@ -1,143 +1,143 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`NumberedStep applies isActive prop correctly 1`] = `
-<StyledNumberStep
+<MockStyledComponent
   $isActive={true}
   $isCompleted={false}
 >
-  <StyledNumberIcon
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </StyledNumberIcon>
-  <StyledNumberContentTail
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={true}
       $isCompleted={false}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledNumberStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`NumberedStep applies isCompleted prop correctly 1`] = `
-<StyledNumberStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={true}
 >
-  <StyledNumberIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   >
     <Check
       size={12}
     />
-  </StyledNumberIcon>
-  <StyledNumberContentTail
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={true}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledNumberStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`NumberedStep applies isLast prop correctly 1`] = `
-<StyledNumberStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={false}
 >
-  <StyledNumberIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </StyledNumberIcon>
-  <StyledContent
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={false}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledNumberStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`NumberedStep applies title prop correctly 1`] = `
-<StyledNumberStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={false}
 >
-  <StyledNumberIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
     <span />
-  </StyledNumberIcon>
-  <StyledNumberContentTail
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </StyledContentTitle>
-    <StyledContentDescription />
-  </StyledContent>
-</StyledNumberStep>
+    </MockStyledComponent>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`NumberedStep renders children correctly if isActive is provided 1`] = `
-<StyledNumberStep
+<MockStyledComponent
   $isActive={true}
   $isCompleted={false}
 >
-  <StyledNumberIcon
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
     <span />
-  </StyledNumberIcon>
-  <StyledNumberContentTail
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={true}
       $isCompleted={false}
     />
-    <StyledContentDescription>
+    <MockStyledComponent>
       Content
-    </StyledContentDescription>
-  </StyledContent>
-</StyledNumberStep>
+    </MockStyledComponent>
+  </MockStyledComponent>
+</MockStyledComponent>
 `;

--- a/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
@@ -1,135 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Step applies isActive prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledInnerIcon />
+  </StyledIcon>
+  <StyledContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies isCompleted prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={true}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContentTail
     $isActive={false}
     $isCompleted={true}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={true}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={true}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies isLast prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     />
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step applies title prop correctly 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={false}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContentTail
     $isActive={false}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={false}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </MockStyledComponent>
-    <MockStyledComponent />
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentTitle>
+    <StyledContentDescription />
+  </StyledContent>
+</StyledStep>
 `;
 
 exports[`Step renders children correctly if isActive is provided 1`] = `
-<MockStyledComponent
+<StyledStep
   $isActive={true}
   $isCompleted={false}
 >
-  <MockStyledComponent
+  <StyledIcon
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent />
-  </MockStyledComponent>
-  <MockStyledComponent
+    <StyledInnerIcon />
+  </StyledIcon>
+  <StyledContentTail
     $isActive={true}
     $isCompleted={false}
   />
-  <MockStyledComponent
+  <StyledContent
     $isActive={true}
     $isCompleted={false}
   >
-    <MockStyledComponent
+    <StyledContentTitle
       $isActive={true}
       $isCompleted={false}
     />
-    <MockStyledComponent>
+    <StyledContentDescription>
       Content
-    </MockStyledComponent>
-  </MockStyledComponent>
-</MockStyledComponent>
+    </StyledContentDescription>
+  </StyledContent>
+</StyledStep>
 `;

--- a/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
+++ b/src/progress-steps/__tests__/__snapshots__/step.test.js.snap
@@ -1,135 +1,135 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Step applies isActive prop correctly 1`] = `
-<StyledStep
+<MockStyledComponent
   $isActive={true}
   $isCompleted={false}
 >
-  <StyledIcon
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledInnerIcon />
-  </StyledIcon>
-  <StyledContentTail
+    <MockStyledComponent />
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={true}
       $isCompleted={false}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`Step applies isCompleted prop correctly 1`] = `
-<StyledStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={true}
 >
-  <StyledIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   />
-  <StyledContentTail
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={true}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={true}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`Step applies isLast prop correctly 1`] = `
-<StyledStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={false}
 >
-  <StyledIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={false}
     />
-    <StyledContentDescription />
-  </StyledContent>
-</StyledStep>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`Step applies title prop correctly 1`] = `
-<StyledStep
+<MockStyledComponent
   $isActive={false}
   $isCompleted={false}
 >
-  <StyledIcon
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   />
-  <StyledContentTail
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={false}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={false}
       $isCompleted={false}
     >
       Test Title
-    </StyledContentTitle>
-    <StyledContentDescription />
-  </StyledContent>
-</StyledStep>
+    </MockStyledComponent>
+    <MockStyledComponent />
+  </MockStyledComponent>
+</MockStyledComponent>
 `;
 
 exports[`Step renders children correctly if isActive is provided 1`] = `
-<StyledStep
+<MockStyledComponent
   $isActive={true}
   $isCompleted={false}
 >
-  <StyledIcon
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledInnerIcon />
-  </StyledIcon>
-  <StyledContentTail
+    <MockStyledComponent />
+  </MockStyledComponent>
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   />
-  <StyledContent
+  <MockStyledComponent
     $isActive={true}
     $isCompleted={false}
   >
-    <StyledContentTitle
+    <MockStyledComponent
       $isActive={true}
       $isCompleted={false}
     />
-    <StyledContentDescription>
+    <MockStyledComponent>
       Content
-    </StyledContentDescription>
-  </StyledContent>
-</StyledStep>
+    </MockStyledComponent>
+  </MockStyledComponent>
+</MockStyledComponent>
 `;

--- a/src/progress-steps/progress-steps.js
+++ b/src/progress-steps/progress-steps.js
@@ -33,7 +33,11 @@ function ProgressSteps({
     );
   });
 
-  return <Root {...rootProps}>{modifiedChildren}</Root>;
+  return (
+    <Root data-baseweb="progress-steps" {...rootProps}>
+      {modifiedChildren}
+    </Root>
+  );
 }
 
 ProgressSteps.defaultProps = {

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -129,6 +129,7 @@ class Radio extends React.Component<RadioPropsT, RadioStateT> {
 
     return (
       <Root
+        data-baseweb="radio"
         onMouseEnter={this.onMouseEnter}
         onMouseLeave={this.onMouseLeave}
         onMouseDown={this.onMouseDown}

--- a/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EmoticonRating RatingItem applies correct props if item is active 1`] = `
-<MockStyledComponent
+<StyledEmoticon
   $index={1}
   $isActive={false}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`EmoticonRating RatingItem applies correct props if item is active 1`] =
 `;
 
 exports[`EmoticonRating RatingItem applies correct props if item is selected 1`] = `
-<MockStyledComponent
+<StyledEmoticon
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/emoticon-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EmoticonRating RatingItem applies correct props if item is active 1`] = `
-<StyledEmoticon
+<MockStyledComponent
   $index={1}
   $isActive={false}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`EmoticonRating RatingItem applies correct props if item is active 1`] =
 `;
 
 exports[`EmoticonRating RatingItem applies correct props if item is selected 1`] = `
-<StyledEmoticon
+<MockStyledComponent
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StarRating RatingItem applies correct props if item is active 1`] = `
-<StyledStar
+<MockStyledComponent
   $index={1}
   $isActive={true}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`StarRating RatingItem applies correct props if item is active 1`] = `
 `;
 
 exports[`StarRating RatingItem applies correct props if item is selected 1`] = `
-<StyledStar
+<MockStyledComponent
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
+++ b/src/rating/__tests__/__snapshots__/star-rating.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StarRating RatingItem applies correct props if item is active 1`] = `
-<MockStyledComponent
+<StyledStar
   $index={1}
   $isActive={true}
   $isSelected={false}
@@ -20,7 +20,7 @@ exports[`StarRating RatingItem applies correct props if item is active 1`] = `
 `;
 
 exports[`StarRating RatingItem applies correct props if item is selected 1`] = `
-<MockStyledComponent
+<StyledStar
   $index={2}
   $isActive={true}
   $isSelected={true}

--- a/src/rating/emoticon-rating.js
+++ b/src/rating/emoticon-rating.js
@@ -82,6 +82,7 @@ class EmoticonRating extends React.Component<
 
     return (
       <Root
+        data-baseweb="emoticon-rating"
         tabIndex={0}
         role="radiogroup"
         onBlur={() => this.updatePreview(undefined)}

--- a/src/rating/star-rating.js
+++ b/src/rating/star-rating.js
@@ -77,6 +77,7 @@ class StarRating extends React.Component<StarRatingPropsT, RatingStateT> {
 
     return (
       <Root
+        data-baseweb="star-rating"
         tabIndex={0}
         role="radiogroup"
         onBlur={() => this.updatePreview(undefined)}

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -68,7 +68,7 @@ exports[`Select component renders component in search mode and false for multipl
     showArrow={false}
     triggerType="click"
   >
-    <StyledRoot
+    <MockStyledComponent
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -101,7 +101,7 @@ exports[`Select component renders component in search mode and false for multipl
         onClick={[Function]}
         styled-component="true"
       >
-        <StyledControlContainer
+        <MockStyledComponent
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -171,7 +171,7 @@ exports[`Select component renders component in search mode and false for multipl
                 title="search"
                 viewBox="0 0 24 24"
               >
-                <StyledSearchIcon
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -201,10 +201,10 @@ exports[`Select component renders component in search mode and false for multipl
                       fillRule="evenodd"
                     />
                   </svg>
-                </StyledSearchIcon>
+                </MockStyledComponent>
               </Icon>
             </Search>
-            <StyledValueContainer
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -221,7 +221,7 @@ exports[`Select component renders component in search mode and false for multipl
               <span
                 styled-component="true"
               >
-                <StyledPlaceholder
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -240,8 +240,8 @@ exports[`Select component renders component in search mode and false for multipl
                   >
                     Select...
                   </div>
-                </StyledPlaceholder>
-                <StyledInputContainer
+                </MockStyledComponent>
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -293,7 +293,7 @@ exports[`Select component renders component in search mode and false for multipl
                       role="combobox"
                       value=""
                     >
-                      <StyledInput
+                      <MockStyledComponent
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -342,20 +342,20 @@ exports[`Select component renders component in search mode and false for multipl
                           styled-component="true"
                           value=""
                         />
-                      </StyledInput>
-                      <StyledInputSizer
+                      </MockStyledComponent>
+                      <MockStyledComponent
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </StyledInputSizer>
+                      </MockStyledComponent>
                     </AutosizeInput>
                   </div>
-                </StyledInputContainer>
+                </MockStyledComponent>
               </span>
-            </StyledValueContainer>
-            <StyledIconsContainer
+            </MockStyledComponent>
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -372,11 +372,11 @@ exports[`Select component renders component in search mode and false for multipl
               <div
                 styled-component="true"
               />
-            </StyledIconsContainer>
+            </MockStyledComponent>
           </div>
-        </StyledControlContainer>
+        </MockStyledComponent>
       </div>
-    </StyledRoot>
+    </MockStyledComponent>
   </Popover>
 </Select>
 `;
@@ -449,7 +449,7 @@ exports[`Select component renders component in search mode and true for multiple
     showArrow={false}
     triggerType="click"
   >
-    <StyledRoot
+    <MockStyledComponent
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -482,7 +482,7 @@ exports[`Select component renders component in search mode and true for multiple
         onClick={[Function]}
         styled-component="true"
       >
-        <StyledControlContainer
+        <MockStyledComponent
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -552,7 +552,7 @@ exports[`Select component renders component in search mode and true for multiple
                 title="search"
                 viewBox="0 0 24 24"
               >
-                <StyledSearchIcon
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -582,10 +582,10 @@ exports[`Select component renders component in search mode and true for multiple
                       fillRule="evenodd"
                     />
                   </svg>
-                </StyledSearchIcon>
+                </MockStyledComponent>
               </Icon>
             </Search>
-            <StyledValueContainer
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -602,7 +602,7 @@ exports[`Select component renders component in search mode and true for multiple
               <span
                 styled-component="true"
               >
-                <StyledPlaceholder
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -621,8 +621,8 @@ exports[`Select component renders component in search mode and true for multiple
                   >
                     Select...
                   </div>
-                </StyledPlaceholder>
-                <StyledInputContainer
+                </MockStyledComponent>
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -674,7 +674,7 @@ exports[`Select component renders component in search mode and true for multiple
                       role="combobox"
                       value=""
                     >
-                      <StyledInput
+                      <MockStyledComponent
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -723,20 +723,20 @@ exports[`Select component renders component in search mode and true for multiple
                           styled-component="true"
                           value=""
                         />
-                      </StyledInput>
-                      <StyledInputSizer
+                      </MockStyledComponent>
+                      <MockStyledComponent
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </StyledInputSizer>
+                      </MockStyledComponent>
                     </AutosizeInput>
                   </div>
-                </StyledInputContainer>
+                </MockStyledComponent>
               </span>
-            </StyledValueContainer>
-            <StyledIconsContainer
+            </MockStyledComponent>
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -753,11 +753,11 @@ exports[`Select component renders component in search mode and true for multiple
               <div
                 styled-component="true"
               />
-            </StyledIconsContainer>
+            </MockStyledComponent>
           </div>
-        </StyledControlContainer>
+        </MockStyledComponent>
       </div>
-    </StyledRoot>
+    </MockStyledComponent>
   </Popover>
 </Select>
 `;
@@ -830,7 +830,7 @@ exports[`Select component renders component in select mode and false for multipl
     showArrow={false}
     triggerType="click"
   >
-    <StyledRoot
+    <MockStyledComponent
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -863,7 +863,7 @@ exports[`Select component renders component in select mode and false for multipl
         onClick={[Function]}
         styled-component="true"
       >
-        <StyledControlContainer
+        <MockStyledComponent
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -890,7 +890,7 @@ exports[`Select component renders component in select mode and false for multipl
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <StyledValueContainer
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -907,7 +907,7 @@ exports[`Select component renders component in select mode and false for multipl
               <span
                 styled-component="true"
               >
-                <StyledPlaceholder
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -926,8 +926,8 @@ exports[`Select component renders component in select mode and false for multipl
                   >
                     Select...
                   </div>
-                </StyledPlaceholder>
-                <StyledInputContainer
+                </MockStyledComponent>
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -979,7 +979,7 @@ exports[`Select component renders component in select mode and false for multipl
                       role="combobox"
                       value=""
                     >
-                      <StyledInput
+                      <MockStyledComponent
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -1028,20 +1028,20 @@ exports[`Select component renders component in select mode and false for multipl
                           styled-component="true"
                           value=""
                         />
-                      </StyledInput>
-                      <StyledInputSizer
+                      </MockStyledComponent>
+                      <MockStyledComponent
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </StyledInputSizer>
+                      </MockStyledComponent>
                     </AutosizeInput>
                   </div>
-                </StyledInputContainer>
+                </MockStyledComponent>
               </span>
-            </StyledValueContainer>
-            <StyledIconsContainer
+            </MockStyledComponent>
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1101,7 +1101,7 @@ exports[`Select component renders component in select mode and false for multipl
                     title="open"
                     viewBox="0 0 24 24"
                   >
-                    <StyledSelectArrow
+                    <MockStyledComponent
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -1129,15 +1129,15 @@ exports[`Select component renders component in select mode and false for multipl
                           d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                         />
                       </svg>
-                    </StyledSelectArrow>
+                    </MockStyledComponent>
                   </Icon>
                 </TriangleDown>
               </div>
-            </StyledIconsContainer>
+            </MockStyledComponent>
           </div>
-        </StyledControlContainer>
+        </MockStyledComponent>
       </div>
-    </StyledRoot>
+    </MockStyledComponent>
   </Popover>
 </Select>
 `;
@@ -1210,7 +1210,7 @@ exports[`Select component renders component in select mode and true for multiple
     showArrow={false}
     triggerType="click"
   >
-    <StyledRoot
+    <MockStyledComponent
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -1243,7 +1243,7 @@ exports[`Select component renders component in select mode and true for multiple
         onClick={[Function]}
         styled-component="true"
       >
-        <StyledControlContainer
+        <MockStyledComponent
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -1270,7 +1270,7 @@ exports[`Select component renders component in select mode and true for multiple
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <StyledValueContainer
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1287,7 +1287,7 @@ exports[`Select component renders component in select mode and true for multiple
               <span
                 styled-component="true"
               >
-                <StyledPlaceholder
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -1306,8 +1306,8 @@ exports[`Select component renders component in select mode and true for multiple
                   >
                     Select...
                   </div>
-                </StyledPlaceholder>
-                <StyledInputContainer
+                </MockStyledComponent>
+                <MockStyledComponent
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -1359,7 +1359,7 @@ exports[`Select component renders component in select mode and true for multiple
                       role="combobox"
                       value=""
                     >
-                      <StyledInput
+                      <MockStyledComponent
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -1408,20 +1408,20 @@ exports[`Select component renders component in select mode and true for multiple
                           styled-component="true"
                           value=""
                         />
-                      </StyledInput>
-                      <StyledInputSizer
+                      </MockStyledComponent>
+                      <MockStyledComponent
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </StyledInputSizer>
+                      </MockStyledComponent>
                     </AutosizeInput>
                   </div>
-                </StyledInputContainer>
+                </MockStyledComponent>
               </span>
-            </StyledValueContainer>
-            <StyledIconsContainer
+            </MockStyledComponent>
+            <MockStyledComponent
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1481,7 +1481,7 @@ exports[`Select component renders component in select mode and true for multiple
                     title="open"
                     viewBox="0 0 24 24"
                   >
-                    <StyledSelectArrow
+                    <MockStyledComponent
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -1509,15 +1509,15 @@ exports[`Select component renders component in select mode and true for multiple
                           d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                         />
                       </svg>
-                    </StyledSelectArrow>
+                    </MockStyledComponent>
                   </Icon>
                 </TriangleDown>
               </div>
-            </StyledIconsContainer>
+            </MockStyledComponent>
           </div>
-        </StyledControlContainer>
+        </MockStyledComponent>
       </div>
-    </StyledRoot>
+    </MockStyledComponent>
   </Popover>
 </Select>
 `;

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -68,7 +68,7 @@ exports[`Select component renders component in search mode and false for multipl
     showArrow={false}
     triggerType="click"
   >
-    <MockStyledComponent
+    <StyledRoot
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -89,6 +89,7 @@ exports[`Select component renders component in search mode and false for multipl
       aria-controls={null}
       aria-expanded="false"
       aria-haspopup="true"
+      data-baseweb="select"
       key="popover-anchor"
       onClick={[Function]}
     >
@@ -96,10 +97,11 @@ exports[`Select component renders component in search mode and false for multipl
         aria-controls={null}
         aria-expanded="false"
         aria-haspopup="true"
+        data-baseweb="select"
         onClick={[Function]}
         styled-component="true"
       >
-        <MockStyledComponent
+        <StyledControlContainer
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -169,7 +171,7 @@ exports[`Select component renders component in search mode and false for multipl
                 title="search"
                 viewBox="0 0 24 24"
               >
-                <MockStyledComponent
+                <StyledSearchIcon
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -182,9 +184,11 @@ exports[`Select component renders component in search mode and false for multipl
                   $searchable={true}
                   $size={16}
                   $type="search"
+                  data-baseweb="icon"
                   viewBox="0 0 24 24"
                 >
                   <svg
+                    data-baseweb="icon"
                     styled-component="true"
                     viewBox="0 0 24 24"
                   >
@@ -197,10 +201,10 @@ exports[`Select component renders component in search mode and false for multipl
                       fillRule="evenodd"
                     />
                   </svg>
-                </MockStyledComponent>
+                </StyledSearchIcon>
               </Icon>
             </Search>
-            <MockStyledComponent
+            <StyledValueContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -217,7 +221,7 @@ exports[`Select component renders component in search mode and false for multipl
               <span
                 styled-component="true"
               >
-                <MockStyledComponent
+                <StyledPlaceholder
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -236,8 +240,8 @@ exports[`Select component renders component in search mode and false for multipl
                   >
                     Select...
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent
+                </StyledPlaceholder>
+                <StyledInputContainer
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -289,7 +293,7 @@ exports[`Select component renders component in search mode and false for multipl
                       role="combobox"
                       value=""
                     >
-                      <MockStyledComponent
+                      <StyledInput
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -338,20 +342,20 @@ exports[`Select component renders component in search mode and false for multipl
                           styled-component="true"
                           value=""
                         />
-                      </MockStyledComponent>
-                      <MockStyledComponent
+                      </StyledInput>
+                      <StyledInputSizer
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </MockStyledComponent>
+                      </StyledInputSizer>
                     </AutosizeInput>
                   </div>
-                </MockStyledComponent>
+                </StyledInputContainer>
               </span>
-            </MockStyledComponent>
-            <MockStyledComponent
+            </StyledValueContainer>
+            <StyledIconsContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -368,11 +372,11 @@ exports[`Select component renders component in search mode and false for multipl
               <div
                 styled-component="true"
               />
-            </MockStyledComponent>
+            </StyledIconsContainer>
           </div>
-        </MockStyledComponent>
+        </StyledControlContainer>
       </div>
-    </MockStyledComponent>
+    </StyledRoot>
   </Popover>
 </Select>
 `;
@@ -445,7 +449,7 @@ exports[`Select component renders component in search mode and true for multiple
     showArrow={false}
     triggerType="click"
   >
-    <MockStyledComponent
+    <StyledRoot
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -466,6 +470,7 @@ exports[`Select component renders component in search mode and true for multiple
       aria-controls={null}
       aria-expanded="false"
       aria-haspopup="true"
+      data-baseweb="select"
       key="popover-anchor"
       onClick={[Function]}
     >
@@ -473,10 +478,11 @@ exports[`Select component renders component in search mode and true for multiple
         aria-controls={null}
         aria-expanded="false"
         aria-haspopup="true"
+        data-baseweb="select"
         onClick={[Function]}
         styled-component="true"
       >
-        <MockStyledComponent
+        <StyledControlContainer
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -546,7 +552,7 @@ exports[`Select component renders component in search mode and true for multiple
                 title="search"
                 viewBox="0 0 24 24"
               >
-                <MockStyledComponent
+                <StyledSearchIcon
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -559,9 +565,11 @@ exports[`Select component renders component in search mode and true for multiple
                   $searchable={true}
                   $size={16}
                   $type="search"
+                  data-baseweb="icon"
                   viewBox="0 0 24 24"
                 >
                   <svg
+                    data-baseweb="icon"
                     styled-component="true"
                     viewBox="0 0 24 24"
                   >
@@ -574,10 +582,10 @@ exports[`Select component renders component in search mode and true for multiple
                       fillRule="evenodd"
                     />
                   </svg>
-                </MockStyledComponent>
+                </StyledSearchIcon>
               </Icon>
             </Search>
-            <MockStyledComponent
+            <StyledValueContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -594,7 +602,7 @@ exports[`Select component renders component in search mode and true for multiple
               <span
                 styled-component="true"
               >
-                <MockStyledComponent
+                <StyledPlaceholder
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -613,8 +621,8 @@ exports[`Select component renders component in search mode and true for multiple
                   >
                     Select...
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent
+                </StyledPlaceholder>
+                <StyledInputContainer
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -666,7 +674,7 @@ exports[`Select component renders component in search mode and true for multiple
                       role="combobox"
                       value=""
                     >
-                      <MockStyledComponent
+                      <StyledInput
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -715,20 +723,20 @@ exports[`Select component renders component in search mode and true for multiple
                           styled-component="true"
                           value=""
                         />
-                      </MockStyledComponent>
-                      <MockStyledComponent
+                      </StyledInput>
+                      <StyledInputSizer
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </MockStyledComponent>
+                      </StyledInputSizer>
                     </AutosizeInput>
                   </div>
-                </MockStyledComponent>
+                </StyledInputContainer>
               </span>
-            </MockStyledComponent>
-            <MockStyledComponent
+            </StyledValueContainer>
+            <StyledIconsContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -745,11 +753,11 @@ exports[`Select component renders component in search mode and true for multiple
               <div
                 styled-component="true"
               />
-            </MockStyledComponent>
+            </StyledIconsContainer>
           </div>
-        </MockStyledComponent>
+        </StyledControlContainer>
       </div>
-    </MockStyledComponent>
+    </StyledRoot>
   </Popover>
 </Select>
 `;
@@ -822,7 +830,7 @@ exports[`Select component renders component in select mode and false for multipl
     showArrow={false}
     triggerType="click"
   >
-    <MockStyledComponent
+    <StyledRoot
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -843,6 +851,7 @@ exports[`Select component renders component in select mode and false for multipl
       aria-controls={null}
       aria-expanded="false"
       aria-haspopup="true"
+      data-baseweb="select"
       key="popover-anchor"
       onClick={[Function]}
     >
@@ -850,10 +859,11 @@ exports[`Select component renders component in select mode and false for multipl
         aria-controls={null}
         aria-expanded="false"
         aria-haspopup="true"
+        data-baseweb="select"
         onClick={[Function]}
         styled-component="true"
       >
-        <MockStyledComponent
+        <StyledControlContainer
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -880,7 +890,7 @@ exports[`Select component renders component in select mode and false for multipl
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <MockStyledComponent
+            <StyledValueContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -897,7 +907,7 @@ exports[`Select component renders component in select mode and false for multipl
               <span
                 styled-component="true"
               >
-                <MockStyledComponent
+                <StyledPlaceholder
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -916,8 +926,8 @@ exports[`Select component renders component in select mode and false for multipl
                   >
                     Select...
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent
+                </StyledPlaceholder>
+                <StyledInputContainer
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -969,7 +979,7 @@ exports[`Select component renders component in select mode and false for multipl
                       role="combobox"
                       value=""
                     >
-                      <MockStyledComponent
+                      <StyledInput
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -1018,20 +1028,20 @@ exports[`Select component renders component in select mode and false for multipl
                           styled-component="true"
                           value=""
                         />
-                      </MockStyledComponent>
-                      <MockStyledComponent
+                      </StyledInput>
+                      <StyledInputSizer
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </MockStyledComponent>
+                      </StyledInputSizer>
                     </AutosizeInput>
                   </div>
-                </MockStyledComponent>
+                </StyledInputContainer>
               </span>
-            </MockStyledComponent>
-            <MockStyledComponent
+            </StyledValueContainer>
+            <StyledIconsContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1091,7 +1101,7 @@ exports[`Select component renders component in select mode and false for multipl
                     title="open"
                     viewBox="0 0 24 24"
                   >
-                    <MockStyledComponent
+                    <StyledSelectArrow
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -1104,9 +1114,11 @@ exports[`Select component renders component in select mode and false for multipl
                       $searchable={true}
                       $size={16}
                       $type="select"
+                      data-baseweb="icon"
                       viewBox="0 0 24 24"
                     >
                       <svg
+                        data-baseweb="icon"
                         styled-component="true"
                         viewBox="0 0 24 24"
                       >
@@ -1117,15 +1129,15 @@ exports[`Select component renders component in select mode and false for multipl
                           d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                         />
                       </svg>
-                    </MockStyledComponent>
+                    </StyledSelectArrow>
                   </Icon>
                 </TriangleDown>
               </div>
-            </MockStyledComponent>
+            </StyledIconsContainer>
           </div>
-        </MockStyledComponent>
+        </StyledControlContainer>
       </div>
-    </MockStyledComponent>
+    </StyledRoot>
   </Popover>
 </Select>
 `;
@@ -1198,7 +1210,7 @@ exports[`Select component renders component in select mode and true for multiple
     showArrow={false}
     triggerType="click"
   >
-    <MockStyledComponent
+    <StyledRoot
       $clearable={true}
       $disabled={false}
       $error={false}
@@ -1219,6 +1231,7 @@ exports[`Select component renders component in select mode and true for multiple
       aria-controls={null}
       aria-expanded="false"
       aria-haspopup="true"
+      data-baseweb="select"
       key="popover-anchor"
       onClick={[Function]}
     >
@@ -1226,10 +1239,11 @@ exports[`Select component renders component in select mode and true for multiple
         aria-controls={null}
         aria-expanded="false"
         aria-haspopup="true"
+        data-baseweb="select"
         onClick={[Function]}
         styled-component="true"
       >
-        <MockStyledComponent
+        <StyledControlContainer
           $clearable={true}
           $disabled={false}
           $error={false}
@@ -1256,7 +1270,7 @@ exports[`Select component renders component in select mode and true for multiple
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <MockStyledComponent
+            <StyledValueContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1273,7 +1287,7 @@ exports[`Select component renders component in select mode and true for multiple
               <span
                 styled-component="true"
               >
-                <MockStyledComponent
+                <StyledPlaceholder
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -1292,8 +1306,8 @@ exports[`Select component renders component in select mode and true for multiple
                   >
                     Select...
                   </div>
-                </MockStyledComponent>
-                <MockStyledComponent
+                </StyledPlaceholder>
+                <StyledInputContainer
                   $clearable={true}
                   $disabled={false}
                   $error={false}
@@ -1345,7 +1359,7 @@ exports[`Select component renders component in select mode and true for multiple
                       role="combobox"
                       value=""
                     >
-                      <MockStyledComponent
+                      <StyledInput
                         $clearable={true}
                         $disabled={false}
                         $error={false}
@@ -1394,20 +1408,20 @@ exports[`Select component renders component in select mode and true for multiple
                           styled-component="true"
                           value=""
                         />
-                      </MockStyledComponent>
-                      <MockStyledComponent
+                      </StyledInput>
+                      <StyledInputSizer
                         $ref={[Function]}
                       >
                         <div
                           styled-component="true"
                         />
-                      </MockStyledComponent>
+                      </StyledInputSizer>
                     </AutosizeInput>
                   </div>
-                </MockStyledComponent>
+                </StyledInputContainer>
               </span>
-            </MockStyledComponent>
-            <MockStyledComponent
+            </StyledValueContainer>
+            <StyledIconsContainer
               $clearable={true}
               $disabled={false}
               $error={false}
@@ -1467,7 +1481,7 @@ exports[`Select component renders component in select mode and true for multiple
                     title="open"
                     viewBox="0 0 24 24"
                   >
-                    <MockStyledComponent
+                    <StyledSelectArrow
                       $clearable={true}
                       $disabled={false}
                       $error={false}
@@ -1480,9 +1494,11 @@ exports[`Select component renders component in select mode and true for multiple
                       $searchable={true}
                       $size={16}
                       $type="select"
+                      data-baseweb="icon"
                       viewBox="0 0 24 24"
                     >
                       <svg
+                        data-baseweb="icon"
                         styled-component="true"
                         viewBox="0 0 24 24"
                       >
@@ -1493,15 +1509,15 @@ exports[`Select component renders component in select mode and true for multiple
                           d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z"
                         />
                       </svg>
-                    </MockStyledComponent>
+                    </StyledSelectArrow>
                   </Icon>
                 </TriangleDown>
               </div>
-            </MockStyledComponent>
+            </StyledIconsContainer>
           </div>
-        </MockStyledComponent>
+        </StyledControlContainer>
       </div>
-    </MockStyledComponent>
+    </StyledRoot>
   </Popover>
 </Select>
 `;

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -867,7 +867,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
             }}
             placement={PLACEMENT.bottom}
           >
-            <Root {...sharedProps} {...rootProps}>
+            <Root data-baseweb="select" {...sharedProps} {...rootProps}>
               <ControlContainer
                 onKeyDown={this.handleKeyDown}
                 onClick={this.handleClick}

--- a/src/slider/slider.js
+++ b/src/slider/slider.js
@@ -78,7 +78,7 @@ class Slider extends React.Component<PropsT> {
     );
     const sharedProps = this.getSharedProps();
     return (
-      <Root {...sharedProps} {...rootProps}>
+      <Root data-baseweb="slider" {...sharedProps} {...rootProps}>
         <Range
           step={step}
           min={min}

--- a/src/spinner/spinner.js
+++ b/src/spinner/spinner.js
@@ -39,6 +39,7 @@ class Spinner extends React.Component<SpinnerPropsT> {
 
     return (
       <Icon
+        data-baseweb="spinner"
         title="Spinner"
         viewBox="3 3 18 18"
         {...this.props}

--- a/src/table/__tests__/table.test.js
+++ b/src/table/__tests__/table.test.js
@@ -46,13 +46,11 @@ describe('Table', () => {
 
   it('applies correct aria attributes to table container', () => {
     const wrapper = mount(<Table columns={COLUMNS} data={DATA} />);
-    const container = wrapper.find(StyledTable);
-
-    expect(container.getDOMNode().getAttribute('role')).toBe('grid');
-    expect(container.getDOMNode().getAttribute('aria-colcount')).toBe(
+    expect(wrapper.getDOMNode().getAttribute('role')).toBe('grid');
+    expect(wrapper.getDOMNode().getAttribute('aria-colcount')).toBe(
       COLUMNS.length.toString(),
     );
-    expect(container.getDOMNode().getAttribute('aria-rowcount')).toBe(
+    expect(wrapper.getDOMNode().getAttribute('aria-rowcount')).toBe(
       DATA.length.toString(),
     );
   });

--- a/src/table/__tests__/table.test.js
+++ b/src/table/__tests__/table.test.js
@@ -11,7 +11,6 @@ import {mount, shallow} from 'enzyme';
 
 import {
   Table,
-  StyledTable,
   StyledHead,
   StyledHeadCell,
   StyledBody,

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -5,12 +5,21 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+import React from 'react';
+
 export {default as SortableHeadCell} from './sortable-head-cell.js';
 export {default as Table} from './table.js';
 export {default as Filter} from './filter.js';
 // Styled elements
+
+import {StyledTable as Table} from './styled-components.js';
+
+//$FlowFixMe
+export const StyledTable = props => (
+  <Table data-baseweb="table-custom" {...props} />
+);
+
 export {
-  StyledTable,
   StyledFilterButton,
   StyledFilterContent,
   StyledFilterHeading,

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -29,6 +29,7 @@ export default class Table extends React.Component<TablePropsT> {
   render() {
     return (
       <StyledTable
+        data-baseweb="table"
         role="grid"
         aria-colcount={this.props.columns.length}
         aria-rowcount={this.props.data.length}

--- a/src/tabs/__tests__/__snapshots__/stateful-tabs.test.js.snap
+++ b/src/tabs/__tests__/__snapshots__/stateful-tabs.test.js.snap
@@ -26,7 +26,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
       orientation="horizontal"
       overrides={Object {}}
     >
-      <Root
+      <MockStyledComponent
         $disabled={false}
         $orientation="horizontal"
         data-baseweb="tabs"
@@ -35,7 +35,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
           data-baseweb="tabs"
           styled-component="true"
         >
-          <TabBar
+          <MockStyledComponent
             $disabled={false}
             $orientation="horizontal"
             role="tablist"
@@ -56,7 +56,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -80,7 +80,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 1
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -94,7 +94,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={true}
                   $disabled={false}
                   $orientation="horizontal"
@@ -118,7 +118,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 2
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -132,7 +132,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -156,11 +156,11 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 3
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
             </div>
-          </TabBar>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -173,8 +173,8 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
               role="tabpanel"
               styled-component="true"
             />
-          </TabContent>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={true}
             $disabled={false}
             $orientation="horizontal"
@@ -189,8 +189,8 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
             >
               Tab 2 content
             </div>
-          </TabContent>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -203,9 +203,9 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
               role="tabpanel"
               styled-component="true"
             />
-          </TabContent>
+          </MockStyledComponent>
         </div>
-      </Root>
+      </MockStyledComponent>
     </Tabs>
   </StatefulTabs>
 </Component>
@@ -226,7 +226,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
       orientation="horizontal"
       overrides={Object {}}
     >
-      <Root
+      <MockStyledComponent
         $disabled={false}
         $orientation="horizontal"
         data-baseweb="tabs"
@@ -235,7 +235,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
           data-baseweb="tabs"
           styled-component="true"
         >
-          <TabBar
+          <MockStyledComponent
             $disabled={false}
             $orientation="horizontal"
             role="tablist"
@@ -256,7 +256,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={true}
                   $disabled={false}
                   $orientation="horizontal"
@@ -280,7 +280,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 1
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -294,7 +294,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -318,7 +318,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 2
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -332,7 +332,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <Tab
+                <MockStyledComponent
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -356,11 +356,11 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 3
                   </div>
-                </Tab>
+                </MockStyledComponent>
               </TabComponent>
             </div>
-          </TabBar>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={true}
             $disabled={false}
             $orientation="horizontal"
@@ -375,8 +375,8 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
             >
               Tab 1 content
             </div>
-          </TabContent>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -389,8 +389,8 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
               role="tabpanel"
               styled-component="true"
             />
-          </TabContent>
-          <TabContent
+          </MockStyledComponent>
+          <MockStyledComponent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -403,9 +403,9 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
               role="tabpanel"
               styled-component="true"
             />
-          </TabContent>
+          </MockStyledComponent>
         </div>
-      </Root>
+      </MockStyledComponent>
     </Tabs>
   </StatefulTabs>
 </Component>

--- a/src/tabs/__tests__/__snapshots__/stateful-tabs.test.js.snap
+++ b/src/tabs/__tests__/__snapshots__/stateful-tabs.test.js.snap
@@ -26,14 +26,16 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
       orientation="horizontal"
       overrides={Object {}}
     >
-      <MockStyledComponent
+      <Root
         $disabled={false}
         $orientation="horizontal"
+        data-baseweb="tabs"
       >
         <div
+          data-baseweb="tabs"
           styled-component="true"
         >
-          <MockStyledComponent
+          <TabBar
             $disabled={false}
             $orientation="horizontal"
             role="tablist"
@@ -54,7 +56,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -78,7 +80,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 1
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -92,7 +94,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={true}
                   $disabled={false}
                   $orientation="horizontal"
@@ -116,7 +118,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 2
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -130,7 +132,7 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -154,11 +156,11 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
                   >
                     Tab Link 3
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
             </div>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabBar>
+          <TabContent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -171,8 +173,8 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
               role="tabpanel"
               styled-component="true"
             />
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabContent>
+          <TabContent
             $active={true}
             $disabled={false}
             $orientation="horizontal"
@@ -187,8 +189,8 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
             >
               Tab 2 content
             </div>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabContent>
+          <TabContent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -201,9 +203,9 @@ exports[`StatefulTabs basic render with initial state: Stateful tabs render corr
               role="tabpanel"
               styled-component="true"
             />
-          </MockStyledComponent>
+          </TabContent>
         </div>
-      </MockStyledComponent>
+      </Root>
     </Tabs>
   </StatefulTabs>
 </Component>
@@ -224,14 +226,16 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
       orientation="horizontal"
       overrides={Object {}}
     >
-      <MockStyledComponent
+      <Root
         $disabled={false}
         $orientation="horizontal"
+        data-baseweb="tabs"
       >
         <div
+          data-baseweb="tabs"
           styled-component="true"
         >
-          <MockStyledComponent
+          <TabBar
             $disabled={false}
             $orientation="horizontal"
             role="tablist"
@@ -252,7 +256,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={true}
                   $disabled={false}
                   $orientation="horizontal"
@@ -276,7 +280,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 1
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -290,7 +294,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -314,7 +318,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 2
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
               <TabComponent
                 $orientation="horizontal"
@@ -328,7 +332,7 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                 onSelect={[Function]}
                 title=""
               >
-                <MockStyledComponent
+                <Tab
                   $active={false}
                   $disabled={false}
                   $orientation="horizontal"
@@ -352,11 +356,11 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
                   >
                     Tab Link 3
                   </div>
-                </MockStyledComponent>
+                </Tab>
               </TabComponent>
             </div>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabBar>
+          <TabContent
             $active={true}
             $disabled={false}
             $orientation="horizontal"
@@ -371,8 +375,8 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
             >
               Tab 1 content
             </div>
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabContent>
+          <TabContent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -385,8 +389,8 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
               role="tabpanel"
               styled-component="true"
             />
-          </MockStyledComponent>
-          <MockStyledComponent
+          </TabContent>
+          <TabContent
             $active={false}
             $disabled={false}
             $orientation="horizontal"
@@ -399,9 +403,9 @@ exports[`StatefulTabs basic render: Stateful tabs render correctly 1`] = `
               role="tabpanel"
               styled-component="true"
             />
-          </MockStyledComponent>
+          </TabContent>
         </div>
-      </MockStyledComponent>
+      </Root>
     </Tabs>
   </StatefulTabs>
 </Component>

--- a/src/tabs/tabs.js
+++ b/src/tabs/tabs.js
@@ -107,7 +107,7 @@ export default class Tabs extends React.Component<TabsPropsT> {
     const [TabBar, tabBarProps] = getOverrides(TabBarOverride, StyledTabBar);
 
     return (
-      <Root {...sharedProps} {...rootProps}>
+      <Root data-baseweb="tabs" {...sharedProps} {...rootProps}>
         <TabBar role="tablist" {...sharedProps} {...tabBarProps}>
           {this.getTabs()}
         </TabBar>

--- a/src/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -14,7 +14,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
   overrides={Object {}}
   variant="light"
 >
-  <Root
+  <MockStyledComponent
     $clickable={false}
     $closeable={true}
     $disabled={false}
@@ -38,14 +38,14 @@ exports[`Stateless tag should render component: Component has correct render 1`]
       styled-component="true"
       tabIndex={null}
     >
-      <Text>
+      <MockStyledComponent>
         <span
           styled-component="true"
         >
           Some tag
         </span>
-      </Text>
-      <Action
+      </MockStyledComponent>
+      <MockStyledComponent
         $clickable={false}
         $closeable={true}
         $disabled={false}
@@ -67,7 +67,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
           styled-component="true"
           tabIndex="0"
         >
-          <ActionIcon
+          <MockStyledComponent
             fill="none"
             height="10"
             viewBox="0 0 8 8"
@@ -89,10 +89,10 @@ exports[`Stateless tag should render component: Component has correct render 1`]
                 fillRule="evenodd"
               />
             </svg>
-          </ActionIcon>
+          </MockStyledComponent>
         </span>
-      </Action>
+      </MockStyledComponent>
     </span>
-  </Root>
+  </MockStyledComponent>
 </Tag>
 `;

--- a/src/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -14,7 +14,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
   overrides={Object {}}
   variant="light"
 >
-  <MockStyledComponent
+  <Root
     $clickable={false}
     $closeable={true}
     $disabled={false}
@@ -23,6 +23,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
     $kind="primary"
     $variant="light"
     aria-label="button"
+    data-baseweb="tag"
     onClick={null}
     onKeyDown={[Function]}
     role="button"
@@ -30,20 +31,21 @@ exports[`Stateless tag should render component: Component has correct render 1`]
   >
     <span
       aria-label="button"
+      data-baseweb="tag"
       onClick={null}
       onKeyDown={[Function]}
       role="button"
       styled-component="true"
       tabIndex={null}
     >
-      <MockStyledComponent>
+      <Text>
         <span
           styled-component="true"
         >
           Some tag
         </span>
-      </MockStyledComponent>
-      <MockStyledComponent
+      </Text>
+      <Action
         $clickable={false}
         $closeable={true}
         $disabled={false}
@@ -65,7 +67,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
           styled-component="true"
           tabIndex="0"
         >
-          <MockStyledComponent
+          <ActionIcon
             fill="none"
             height="10"
             viewBox="0 0 8 8"
@@ -87,10 +89,10 @@ exports[`Stateless tag should render component: Component has correct render 1`]
                 fillRule="evenodd"
               />
             </svg>
-          </MockStyledComponent>
+          </ActionIcon>
         </span>
-      </MockStyledComponent>
+      </Action>
     </span>
-  </MockStyledComponent>
+  </Root>
 </Tag>
 `;

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -102,6 +102,7 @@ class Tag extends React.Component<PropsT, {}> {
     };
     return (
       <Root
+        data-baseweb="tag"
         aria-label="button"
         role="button"
         tabIndex={clickable ? '0' : null}

--- a/src/template-component/component.js
+++ b/src/template-component/component.js
@@ -34,6 +34,7 @@ class Component extends React.Component<ComponentPropsT> {
     return (
       //$FlowFixMe
       <Root
+        data-baseweb="component"
         onClick={this.props.onClick}
         {...sharedProps}
         {...getOverrideProps(RootOverride)}

--- a/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
+++ b/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
@@ -32,6 +32,7 @@ Object {
   "aria-label": null,
   "aria-labelledby": null,
   "autoFocus": false,
+  "data-baseweb": "textarea",
   "disabled": false,
   "error": false,
   "inputRef": Object {
@@ -68,6 +69,7 @@ Object {
   "aria-label": null,
   "aria-labelledby": null,
   "autoFocus": false,
+  "data-baseweb": "textarea",
   "disabled": false,
   "error": false,
   "inputRef": Object {

--- a/src/textarea/textarea.js
+++ b/src/textarea/textarea.js
@@ -45,6 +45,7 @@ class Textarea extends React.Component<TextareaPropsT> {
     );
     return (
       <BaseInput
+        data-baseweb="textarea"
         {...this.props}
         type={CUSTOM_INPUT_TYPE.textarea}
         overrides={overrides}

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -161,6 +161,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
           <Body
             tabIndex={0}
             role="alert"
+            data-baseweb={this.props['data-baseweb'] || 'toast'}
             {...sharedProps}
             {...bodyProps}
             // the properties below have to go after overrides

--- a/src/toast/toaster.js
+++ b/src/toast/toaster.js
@@ -170,7 +170,7 @@ export class ToasterContainer extends React.Component<
     }
 
     const root = (
-      <Root {...sharedProps} {...rootProps}>
+      <Root data-baseweb="toaster" {...sharedProps} {...rootProps}>
         {toastsToRender}
       </Root>
     );

--- a/src/toast/types.js
+++ b/src/toast/types.js
@@ -74,6 +74,7 @@ export type ToastPropsT = {
   onFocus: (e: Event) => void,
   onMouseEnter: (e: Event) => void,
   onMouseLeave: (e: Event) => void,
+  'data-baseweb'?: string,
   overrides: OverridesT,
   key: React.Key,
 };

--- a/src/tooltip/__tests__/tooltip.test.js
+++ b/src/tooltip/__tests__/tooltip.test.js
@@ -53,6 +53,7 @@ describe('Tooltip', () => {
     expect(component.props()).toEqual({
       ...baseDefaultProps,
       ...props,
+      'data-baseweb': 'tooltip',
       children: button,
       ignoreBoundary: false,
       overrides: {

--- a/src/tooltip/tooltip.js
+++ b/src/tooltip/tooltip.js
@@ -31,7 +31,9 @@ class Tooltip extends React.Component<TooltipPropsT> {
       },
       this.props.overrides,
     );
-    return <Popover {...this.props} overrides={overrides} />;
+    return (
+      <Popover data-baseweb="tooltip" {...this.props} overrides={overrides} />
+    );
   }
 }
 

--- a/src/typography/index.js
+++ b/src/typography/index.js
@@ -13,6 +13,7 @@ import type {BlockPropsT} from '../block/types.js';
 // Captions - aka Caption, CaptionLabel
 export const Caption1 = (props: BlockPropsT) => (
   <Block
+    data-baseweb="typo-caption1"
     {...props}
     font={props.font || 'font200'}
     color={props.color || 'colorSecondary'}
@@ -21,6 +22,7 @@ export const Caption1 = (props: BlockPropsT) => (
 
 export const Caption2 = (props: BlockPropsT) => (
   <Block
+    data-baseweb="typo-caption2"
     {...props}
     font={props.font || 'font250'}
     color={props.color || 'colorSecondary'}
@@ -30,6 +32,7 @@ export const Caption2 = (props: BlockPropsT) => (
 // Display
 export const Display = (props: BlockPropsT) => (
   <Block
+    data-baseweb="typo-display"
     {...props}
     font={props.font || 'font1100'}
     color={props.color || 'colorPrimary'}
@@ -41,6 +44,7 @@ export function H1(props: BlockPropsT) {
   const as = props.as || 'h1';
   return (
     <Block
+      data-baseweb="typo-h1"
       as={as}
       {...props}
       font={props.font || 'font1000'}
@@ -53,6 +57,7 @@ export function H2(props: BlockPropsT) {
   const as = props.as || 'h2';
   return (
     <Block
+      data-baseweb="typo-h2"
       as={as}
       {...props}
       font={props.font || 'font900'}
@@ -65,6 +70,7 @@ export function H3(props: BlockPropsT) {
   const as = props.as || 'h3';
   return (
     <Block
+      data-baseweb="typo-h3"
       as={as}
       {...props}
       font={props.font || 'font800'}
@@ -77,6 +83,7 @@ export function H4(props: BlockPropsT) {
   const as = props.as || 'h4';
   return (
     <Block
+      data-baseweb="typo-h4"
       as={as}
       {...props}
       font={props.font || 'font700'}
@@ -89,6 +96,7 @@ export function H5(props: BlockPropsT) {
   const as = props.as || 'h5';
   return (
     <Block
+      data-baseweb="typo-h5"
       as={as}
       {...props}
       font={props.font || 'font600'}
@@ -101,6 +109,7 @@ export function H6(props: BlockPropsT) {
   const as = props.as || 'h6';
   return (
     <Block
+      data-baseweb="typo-h6"
       as={as}
       {...props}
       font={props.font || 'font500'}
@@ -112,6 +121,7 @@ export function H6(props: BlockPropsT) {
 // Labels - aka Label1, Label2
 export const Label1 = (props: BlockPropsT) => (
   <Block
+    data-baseweb="typo-label1"
     {...props}
     font={props.font || 'font350'}
     color={props.color || 'colorPrimary'}
@@ -120,6 +130,7 @@ export const Label1 = (props: BlockPropsT) => (
 
 export const Label2 = (props: BlockPropsT) => (
   <Block
+    data-baseweb="typo-label2"
     {...props}
     font={props.font || 'font450'}
     color={props.color || 'colorPrimary'}
@@ -131,6 +142,7 @@ export function Paragraph1(props: BlockPropsT) {
   const as = props.as || 'p';
   return (
     <Block
+      data-baseweb="typo-p1"
       as={as}
       {...props}
       font={props.font || 'font300'}
@@ -143,6 +155,7 @@ export function Paragraph2(props: BlockPropsT) {
   const as = props.as || 'p';
   return (
     <Block
+      data-baseweb="typo-p2"
       as={as}
       {...props}
       font={props.font || 'font400'}


### PR DESCRIPTION
This adds a new `data-baseweb="component"` attribute to all component roots (there are some exceptions). The idea is that we can later use this attribute to easily detect/scrape/test/screenshot our components across projects.
