### PR TITLE
chore: run documentation link checker in workers queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -65,7 +65,7 @@ steps:
           - docs-site-server
           - docs-site-healthy
     agents:
-      queue: builders
+      queue: workers
   - name: ':puppeteer:'
     command: yarn e2e:test:ci
     plugins:


### PR DESCRIPTION
#### Description

The workers queue has better autoscaling and generally more agents. This should result in faster builds.

#### Scope

Refactor only, no release necessary.