### PR TITLE
fix(icon): applies isolated styles to globally overridden icons

### DIFF
--- a/documentation-site/routes.js
+++ b/documentation-site/routes.js
@@ -62,8 +62,8 @@ const routes = [
         itemId: '/theming/understanding-overrides',
       },
       {
-        text: 'Icons',
-        path: '/theming/overriding-icons',
+        title: 'Icons',
+        itemId: '/theming/overriding-icons',
       },
     ],
   },

--- a/src/accordion/styled-components.js
+++ b/src/accordion/styled-components.js
@@ -34,7 +34,7 @@ export const Header = styled('div', (props: SharedStylePropsT) => {
     paddingTop: sizing.scale600,
     paddingBottom: sizing.scale600,
     paddingLeft: sizing.scale700,
-    paddingRight: sizing.scale1200,
+    paddingRight: sizing.scale800,
     marginTop: 0,
     marginBottom: 0,
     marginLeft: 0,
@@ -43,6 +43,7 @@ export const Header = styled('div', (props: SharedStylePropsT) => {
     position: 'relative',
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'space-between',
     ':hover': {
       color: colors.linkHover,
     },
@@ -58,8 +59,6 @@ export const ToggleIcon = styled('svg', props => {
     ...getSvgStyles(props),
     color: $color || $theme.colors.foreground,
     cursor: $disabled ? 'not-allowed' : 'pointer',
-    position: 'absolute',
-    right: '12px',
   };
 });
 

--- a/src/icon/alert.js
+++ b/src/icon/alert.js
@@ -17,7 +17,9 @@ export default function Alert(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Alert ? (
-          <theme.icons.Alert title="Alert" viewBox="0 0 24 24" {...props} />
+          <Icon title="Alert" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Alert />
+          </Icon>
         ) : (
           <Icon title="Alert" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/arrow-down.js
+++ b/src/icon/arrow-down.js
@@ -17,11 +17,9 @@ export default function ArrowDown(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ArrowDown ? (
-          <theme.icons.ArrowDown
-            title="Arrow Down"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Arrow Down" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ArrowDown />
+          </Icon>
         ) : (
           <Icon title="Arrow Down" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/arrow-left.js
+++ b/src/icon/arrow-left.js
@@ -17,11 +17,9 @@ export default function ArrowLeft(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ArrowLeft ? (
-          <theme.icons.ArrowLeft
-            title="Arrow Left"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Arrow Left" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ArrowLeft />
+          </Icon>
         ) : (
           <Icon title="Arrow Left" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/arrow-right.js
+++ b/src/icon/arrow-right.js
@@ -17,11 +17,9 @@ export default function ArrowRight(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ArrowRight ? (
-          <theme.icons.ArrowRight
-            title="Arrow Right"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Arrow Right" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ArrowRight />
+          </Icon>
         ) : (
           <Icon title="Arrow Right" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/arrow-up.js
+++ b/src/icon/arrow-up.js
@@ -17,11 +17,9 @@ export default function ArrowUp(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ArrowUp ? (
-          <theme.icons.ArrowUp
-            title="Arrow Up"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Arrow Up" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ArrowUp />
+          </Icon>
         ) : (
           <Icon title="Arrow Up" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/check-indeterminate.js
+++ b/src/icon/check-indeterminate.js
@@ -17,11 +17,9 @@ export default function CheckIndeterminate(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.CheckIndeterminate ? (
-          <theme.icons.CheckIndeterminate
-            title="Check Indeterminate"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Check Indeterminate" viewBox="0 0 24 24" {...props}>
+            <theme.icons.CheckIndeterminate />
+          </Icon>
         ) : (
           <Icon title="Check Indeterminate" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/check.js
+++ b/src/icon/check.js
@@ -17,7 +17,9 @@ export default function Check(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Check ? (
-          <theme.icons.Check title="Check" viewBox="0 0 24 24" {...props} />
+          <Icon title="Check" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Check />
+          </Icon>
         ) : (
           <Icon title="Check" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/chevron-left.js
+++ b/src/icon/chevron-left.js
@@ -17,11 +17,9 @@ export default function ChevronLeft(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ChevronLeft ? (
-          <theme.icons.ChevronLeft
-            title="Chevron Left"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Chevron Left" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ChevronLeft />
+          </Icon>
         ) : (
           <Icon title="Chevron Left" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/chevron-right.js
+++ b/src/icon/chevron-right.js
@@ -17,11 +17,9 @@ export default function ChevronRight(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.ChevronRight ? (
-          <theme.icons.ChevronRight
-            title="Chevron Right"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Chevron Right" viewBox="0 0 24 24" {...props}>
+            <theme.icons.ChevronRight />
+          </Icon>
         ) : (
           <Icon title="Chevron Right" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/delete-alt.js
+++ b/src/icon/delete-alt.js
@@ -17,11 +17,9 @@ export default function DeleteAlt(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.DeleteAlt ? (
-          <theme.icons.DeleteAlt
-            title="Delete Alt"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Delete Alt" viewBox="0 0 24 24" {...props}>
+            <theme.icons.DeleteAlt />
+          </Icon>
         ) : (
           <Icon title="Delete Alt" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/delete.js
+++ b/src/icon/delete.js
@@ -17,7 +17,9 @@ export default function Delete(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Delete ? (
-          <theme.icons.Delete title="Delete" viewBox="0 0 24 24" {...props} />
+          <Icon title="Delete" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Delete />
+          </Icon>
         ) : (
           <Icon title="Delete" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/filter.js
+++ b/src/icon/filter.js
@@ -17,7 +17,9 @@ export default function Filter(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Filter ? (
-          <theme.icons.Filter title="Filter" viewBox="0 0 24 24" {...props} />
+          <Icon title="Filter" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Filter />
+          </Icon>
         ) : (
           <Icon title="Filter" viewBox="0 0 24 24" {...props}>
             <rect x="7" y="11" width="10" height="2" rx="1" />

--- a/src/icon/grab.js
+++ b/src/icon/grab.js
@@ -17,7 +17,9 @@ export default function Grab(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Grab ? (
-          <theme.icons.Grab title="Grab" viewBox="0 0 24 24" {...props} />
+          <Icon title="Grab" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Grab />
+          </Icon>
         ) : (
           <Icon title="Grab" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/icon-template.txt
+++ b/src/icon/icon-template.txt
@@ -18,7 +18,9 @@ export default function %%ICON_NAME%%(props: IconPropsT) {
       {theme => (
         theme.icons && theme.icons.%%ICON_NAME%% ?
         (
-          <theme.icons.%%ICON_NAME%% %%ICON_PROPS%% {...props} />
+          <Icon %%ICON_PROPS%% {...props}>
+            <theme.icons.%%ICON_NAME%% />
+          </Icon>
         )
         :
         (

--- a/src/icon/menu.js
+++ b/src/icon/menu.js
@@ -17,7 +17,9 @@ export default function Menu(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Menu ? (
-          <theme.icons.Menu title="Menu" viewBox="0 0 24 24" {...props} />
+          <Icon title="Menu" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Menu />
+          </Icon>
         ) : (
           <Icon title="Menu" viewBox="0 0 24 24" {...props}>
             <rect x="4" y="11" width="16" height="2" rx="1" />

--- a/src/icon/overflow.js
+++ b/src/icon/overflow.js
@@ -17,11 +17,9 @@ export default function Overflow(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Overflow ? (
-          <theme.icons.Overflow
-            title="Overflow"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Overflow" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Overflow />
+          </Icon>
         ) : (
           <Icon title="Overflow" viewBox="0 0 24 24" {...props}>
             <circle cx="6" cy="12" r="2" />

--- a/src/icon/plus.js
+++ b/src/icon/plus.js
@@ -17,7 +17,9 @@ export default function Plus(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Plus ? (
-          <theme.icons.Plus title="Plus" viewBox="0 0 24 24" {...props} />
+          <Icon title="Plus" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Plus />
+          </Icon>
         ) : (
           <Icon title="Plus" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/search.js
+++ b/src/icon/search.js
@@ -17,7 +17,9 @@ export default function Search(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Search ? (
-          <theme.icons.Search title="Search" viewBox="0 0 24 24" {...props} />
+          <Icon title="Search" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Search />
+          </Icon>
         ) : (
           <Icon title="Search" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/spinner.js
+++ b/src/icon/spinner.js
@@ -17,7 +17,9 @@ export default function Spinner(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Spinner ? (
-          <theme.icons.Spinner title="Spinner" viewBox="0 0 24 24" {...props} />
+          <Icon title="Spinner" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Spinner />
+          </Icon>
         ) : (
           <Icon title="Spinner" viewBox="0 0 24 24" {...props}>
             <path

--- a/src/icon/triangle-down.js
+++ b/src/icon/triangle-down.js
@@ -17,11 +17,9 @@ export default function TriangleDown(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.TriangleDown ? (
-          <theme.icons.TriangleDown
-            title="Triangle Down"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Triangle Down" viewBox="0 0 24 24" {...props}>
+            <theme.icons.TriangleDown />
+          </Icon>
         ) : (
           <Icon title="Triangle Down" viewBox="0 0 24 24" {...props}>
             <path d="M12.7071 15.2929L17.1464 10.8536C17.4614 10.5386 17.2383 10 16.7929 10L7.20711 10C6.76165 10 6.53857 10.5386 6.85355 10.8536L11.2929 15.2929C11.6834 15.6834 12.3166 15.6834 12.7071 15.2929Z" />

--- a/src/icon/triangle-left.js
+++ b/src/icon/triangle-left.js
@@ -17,11 +17,9 @@ export default function TriangleLeft(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.TriangleLeft ? (
-          <theme.icons.TriangleLeft
-            title="Triangle Left"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Triangle Left" viewBox="0 0 24 24" {...props}>
+            <theme.icons.TriangleLeft />
+          </Icon>
         ) : (
           <Icon title="Triangle Left" viewBox="0 0 24 24" {...props}>
             <path d="M8.70711 11.2929L13.1464 6.85355C13.4614 6.53857 14 6.76165 14 7.20711L14 16.7929C14 17.2383 13.4614 17.4614 13.1464 17.1464L8.70711 12.7071C8.31658 12.3166 8.31658 11.6834 8.70711 11.2929Z" />

--- a/src/icon/triangle-right.js
+++ b/src/icon/triangle-right.js
@@ -17,11 +17,9 @@ export default function TriangleRight(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.TriangleRight ? (
-          <theme.icons.TriangleRight
-            title="Triangle Right"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Triangle Right" viewBox="0 0 24 24" {...props}>
+            <theme.icons.TriangleRight />
+          </Icon>
         ) : (
           <Icon title="Triangle Right" viewBox="0 0 24 24" {...props}>
             <path d="M15.2929 11.2929L10.8536 6.85355C10.5386 6.53857 10 6.76165 10 7.20711L10 16.7929C10 17.2383 10.5386 17.4614 10.8536 17.1464L15.2929 12.7071C15.6834 12.3166 15.6834 11.6834 15.2929 11.2929Z" />

--- a/src/icon/triangle-up.js
+++ b/src/icon/triangle-up.js
@@ -17,11 +17,9 @@ export default function TriangleUp(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.TriangleUp ? (
-          <theme.icons.TriangleUp
-            title="Triangle Up"
-            viewBox="0 0 24 24"
-            {...props}
-          />
+          <Icon title="Triangle Up" viewBox="0 0 24 24" {...props}>
+            <theme.icons.TriangleUp />
+          </Icon>
         ) : (
           <Icon title="Triangle Up" viewBox="0 0 24 24" {...props}>
             <path d="M12.7071 8.70711L17.1464 13.1464C17.4614 13.4614 17.2383 14 16.7929 14L7.20711 14C6.76165 14 6.53857 13.4614 6.85355 13.1464L11.2929 8.70711C11.6834 8.31658 12.3166 8.31658 12.7071 8.70711Z" />

--- a/src/icon/upload.js
+++ b/src/icon/upload.js
@@ -17,7 +17,9 @@ export default function Upload(props: IconPropsT) {
     <ThemeContext.Consumer>
       {theme =>
         theme.icons && theme.icons.Upload ? (
-          <theme.icons.Upload title="Upload" viewBox="0 0 24 24" {...props} />
+          <Icon title="Upload" viewBox="0 0 24 24" {...props}>
+            <theme.icons.Upload />
+          </Icon>
         ) : (
           <Icon title="Upload" viewBox="0 0 24 24" {...props}>
             <path


### PR DESCRIPTION
#### Description

Some components allow for style overrides of icons, and apply their own styles to the icons. For example, the close icon on 'toast' has the cursor be a pointer on hover. Refactored the icons to call the main `Icon` component if globally overridden. 

#### Scope

- [x] Patch: Bug Fix
