### PR TITLE
fix(select): don't suggest creation of an option that was already picked

### DIFF
--- a/src/select/__tests__/select-creatable-multi.scenario.js
+++ b/src/select/__tests__/select-creatable-multi.scenario.js
@@ -1,0 +1,31 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {StatefulSelect} from '../index.js';
+
+export const name = 'select-creatable-multi';
+
+export const component = () => (
+  <StatefulSelect
+    creatable
+    multi
+    options={[
+      {id: 'Portland', label: 'Portland'},
+      {id: 'NYC', label: 'New York City'},
+      {id: 'LosAngeles', label: 'Los Angeles'},
+      {id: 'Boston', label: 'Boston'},
+      {id: 'Atlanta', label: 'Atlanta'},
+      {id: 'SanFrancisco', label: 'San Francisco'},
+    ]}
+    labelKey="label"
+    valueKey="id"
+    overrides={{ValueContainer: {props: {'data-id': 'selected'}}}}
+  />
+);

--- a/src/select/__tests__/select.e2e.js
+++ b/src/select/__tests__/select.e2e.js
@@ -123,4 +123,34 @@ describe('select', () => {
     );
     expect(inputValue).toBe('Paris');
   });
+
+  it('creates multiple options', async () => {
+    await mount(page, 'select-creatable-multi');
+    await page.waitFor(selectors.selectInput);
+    await page.click(selectors.selectInput);
+    await page.waitFor(selectors.selectDropDown);
+
+    // add "Paris"
+    await page.keyboard.type('Paris');
+    await page.click(optionAtPosition(1));
+    const inputValue = await page.$eval(
+      selectors.selectedList,
+      select => select.innerText,
+    );
+    expect(inputValue).toBe('Paris');
+
+    // add "London"
+    await page.keyboard.type('London');
+    await page.click(optionAtPosition(1));
+    const inputValue2 = await page.$eval(
+      selectors.selectedList,
+      select => select.innerText,
+    );
+    expect(inputValue2).toBe('Paris\nLondon');
+
+    // add "Paris" again, option to create should not be provided
+    await page.keyboard.type('Paris');
+    const canBeParisCreated = (await page.$(optionAtPosition(1))) !== null;
+    expect(canBeParisCreated).toBeFalsy();
+  });
 });

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -756,11 +756,13 @@ class Select extends React.Component<PropsT, SelectStateT> {
     if (
       filterValue &&
       this.props.creatable &&
-      options.every(
-        opt =>
-          opt[this.props.labelKey].toLowerCase() !==
-          filterValue.toLowerCase().trim(),
-      )
+      options
+        .concat(this.props.value)
+        .every(
+          opt =>
+            opt[this.props.labelKey].toLowerCase() !==
+            filterValue.toLowerCase().trim(),
+        )
     ) {
       // $FlowFixMe
       options.push({


### PR DESCRIPTION
Fixes problems mentioned in:

https://github.com/uber-web/baseui/pull/1086#pullrequestreview-219212436
https://github.com/uber-web/baseui/pull/1086#issuecomment-476900871

It now considers already created/selected values when filtering the list of options, so it doesn't suggest to create a new option if it already was created/selected.