### PR TITLE
fix(table): styledHead is missing styletron reassign

### DIFF
--- a/src/table/styled-components.js
+++ b/src/table/styled-components.js
@@ -48,6 +48,7 @@ const StyledHeadElement = styled(
 export const StyledHead = (props: *) => (
   <StyledHeadElement role="row" {...props} />
 );
+StyledHead.__STYLETRON__ = StyledHeadElement.__STYLETRON__;
 
 const StyledHeadCellElement = styled('div', ({$theme}: SharedStylePropsT) => {
   return {


### PR DESCRIPTION
StyledHead can't be styled with `withStyle` now