### PR TITLE
fix(select): enables globally overrided search icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "predocumentation:build": "node ./scripts/post-generator.js",
     "predocumentation:serve": "node ./scripts/post-generator.js",
     "documentation:dev": "run-p build:es2015 next:dev",
+    "documentation:dev:watch": "yarn build:es2015 --watch & next documentation-site",
     "documentation:build": "run-s build:es2015 next:build next:export",
     "documentation:serve": "static-server public --port 8081",
     "next:dev": "next documentation-site",

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -131,7 +131,7 @@ exports[`Select component renders component in search mode and false for multipl
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <Search
+            <MockStyledComponent
               $clearable={true}
               $creatable={false}
               $disabled={false}
@@ -145,71 +145,43 @@ exports[`Select component renders component in search mode and false for multipl
               $searchable={true}
               $size="default"
               $type="search"
-              overrides={
-                Object {
-                  "Svg": [Function],
-                }
-              }
-              size={16}
-              title="search"
             >
-              <Icon
-                $clearable={true}
-                $creatable={false}
-                $disabled={false}
-                $error={false}
-                $isFocused={false}
-                $isLoading={false}
-                $isOpen={false}
-                $isPseudoFocused={false}
-                $multi={false}
-                $required={false}
-                $searchable={true}
-                $size="default"
-                $type="search"
-                overrides={
-                  Object {
-                    "Svg": [Function],
-                  }
-                }
-                size={16}
-                title="search"
-                viewBox="0 0 24 24"
+              <div
+                styled-component="true"
               >
-                <MockStyledComponent
-                  $clearable={true}
-                  $creatable={false}
-                  $disabled={false}
-                  $error={false}
-                  $isFocused={false}
-                  $isLoading={false}
-                  $isOpen={false}
-                  $isPseudoFocused={false}
-                  $multi={false}
-                  $required={false}
-                  $searchable={true}
-                  $size={16}
-                  $type="search"
-                  data-baseweb="icon"
-                  viewBox="0 0 24 24"
+                <Search
+                  size={16}
+                  title="search"
                 >
-                  <svg
-                    data-baseweb="icon"
-                    styled-component="true"
+                  <Icon
+                    size={16}
+                    title="search"
                     viewBox="0 0 24 24"
                   >
-                    <title>
-                      search
-                    </title>
-                    <path
-                      clipRule="evenodd"
-                      d="M11 6C8.79086 6 7 7.79086 7 10C7 12.2091 8.79086 14 11 14C13.2091 14 15 12.2091 15 10C15 7.79086 13.2091 6 11 6ZM5 10C5 6.68629 7.68629 4 11 4C14.3137 4 17 6.68629 17 10C17 11.2958 16.5892 12.4957 15.8907 13.4765L19.7071 17.2929C20.0976 17.6834 20.0976 18.3166 19.7071 18.7071C19.3166 19.0976 18.6834 19.0976 18.2929 18.7071L14.4765 14.8907C13.4957 15.5892 12.2958 16 11 16C7.68629 16 5 13.3137 5 10Z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </MockStyledComponent>
-              </Icon>
-            </Search>
+                    <MockStyledComponent
+                      $size={16}
+                      data-baseweb="icon"
+                      viewBox="0 0 24 24"
+                    >
+                      <svg
+                        data-baseweb="icon"
+                        styled-component="true"
+                        viewBox="0 0 24 24"
+                      >
+                        <title>
+                          search
+                        </title>
+                        <path
+                          clipRule="evenodd"
+                          d="M11 6C8.79086 6 7 7.79086 7 10C7 12.2091 8.79086 14 11 14C13.2091 14 15 12.2091 15 10C15 7.79086 13.2091 6 11 6ZM5 10C5 6.68629 7.68629 4 11 4C14.3137 4 17 6.68629 17 10C17 11.2958 16.5892 12.4957 15.8907 13.4765L19.7071 17.2929C20.0976 17.6834 20.0976 18.3166 19.7071 18.7071C19.3166 19.0976 18.6834 19.0976 18.2929 18.7071L14.4765 14.8907C13.4957 15.5892 12.2958 16 11 16C7.68629 16 5 13.3137 5 10Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                    </MockStyledComponent>
+                  </Icon>
+                </Search>
+              </div>
+            </MockStyledComponent>
             <MockStyledComponent
               $clearable={true}
               $creatable={false}
@@ -524,7 +496,7 @@ exports[`Select component renders component in search mode and true for multiple
             onTouchStart={[Function]}
             styled-component="true"
           >
-            <Search
+            <MockStyledComponent
               $clearable={true}
               $creatable={false}
               $disabled={false}
@@ -538,71 +510,43 @@ exports[`Select component renders component in search mode and true for multiple
               $searchable={true}
               $size="default"
               $type="search"
-              overrides={
-                Object {
-                  "Svg": [Function],
-                }
-              }
-              size={16}
-              title="search"
             >
-              <Icon
-                $clearable={true}
-                $creatable={false}
-                $disabled={false}
-                $error={false}
-                $isFocused={false}
-                $isLoading={false}
-                $isOpen={false}
-                $isPseudoFocused={false}
-                $multi={false}
-                $required={false}
-                $searchable={true}
-                $size="default"
-                $type="search"
-                overrides={
-                  Object {
-                    "Svg": [Function],
-                  }
-                }
-                size={16}
-                title="search"
-                viewBox="0 0 24 24"
+              <div
+                styled-component="true"
               >
-                <MockStyledComponent
-                  $clearable={true}
-                  $creatable={false}
-                  $disabled={false}
-                  $error={false}
-                  $isFocused={false}
-                  $isLoading={false}
-                  $isOpen={false}
-                  $isPseudoFocused={false}
-                  $multi={false}
-                  $required={false}
-                  $searchable={true}
-                  $size={16}
-                  $type="search"
-                  data-baseweb="icon"
-                  viewBox="0 0 24 24"
+                <Search
+                  size={16}
+                  title="search"
                 >
-                  <svg
-                    data-baseweb="icon"
-                    styled-component="true"
+                  <Icon
+                    size={16}
+                    title="search"
                     viewBox="0 0 24 24"
                   >
-                    <title>
-                      search
-                    </title>
-                    <path
-                      clipRule="evenodd"
-                      d="M11 6C8.79086 6 7 7.79086 7 10C7 12.2091 8.79086 14 11 14C13.2091 14 15 12.2091 15 10C15 7.79086 13.2091 6 11 6ZM5 10C5 6.68629 7.68629 4 11 4C14.3137 4 17 6.68629 17 10C17 11.2958 16.5892 12.4957 15.8907 13.4765L19.7071 17.2929C20.0976 17.6834 20.0976 18.3166 19.7071 18.7071C19.3166 19.0976 18.6834 19.0976 18.2929 18.7071L14.4765 14.8907C13.4957 15.5892 12.2958 16 11 16C7.68629 16 5 13.3137 5 10Z"
-                      fillRule="evenodd"
-                    />
-                  </svg>
-                </MockStyledComponent>
-              </Icon>
-            </Search>
+                    <MockStyledComponent
+                      $size={16}
+                      data-baseweb="icon"
+                      viewBox="0 0 24 24"
+                    >
+                      <svg
+                        data-baseweb="icon"
+                        styled-component="true"
+                        viewBox="0 0 24 24"
+                      >
+                        <title>
+                          search
+                        </title>
+                        <path
+                          clipRule="evenodd"
+                          d="M11 6C8.79086 6 7 7.79086 7 10C7 12.2091 8.79086 14 11 14C13.2091 14 15 12.2091 15 10C15 7.79086 13.2091 6 11 6ZM5 10C5 6.68629 7.68629 4 11 4C14.3137 4 17 6.68629 17 10C17 11.2958 16.5892 12.4957 15.8907 13.4765L19.7071 17.2929C20.0976 17.6834 20.0976 18.3166 19.7071 18.7071C19.3166 19.0976 18.6834 19.0976 18.2929 18.7071L14.4765 14.8907C13.4957 15.5892 12.2958 16 11 16C7.68629 16 5 13.3137 5 10Z"
+                          fillRule="evenodd"
+                        />
+                      </svg>
+                    </MockStyledComponent>
+                  </Icon>
+                </Search>
+              </div>
+            </MockStyledComponent>
             <MockStyledComponent
               $clearable={true}
               $creatable={false}

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -731,14 +731,11 @@ class Select extends React.Component<PropsT, SelectStateT> {
       SearchIconComponent,
     );
     const sharedProps = this.getSharedProps();
+
     return (
-      <SearchIcon
-        size={16}
-        title={'search'}
-        overrides={{Svg: StyledSearchIcon}}
-        {...sharedProps}
-        {...searchIconProps}
-      />
+      <StyledSearchIcon {...sharedProps} {...searchIconProps}>
+        <SearchIcon size={16} title={'search'} />
+      </StyledSearchIcon>
     );
   }
 

--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -327,7 +327,7 @@ export const getLoadingIconStyles = (props: SharedStylePropsT) => {
   };
 };
 
-export const StyledSearchIcon = styled('svg', (props: SharedStylePropsT) => {
+export const StyledSearchIcon = styled('div', (props: SharedStylePropsT) => {
   const {$disabled, $theme} = props;
   const {colors, sizing} = $theme;
   return {
@@ -337,7 +337,8 @@ export const StyledSearchIcon = styled('svg', (props: SharedStylePropsT) => {
     cursor: $disabled ? 'not-allowed' : 'pointer',
     position: 'absolute',
     left: sizing.scale500,
-    display: 'inline-block',
+    display: 'flex',
+    alignItems: 'center',
     height: '100%',
   };
 });


### PR DESCRIPTION
#### Description

When importing and overriding an icon not included in baseui, the search icon was unstyled. This was due to the code assuming that the icon would always have the `overrides` prop.

before:
<img width="327" alt="search_icon" src="https://user-images.githubusercontent.com/5317799/56242327-dd69f300-604c-11e9-991b-5572f36b0628.png">

after:
<img width="595" alt="Screen Shot 2019-04-16 at 1 32 32 PM" src="https://user-images.githubusercontent.com/5317799/56242258-bca19d80-604c-11e9-9b0d-efa648838f27.png">

#### Scope

- [x] Patch: Bug Fix