### PR TITLE
fix(link): get color values from related theme tokens

### DIFF
--- a/src/link/styled-components.js
+++ b/src/link/styled-components.js
@@ -11,17 +11,20 @@ import {styled} from '../styles/index.js';
 export const Link = styled('a', ({$theme}) => {
   const {colors, typography, animation} = $theme;
   return {
-    color: colors.primary400,
+    color: colors.linkText,
     ...typography.font450,
     textDecoration: 'none',
     transitionProperty: 'color',
     transitionDuration: animation.timing100,
     transitionTimingFunction: animation.easeOutCurve,
+    ':visited': {
+      color: colors.linkVisited,
+    },
     ':hover': {
-      color: colors.primary500,
+      color: colors.linkHover,
     },
     ':active': {
-      color: colors.primary600,
+      color: colors.linkActive,
     },
   };
 });

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -157,7 +157,7 @@ export default function createTheme(
       linkText: primitives.primary400,
       linkVisited: primitives.primary500,
       linkHover: primitives.primary600,
-      linkActive: primitives.primary400,
+      linkActive: primitives.primary600,
 
       // Shadow
       shadowFocus: 'rgba(39, 110, 241, 0.32)',

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -157,6 +157,7 @@ export default function createTheme(
       linkText: primitives.primary400,
       linkVisited: primitives.primary500,
       linkHover: primitives.primary600,
+      linkActive: primitives.primary400,
 
       // Shadow
       shadowFocus: 'rgba(39, 110, 241, 0.32)',

--- a/src/themes/dark-theme-colors.js
+++ b/src/themes/dark-theme-colors.js
@@ -80,6 +80,7 @@ export default {
     linkText: primitives.primary300,
     linkVisited: primitives.primary300,
     linkHover: primitives.primary400,
+    linkActive: primitives.primary300,
 
     // List
     listHeaderFill: primitives.mono600,

--- a/src/themes/dark-theme-colors.js
+++ b/src/themes/dark-theme-colors.js
@@ -80,7 +80,7 @@ export default {
     linkText: primitives.primary300,
     linkVisited: primitives.primary300,
     linkHover: primitives.primary400,
-    linkActive: primitives.primary300,
+    linkActive: primitives.primary400,
 
     // List
     listHeaderFill: primitives.mono600,


### PR DESCRIPTION
#### Description

Make the Link component use the related theme tokens for its text color values.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
