### PR TITLE
feat(avatar): crop non-square images

### DIFF
--- a/src/avatar/styled-components.js
+++ b/src/avatar/styled-components.js
@@ -26,6 +26,7 @@ export const Avatar = styled('img', (props: StylePropsT) => {
     display: 'block',
     height: themedSize,
     width: themedSize,
+    objectFit: 'cover',
   };
 });
 


### PR DESCRIPTION
#### Description

When `Avatar` is used with non-square images, they are displayed stretched (forced to square aspect ratio) unless an override is used. This makes the default behavior to center & crop using `object-fit: cover`.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
