### PR TITLE
fix(button-group): add margins with values of zero

### DIFF
--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -67,6 +67,10 @@ export const BaseButton = styled(
     ...getStyleForShape({$theme, $shape, $size}),
     // Kind style override
     ...getStyleForKind({$theme, $kind, $isLoading, $isSelected, $disabled}),
+    marginLeft: 0,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
   }),
 );
 


### PR DESCRIPTION
by default, safari ships buttons with margins of 2px, that's why the space between the buttons in the buttongroup component