### PR TITLE
fix(progress-steps): add zIndex to styledIcon

### DIFF
--- a/src/progress-steps/styled-components.js
+++ b/src/progress-steps/styled-components.js
@@ -75,6 +75,8 @@ export const StyledIcon = styled(
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
+      position: 'absolute',
+      zIndex: 1,
     };
   },
 );


### PR DESCRIPTION
Fixes #1167 

#### Description

Currently, the progress-tail has its position type set to 'absolute' which gives it layering preference over the progress Icon. 

Implemented a quick fix for the StyledIcon component by adding 'position: absolute' and 'zIndex: 1'.

Longterm fix would most likely involve a larger refactor of the progress-tail logic if we want all zIndexes to be removed from baseweb/baseui.

#### Scope

- [x] Patch: Bug Fix

<img width="274" alt="Screen Shot 2019-04-22 at 12 42 59 PM" src="https://user-images.githubusercontent.com/37092291/56523333-34b00d80-64fc-11e9-85c8-d7af019e752f.png">
