### PR TITLE
feat(button): update button styles

### DIFF
--- a/docs/migrations/01204.md
+++ b/docs/migrations/01204.md
@@ -1,0 +1,17 @@
+# Purpose
+
+Button designs were updated to have uniform padding on all sides.
+This change made the `square` shape redundant so it has been removed.
+
+## Button
+
+The main use case for the `square` shape was to create square buttons with an icon inside of them.
+This use case is supported by default now.
+You can simply remove the `shape="square"` property.
+
+```diff
+- <Button shape="square">
++ <Button>
+    <Upload />
+  </Button>
+```

--- a/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
+++ b/documentation-site/pages/blog/getting-started-with-base-web/index.mdx
@@ -155,9 +155,7 @@ It would be nice to have a button inside our input that generates a new password
 <Input
   overrides={{
     After: () => (
-      <Button
-        kind={KIND.minimal}
-        shape={SHAPE.square}
+      <Button kind={KIND.minimal}>
         <Icon/>
       </Button>
     ),

--- a/documentation-site/static/examples/button/basic-compact.js
+++ b/documentation-site/static/examples/button/basic-compact.js
@@ -4,6 +4,8 @@ import {Block} from 'baseui/block';
 
 export default () => (
   <React.Fragment>
+    <Button size={SIZE.large}>Large size</Button>
+    <Block marginBottom="scale300" />
     <Button size={SIZE.default}>Default size</Button>
     <Block marginBottom="scale300" />
     <Button size={SIZE.compact}>Compact size</Button>

--- a/documentation-site/static/examples/button/basic-compact.js
+++ b/documentation-site/static/examples/button/basic-compact.js
@@ -4,10 +4,10 @@ import {Block} from 'baseui/block';
 
 export default () => (
   <React.Fragment>
-    <Button size={SIZE.large}>Large size</Button>
+    <Button size={SIZE.compact}>Compact size</Button>
     <Block marginBottom="scale300" />
     <Button size={SIZE.default}>Default size</Button>
     <Block marginBottom="scale300" />
-    <Button size={SIZE.compact}>Compact size</Button>
+    <Button size={SIZE.large}>Large size</Button>
   </React.Fragment>
 );

--- a/documentation-site/static/examples/button/shapes.js
+++ b/documentation-site/static/examples/button/shapes.js
@@ -8,7 +8,7 @@ export default () => (
       <Button shape={SHAPE.default}>Default shape</Button>
     </p>
     <p>
-      <Button shape={SHAPE.square}>
+      <Button>
         <Upload />
       </Button>
     </p>

--- a/documentation-site/static/examples/icon/button.js
+++ b/documentation-site/static/examples/icon/button.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import {Block} from 'baseui/block';
-import {Button, SHAPE} from 'baseui/button';
+import {Button} from 'baseui/button';
 
 import ChevronLeft from 'baseui/icon/chevron-left';
 import ChevronRight from 'baseui/icon/chevron-right';
@@ -17,7 +17,7 @@ export default () => (
     </Block>
 
     <Block>
-      <Button shape={SHAPE.square}>
+      <Button>
         <Upload />
       </Button>
     </Block>

--- a/src/button-group/__tests__/button-group-sizes.scenario.js
+++ b/src/button-group/__tests__/button-group-sizes.scenario.js
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {Button} from '../../button/index.js';
+import {StatefulButtonGroup, MODE} from '../index.js';
+import {SIZE} from '../../button/index.js';
+
+export const name = 'button-group-sizes';
+
+export const component = () => (
+  <React.Fragment>
+    <StatefulButtonGroup mode={MODE.radio} size={SIZE.compact}>
+      <Button>Label</Button>
+      <Button>Label</Button>
+      <Button>Label</Button>
+    </StatefulButtonGroup>
+    <StatefulButtonGroup mode={MODE.radio} size={SIZE.default}>
+      <Button>Label</Button>
+      <Button>Label</Button>
+      <Button>Label</Button>
+    </StatefulButtonGroup>
+    <StatefulButtonGroup mode={MODE.radio} size={SIZE.large}>
+      <Button>Label</Button>
+      <Button>Label</Button>
+      <Button>Label</Button>
+    </StatefulButtonGroup>
+  </React.Fragment>
+);

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -28,29 +28,6 @@ function isSelected(selected, index) {
   return selected === index;
 }
 
-function getBorderRadii(index, length) {
-  if (index === 0) {
-    return {
-      borderTopRightRadius: 0,
-      borderBottomRightRadius: 0,
-    };
-  }
-
-  if (index === length - 1) {
-    return {
-      borderTopLeftRadius: 0,
-      borderBottomLeftRadius: 0,
-    };
-  }
-
-  return {
-    borderTopRightRadius: 0,
-    borderBottomRightRadius: 0,
-    borderTopLeftRadius: 0,
-    borderBottomLeftRadius: 0,
-  };
-}
-
 type LocaleT = {|locale?: ButtonGroupLocaleT|};
 export function ButtonGroupRoot(props: {|...PropsT, ...LocaleT|}) {
   const {overrides = {}} = props;
@@ -85,12 +62,6 @@ export function ButtonGroupRoot(props: {|...PropsT, ...LocaleT|}) {
             if (props.onClick) {
               props.onClick(event, index);
             }
-          },
-          overrides: {
-            BaseButton: {
-              style: getBorderRadii(index, props.children.length),
-            },
-            ...child.props.overrides,
           },
           shape: props.shape,
           size: props.size,

--- a/src/button/__tests__/button-sizes.scenario.js
+++ b/src/button/__tests__/button-sizes.scenario.js
@@ -9,7 +9,6 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 
 import {Button} from '../index.js';
-import ArrowRight from '../../icon/arrow-right.js';
 import {SIZE} from '../constants.js';
 
 export const name = 'button-sizes';

--- a/src/button/__tests__/button-sizes.scenario.js
+++ b/src/button/__tests__/button-sizes.scenario.js
@@ -1,0 +1,23 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {Button} from '../index.js';
+import ArrowRight from '../../icon/arrow-right.js';
+import {SIZE} from '../constants.js';
+
+export const name = 'button-sizes';
+
+export const component = () => (
+  <React.Fragment>
+    <Button size={SIZE.compact}>Primary</Button>
+    <Button size={SIZE.default}>Primary</Button>
+    <Button size={SIZE.large}>Primary</Button>
+  </React.Fragment>
+);

--- a/src/button/constants.js
+++ b/src/button/constants.js
@@ -22,4 +22,5 @@ export const SHAPE = {
 export const SIZE = {
   default: 'default',
   compact: 'compact',
+  large: 'large',
 };

--- a/src/button/constants.js
+++ b/src/button/constants.js
@@ -16,7 +16,6 @@ export const KIND = {
 export const SHAPE = {
   default: 'default',
   round: 'round',
-  square: 'square',
 };
 
 export const SIZE = {

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -29,6 +29,17 @@ function getBorderRadii({$shape, $theme}: StylePropsT) {
   };
 }
 
+function getSize({$size, $theme}: StylePropsT) {
+  switch ($size) {
+    case SIZE.compact:
+      return $theme.typography.font250;
+    case SIZE.large:
+      return $theme.typography.font450;
+    default:
+      return $theme.typography.font350;
+  }
+}
+
 export const BaseButton = styled(
   'button',
   ({
@@ -41,9 +52,7 @@ export const BaseButton = styled(
     $disabled,
   }: StylePropsT) => ({
     position: 'relative',
-    ...($size === SIZE.compact
-      ? $theme.typography.font250
-      : $theme.typography.font450),
+    ...getSize({$size, $theme}),
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -29,7 +29,7 @@ function getBorderRadii({$shape, $theme}: StylePropsT) {
   };
 }
 
-function getSize({$size, $theme}: StylePropsT) {
+function getFontStyles({$size, $theme}: StylePropsT) {
   switch ($size) {
     case SIZE.compact:
       return $theme.typography.font250;
@@ -52,7 +52,7 @@ export const BaseButton = styled(
     $disabled,
   }: StylePropsT) => ({
     position: 'relative',
-    ...getSize({$size, $theme}),
+    ...getFontStyles({$size, $theme}),
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
@@ -71,7 +71,7 @@ export const BaseButton = styled(
       color: $theme.colors.buttonDisabledText,
     },
     // Padding For Shape and Size
-    ...getStyleForShape({$theme, $shape, $size}),
+    ...getStyleForShapeAndSize({$theme, $shape, $size}),
     // Kind style override
     ...getStyleForKind({$theme, $kind, $isLoading, $isSelected, $disabled}),
     marginLeft: 0,
@@ -151,41 +151,57 @@ export function getLoadingSpinnerColors({
   };
 }
 
-export function getStyleForShape({$theme, $shape, $size}: StylePropsT) {
+export function getStyleForShapeAndSize({$theme, $shape, $size}: StylePropsT) {
   switch ($shape) {
     case SHAPE.round:
     case SHAPE.square:
-      return {
-        paddingTop:
-          $size === SIZE.compact
-            ? $theme.sizing.scale400
-            : $theme.sizing.scale500,
-        paddingBottom:
-          $size === SIZE.compact
-            ? $theme.sizing.scale400
-            : $theme.sizing.scale500,
-        paddingLeft:
-          $size === SIZE.compact
-            ? $theme.sizing.scale400
-            : $theme.sizing.scale500,
-        paddingRight:
-          $size === SIZE.compact
-            ? $theme.sizing.scale400
-            : $theme.sizing.scale500,
-      };
+      switch ($size) {
+        case SIZE.compact:
+          return {
+            paddingTop: $theme.sizing.scale300,
+            paddingBottom: $theme.sizing.scale300,
+            paddingLeft: $theme.sizing.scale300,
+            paddingRight: $theme.sizing.scale300,
+          };
+        case SIZE.large:
+          return {
+            paddingTop: $theme.sizing.scale600,
+            paddingBottom: $theme.sizing.scale600,
+            paddingLeft: $theme.sizing.scale600,
+            paddingRight: $theme.sizing.scale600,
+          };
+        default:
+          return {
+            paddingTop: $theme.sizing.scale400,
+            paddingBottom: $theme.sizing.scale400,
+            paddingLeft: $theme.sizing.scale400,
+            paddingRight: $theme.sizing.scale400,
+          };
+      }
     default:
-      return {
-        paddingTop:
-          $size === SIZE.compact
-            ? $theme.sizing.scale200
-            : $theme.sizing.scale300,
-        paddingBottom:
-          $size === SIZE.compact
-            ? $theme.sizing.scale200
-            : $theme.sizing.scale300,
-        paddingLeft: $theme.sizing.scale600,
-        paddingRight: $theme.sizing.scale600,
-      };
+      switch ($size) {
+        case SIZE.compact:
+          return {
+            paddingTop: $theme.sizing.scale200,
+            paddingBottom: $theme.sizing.scale200,
+            paddingLeft: $theme.sizing.scale300,
+            paddingRight: $theme.sizing.scale300,
+          };
+        case SIZE.large:
+          return {
+            paddingTop: $theme.sizing.scale600,
+            paddingBottom: $theme.sizing.scale600,
+            paddingLeft: $theme.sizing.scale900,
+            paddingRight: $theme.sizing.scale900,
+          };
+        default:
+          return {
+            paddingTop: $theme.sizing.scale400,
+            paddingBottom: $theme.sizing.scale400,
+            paddingLeft: $theme.sizing.scale600,
+            paddingRight: $theme.sizing.scale600,
+          };
+      }
   }
 }
 

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -19,8 +19,6 @@ function getBorderRadii({$shape, $theme}: StylePropsT) {
 
   if ($shape === SHAPE.round) {
     value = '50%';
-  } else if ($theme.borders.useRoundedCorners) {
-    value = $theme.borders.radius200;
   }
 
   return {

--- a/src/button/styled-components.js
+++ b/src/button/styled-components.js
@@ -14,32 +14,6 @@ type StylePropsT = SharedStylePropsT & {
   $theme: ThemeT,
 };
 
-function getBorderRadii({$shape, $theme}: StylePropsT) {
-  let value = '0px';
-
-  if ($shape === SHAPE.round) {
-    value = '50%';
-  }
-
-  return {
-    borderTopRightRadius: value,
-    borderBottomRightRadius: value,
-    borderTopLeftRadius: value,
-    borderBottomLeftRadius: value,
-  };
-}
-
-function getFontStyles({$size, $theme}: StylePropsT) {
-  switch ($size) {
-    case SIZE.compact:
-      return $theme.typography.font250;
-    case SIZE.large:
-      return $theme.typography.font450;
-    default:
-      return $theme.typography.font350;
-  }
-}
-
 export const BaseButton = styled(
   'button',
   ({
@@ -52,12 +26,10 @@ export const BaseButton = styled(
     $disabled,
   }: StylePropsT) => ({
     position: 'relative',
-    ...getFontStyles({$size, $theme}),
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     border: 'none',
-    ...getBorderRadii({$shape, $theme}),
     textDecoration: 'none',
     outline: 'none',
     WebkitAppearance: 'none',
@@ -70,14 +42,15 @@ export const BaseButton = styled(
       backgroundColor: $theme.colors.buttonDisabledFill,
       color: $theme.colors.buttonDisabledText,
     },
-    // Padding For Shape and Size
-    ...getStyleForShapeAndSize({$theme, $shape, $size}),
-    // Kind style override
-    ...getStyleForKind({$theme, $kind, $isLoading, $isSelected, $disabled}),
     marginLeft: 0,
     marginTop: 0,
     marginRight: 0,
     marginBottom: 0,
+    ...getFontStyles({$theme, $size}),
+    ...getBorderRadiiStyles({$theme, $shape}),
+    ...getPaddingStyles({$theme, $size}),
+    // Kind style override
+    ...getKindStyles({$theme, $kind, $isLoading, $isSelected, $disabled}),
   }),
 );
 
@@ -151,61 +124,59 @@ export function getLoadingSpinnerColors({
   };
 }
 
-export function getStyleForShapeAndSize({$theme, $shape, $size}: StylePropsT) {
-  switch ($shape) {
-    case SHAPE.round:
-    case SHAPE.square:
-      switch ($size) {
-        case SIZE.compact:
-          return {
-            paddingTop: $theme.sizing.scale300,
-            paddingBottom: $theme.sizing.scale300,
-            paddingLeft: $theme.sizing.scale300,
-            paddingRight: $theme.sizing.scale300,
-          };
-        case SIZE.large:
-          return {
-            paddingTop: $theme.sizing.scale600,
-            paddingBottom: $theme.sizing.scale600,
-            paddingLeft: $theme.sizing.scale600,
-            paddingRight: $theme.sizing.scale600,
-          };
-        default:
-          return {
-            paddingTop: $theme.sizing.scale400,
-            paddingBottom: $theme.sizing.scale400,
-            paddingLeft: $theme.sizing.scale400,
-            paddingRight: $theme.sizing.scale400,
-          };
-      }
+export function getBorderRadiiStyles({$theme, $shape}: StylePropsT) {
+  let value = '0px';
+
+  if ($shape === SHAPE.round) {
+    value = '50%';
+  }
+
+  return {
+    borderTopRightRadius: value,
+    borderBottomRightRadius: value,
+    borderTopLeftRadius: value,
+    borderBottomLeftRadius: value,
+  };
+}
+
+export function getFontStyles({$theme, $size}: StylePropsT) {
+  switch ($size) {
+    case SIZE.compact:
+      return $theme.typography.font250;
+    case SIZE.large:
+      return $theme.typography.font450;
     default:
-      switch ($size) {
-        case SIZE.compact:
-          return {
-            paddingTop: $theme.sizing.scale200,
-            paddingBottom: $theme.sizing.scale200,
-            paddingLeft: $theme.sizing.scale300,
-            paddingRight: $theme.sizing.scale300,
-          };
-        case SIZE.large:
-          return {
-            paddingTop: $theme.sizing.scale600,
-            paddingBottom: $theme.sizing.scale600,
-            paddingLeft: $theme.sizing.scale900,
-            paddingRight: $theme.sizing.scale900,
-          };
-        default:
-          return {
-            paddingTop: $theme.sizing.scale400,
-            paddingBottom: $theme.sizing.scale400,
-            paddingLeft: $theme.sizing.scale600,
-            paddingRight: $theme.sizing.scale600,
-          };
-      }
+      return $theme.typography.font350;
   }
 }
 
-export function getStyleForKind({
+export function getPaddingStyles({$theme, $size}: StylePropsT) {
+  switch ($size) {
+    case SIZE.compact:
+      return {
+        paddingTop: $theme.sizing.scale300,
+        paddingBottom: $theme.sizing.scale300,
+        paddingLeft: $theme.sizing.scale300,
+        paddingRight: $theme.sizing.scale300,
+      };
+    case SIZE.large:
+      return {
+        paddingTop: $theme.sizing.scale600,
+        paddingBottom: $theme.sizing.scale600,
+        paddingLeft: $theme.sizing.scale600,
+        paddingRight: $theme.sizing.scale600,
+      };
+    default:
+      return {
+        paddingTop: $theme.sizing.scale500,
+        paddingBottom: $theme.sizing.scale500,
+        paddingLeft: $theme.sizing.scale500,
+        paddingRight: $theme.sizing.scale500,
+      };
+  }
+}
+
+export function getKindStyles({
   $theme,
   $isLoading,
   $isSelected,

--- a/src/icon/__tests__/icon-buttons.scenario.js
+++ b/src/icon/__tests__/icon-buttons.scenario.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import React from 'react';
 
-import {Button, SHAPE} from '../../button/index.js';
+import {Button} from '../../button/index.js';
 import Upload from '../upload.js';
 
 export const name = 'icon-buttons';
@@ -21,7 +21,7 @@ export const component = () => (
     <Button endEnhancer={Upload}>End Enhancer</Button>
     <br />
     <br />
-    <Button shape={SHAPE.square}>
+    <Button>
       <Upload />
     </Button>
   </div>


### PR DESCRIPTION
#### Description

Updates `Button` & `ButtonGroup` styles to match latest Base designs:
- Remove rounded corners from `Button`/`ButtonGroup`
- Adds a `large` size to `Button`/`ButtonGroup`
- Updates padding for all buttons to match latest Base designs
- Updates docs with new sizing option
- Removes `'square'` option for `shape` property (horizontal/vertical padding is the same by default now)

Existing buttons:

<img width="195" alt="Screen Shot 2019-04-29 at 5 11 25 PM" src="https://user-images.githubusercontent.com/1939257/56934702-dd80de80-6aa1-11e9-958d-5192f48c3ee9.png">

New buttons:

<img width="228" alt="Screen Shot 2019-04-30 at 1 52 00 PM" src="https://user-images.githubusercontent.com/1939257/56992562-2cd11880-6b4f-11e9-84ab-02b5ddbcef6a.png">

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [x] Major: Breaking Change
