### PR TITLE
chore(tag): remove deprecated COLOR_STYLE_KEYS export

### DIFF
--- a/docs/migrations/01206.md
+++ b/docs/migrations/01206.md
@@ -1,0 +1,3 @@
+# Purpose
+
+Removing the deprecated `COLOR_STYLE_KEYS` export from the Tag component. Instead of that, please use `KIND` and `VARIANT`.

--- a/src/tag/constants.js
+++ b/src/tag/constants.js
@@ -8,25 +8,20 @@ LICENSE file in the root directory of this source tree.
 
 import type {TagKindT} from './types.js';
 
-// Remove this in the next major version
-export const COLOR_STYLE_KEYS = {
-  neutral: 'tagNeutralBackground',
-  primary: 'tagPrimaryBackground',
-  positive: 'tagPositiveBackground',
-  warning: 'tagWarningBackground',
-  negative: 'tagNegativeBackground',
-};
-
 export const VARIANT = Object.freeze({
   solid: 'solid',
   light: 'light',
   outlined: 'outlined',
 });
 
-export const KIND: {[TagKindT]: string} = Object.keys({
-  ...COLOR_STYLE_KEYS,
-  custom: null,
-}).reduce((kindMap, key) => {
+export const KIND: {[TagKindT]: string} = [
+  'neutral',
+  'primary',
+  'positive',
+  'warning',
+  'negative',
+  'custom',
+].reduce((kindMap, key) => {
   kindMap[key] = key;
   return kindMap;
 }, {});

--- a/src/tag/index.js
+++ b/src/tag/index.js
@@ -13,5 +13,5 @@ export {
   ActionIcon as StyledActionIcon,
   Text as StyledText,
 } from './styled-components.js';
-export {COLOR_STYLE_KEYS, KIND, VARIANT} from './constants.js';
+export {KIND, VARIANT} from './constants.js';
 export * from './types.js';


### PR DESCRIPTION
This is a PR against the new `v7` branch.