### PR TITLE
feat(theme): theme docs respect OS theme preference

### DIFF
--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -52,7 +52,6 @@ export default class MyApp extends App {
     super(props);
     this.state = {
       theme: LightTheme,
-      matchMediaListeners: [],
     };
     this.mediaQueryListener = this.mediaQueryListener.bind(this);
   }

--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -34,6 +34,9 @@ const themes = {
   DarkThemeMove,
 };
 
+const DARK_MEDIA_QUERY = '(prefers-color-scheme: dark)';
+const LIGHT_MEDIA_QUERY = '(prefers-color-scheme: light)';
+
 const BlockOverrides = {
   Block: {
     style: ({$theme}) => ({
@@ -49,7 +52,9 @@ export default class MyApp extends App {
     super(props);
     this.state = {
       theme: LightTheme,
+      matchMediaListeners: [],
     };
+    this.mediaQueryListener = this.mediaQueryListener.bind(this);
   }
 
   static async getInitialProps({Component, ctx}) {
@@ -64,7 +69,36 @@ export default class MyApp extends App {
     Router.onRouteChangeComplete = url => {
       trackPageView(url);
     };
+    if (window.matchMedia) {
+      const mmDark = window.matchMedia(DARK_MEDIA_QUERY);
+      const mmLight = window.matchMedia(LIGHT_MEDIA_QUERY);
+      const theme = mmDark.matches ? 'dark' : 'light';
+      localStorage.setItem('docs-theme', theme);
+      mmDark.addListener(this.mediaQueryListener);
+      mmLight.addListener(this.mediaQueryListener);
+    }
     this.setTheme();
+  }
+
+  componentWillUnmount() {
+    if (window.matchMedia) {
+      const mmDark = window.matchMedia(DARK_MEDIA_QUERY);
+      const mmLight = window.matchMedia(LIGHT_MEDIA_QUERY);
+      mmDark.removeListener(this.mediaQueryListener);
+      mmLight.removeListener(this.mediaQueryListener);
+    }
+  }
+
+  mediaQueryListener(e) {
+    if (e && e.matches) {
+      if (e.media === DARK_MEDIA_QUERY) {
+        this.setThemeStyle('dark');
+      }
+      if (e.media === LIGHT_MEDIA_QUERY) {
+        this.setThemeStyle('light');
+      }
+      this.setTheme();
+    }
   }
 
   setTheme() {
@@ -122,17 +156,25 @@ export default class MyApp extends App {
     });
   }
 
+  getThemeStyle() {
+    return localStorage.getItem('docs-theme');
+  }
+
+  setThemeStyle(theme) {
+    localStorage.setItem('docs-theme', theme);
+  }
+
   toggleTheme() {
-    const theme = localStorage.getItem('docs-theme');
+    const theme = this.getThemeStyle();
 
     if (!theme) {
-      localStorage.setItem('docs-theme', 'dark');
+      this.setThemeStyle('dark');
     }
 
     if (theme === 'dark') {
-      localStorage.setItem('docs-theme', 'light');
+      this.setThemeStyle('light');
     } else {
-      localStorage.setItem('docs-theme', 'dark');
+      this.setThemeStyle('dark');
     }
 
     this.setTheme();


### PR DESCRIPTION
#### Description

<!-- Describe your changes below in as much detail as possible -->
In browsers that expose `prefers-color-scheme` this will match the docs theme to the OS theme. Currently supported browsers are Safari and Firefox:
https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

![base-web-respect-os-theme](https://user-images.githubusercontent.com/216963/57032933-784ff900-6c19-11e9-9495-62d2d5722e2e.gif)

The theme is set on initial page load and whenever the OS theme is changed. The theme toggle button continues to functional as it did previously.


#### Scope

- [ ] Patch: Bug Fix
- [✅] Minor: New Feature
- [ ] Major: Breaking Change
