### PR TITLE
Remove engines fields, too restrictive and not being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,11 +158,6 @@
     "react-dom": ">= 16.4.0 < 17",
     "styletron-react": "^4.4.6"
   },
-  "engines": {
-    "node": ">=8.11.0",
-    "npm": ">=5.6.0",
-    "yarn": ">=1.5.1"
-  },
   "husky": {
     "hooks": {
       "commit-msg": "commitlint -e $GIT_PARAMS",


### PR DESCRIPTION
Node is used only for our build tools and we don't really keep track with Node releases anyway. 

Also, **right now you can't deploy next.js app with baseui as a serverless lamba** since their environment currently supports only Node 8.10 and we are enforcing 8.11, so the build fails.

For `yarn` and `npm`, we don't have practical reasons to be restrictive.