### PR TITLE
feat: accessibility addition suggestions for pagination

### DIFF
--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -24,6 +24,7 @@ import ChevronLeft from '../icon/chevron-left.js';
 import ChevronRight from '../icon/chevron-right.js';
 import {getOverrides} from '../helpers/overrides.js';
 import type {PaginationPropsT, PaginationStateT} from './types.js';
+import type {LocaleT} from '../locale/types.js';
 import type {OnItemSelectFnT} from '../menu/types.js';
 
 type MenuItemT = {
@@ -101,7 +102,7 @@ export default class Pagination extends React.PureComponent<
     this.setState({isMenuOpen});
   };
 
-  constructAriaWayfinderLabel = (locale: object, prefix: string) => {
+  constructAriaWayfinderLabel = (locale: LocaleT, prefix: string) => {
     const {currentPage, numPages, labels} = this.props;
     return (
       prefix +

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -70,16 +70,20 @@ export default class Pagination extends React.PureComponent<
 
   onPrevClick = (event: SyntheticEvent<>) => {
     const {currentPage, onPageChange, onPrevClick} = this.props;
-    onPageChange &&
-      onPageChange({nextPage: currentPage - 1, prevPage: currentPage});
-    onPrevClick && onPrevClick({event});
+    if (currentPage > 1) {
+      onPageChange &&
+        onPageChange({nextPage: currentPage - 1, prevPage: currentPage});
+      onPrevClick && onPrevClick({event});
+    }
   };
 
   onNextClick = (event: SyntheticEvent<>) => {
-    const {currentPage, onPageChange, onNextClick} = this.props;
-    onPageChange &&
-      onPageChange({nextPage: currentPage + 1, prevPage: currentPage});
-    onNextClick && onNextClick({event});
+    const {currentPage, numPages, onPageChange, onNextClick} = this.props;
+    if (currentPage < numPages) {
+      onPageChange &&
+        onPageChange({nextPage: currentPage + 1, prevPage: currentPage});
+      onNextClick && onNextClick({event});
+    }
   };
 
   onDropdownButtonClick = () => {
@@ -95,6 +99,23 @@ export default class Pagination extends React.PureComponent<
       });
     }
     this.setState({isMenuOpen});
+  };
+
+  constructAriaWayfinderLabel = (locale, prefix) => {
+    const {currentPage, numPages, labels} = this.props;
+    return (
+      prefix +
+      ' ' +
+      currentPage +
+      ' ' +
+      `${
+        labels && labels.preposition
+          ? labels.preposition
+          : locale.pagination.preposition
+      }` +
+      ' ' +
+      numPages
+    );
   };
 
   render() {
@@ -132,8 +153,17 @@ export default class Pagination extends React.PureComponent<
     return (
       <LocaleContext.Consumer>
         {locale => (
-          <Root data-baseweb="pagination" {...rootProps}>
+          <Root
+            aria-label="pagination"
+            data-baseweb="pagination"
+            {...rootProps}
+          >
             <Button
+              aria-label={this.constructAriaWayfinderLabel(
+                locale,
+                'previous page. current page',
+              )}
+              disabled={currentPage <= 1}
               onClick={this.onPrevClick}
               startEnhancer={() => <ChevronLeft title={''} size={24} />}
               kind={KIND.tertiary}
@@ -151,6 +181,12 @@ export default class Pagination extends React.PureComponent<
               {...dropdownContainerProps}
             >
               <Button
+                aria-label={this.constructAriaWayfinderLabel(
+                  locale,
+                  'select page number. current page',
+                )}
+                aria-haspopup="true"
+                aria-expanded={isMenuOpen}
                 onClick={this.onDropdownButtonClick}
                 endEnhancer={() => (
                   <TriangleDown
@@ -175,26 +211,31 @@ export default class Pagination extends React.PureComponent<
               </Button>
               {isMenuOpen && (
                 // $FlowFixMe
-                <DropdownMenu
-                  items={options}
-                  onItemSelect={this.onMenuItemSelect}
-                  initialState={{
-                    highlightedIndex: Math.max(currentPage - 1, 0),
-                  }}
-                  overrides={{
-                    List: {
-                      component: StyledDropdownMenu,
-                      // Access $style manually because it has gone through transformation
-                      // from the override helper function already
-                      // $FlowFixMe
-                      style: dropdownMenuProps.$style,
-                    },
-                  }}
-                  {...dropdownMenuProps}
-                />
+                <div role="menu">
+                  <DropdownMenu
+                    items={options}
+                    onItemSelect={this.onMenuItemSelect}
+                    initialState={{
+                      highlightedIndex: Math.max(currentPage - 1, 0),
+                    }}
+                    overrides={{
+                      List: {
+                        component: StyledDropdownMenu,
+                        // Access $style manually because it has gone through transformation
+                        // from the override helper function already
+                        // $FlowFixMe
+                        style: dropdownMenuProps.$style,
+                      },
+                    }}
+                    {...dropdownMenuProps}
+                  />
+                </div>
               )}
             </DropdownContainer>
-            <MaxLabel {...maxLabelProps}>
+            <MaxLabel
+              aria-label={this.constructAriaWayfinderLabel(locale, 'page')}
+              {...maxLabelProps}
+            >
               {`${
                 labels && labels.preposition
                   ? labels.preposition
@@ -202,6 +243,11 @@ export default class Pagination extends React.PureComponent<
               } ${numPages}`}
             </MaxLabel>
             <Button
+              aria-label={this.constructAriaWayfinderLabel(
+                locale,
+                'next page. current page',
+              )}
+              disabled={currentPage >= numPages}
               onClick={this.onNextClick}
               endEnhancer={() => <ChevronRight title={''} size={24} />}
               kind={KIND.tertiary}

--- a/src/pagination/pagination.js
+++ b/src/pagination/pagination.js
@@ -101,7 +101,7 @@ export default class Pagination extends React.PureComponent<
     this.setState({isMenuOpen});
   };
 
-  constructAriaWayfinderLabel = (locale, prefix) => {
+  constructAriaWayfinderLabel = (locale: object, prefix: string) => {
     const {currentPage, numPages, labels} = this.props;
     return (
       prefix +
@@ -211,25 +211,27 @@ export default class Pagination extends React.PureComponent<
               </Button>
               {isMenuOpen && (
                 // $FlowFixMe
-                <div role="menu">
-                  <DropdownMenu
-                    items={options}
-                    onItemSelect={this.onMenuItemSelect}
-                    initialState={{
-                      highlightedIndex: Math.max(currentPage - 1, 0),
-                    }}
-                    overrides={{
-                      List: {
-                        component: StyledDropdownMenu,
-                        // Access $style manually because it has gone through transformation
-                        // from the override helper function already
-                        // $FlowFixMe
-                        style: dropdownMenuProps.$style,
-                      },
-                    }}
-                    {...dropdownMenuProps}
-                  />
-                </div>
+                <DropdownMenu
+                  items={options}
+                  onItemSelect={this.onMenuItemSelect}
+                  initialState={{
+                    highlightedIndex: Math.max(currentPage - 1, 0),
+                  }}
+                  overrides={{
+                    List: {
+                      component: StyledDropdownMenu,
+                      // Access $style manually because it has gone through transformation
+                      // from the override helper function already
+                      // $FlowFixMe
+                      style: dropdownMenuProps.$style,
+                      props: {role: 'menu'},
+                    },
+                    Option: {
+                      props: {role: 'menuitem'},
+                    },
+                  }}
+                  {...dropdownMenuProps}
+                />
               )}
             </DropdownContainer>
             <MaxLabel

--- a/src/pagination/styled-components.js
+++ b/src/pagination/styled-components.js
@@ -9,7 +9,7 @@ import {styled} from '../styles/index.js';
 import {StyledList} from '../menu/index.js';
 import {StyledBaseButton} from '../button/index.js';
 
-export const Root = styled('div', {
+export const Root = styled('nav', {
   display: 'flex',
   alignItems: 'center',
 });


### PR DESCRIPTION
Accessibility addition suggestions for pagination

#### Description

Adds aria attributes to pagination controls for a11y. 

- `aria-haspopup="true"`
- `aria-expanded="false"`
- `aria-label="next page. current page 2 of 20"`
- `role="menu"`

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
