### PR TITLE
feat(side-navigation): Remove renderItem prop, fix overrides

### DIFF
--- a/docs/migrations/01251.md
+++ b/docs/migrations/01251.md
@@ -1,0 +1,8 @@
+# Purpose
+
+`renderItem` prop is not necessary since it's identical to `overrides.NavLink.component`.
+
+```diff
+- <Navigation renderItem={MyItem} />
++ <Navigation overrides={{ NavLink: { component: MyItem }}} />
+```

--- a/documentation-site/static/examples/side-navigation/nav-overrides.js
+++ b/documentation-site/static/examples/side-navigation/nav-overrides.js
@@ -1,16 +1,10 @@
 import React, {useState} from 'react';
-import {styled, createTheme, lightThemePrimitives, ThemeProvider} from 'baseui';
-import {Navigation, StyledNavLink, StyledNavItem} from 'baseui/side-navigation';
-import {Label2} from 'baseui/typography';
-
-const heading = {
-  Label2,
-};
+import {Navigation} from 'baseui/side-navigation';
 
 const nav = [
   {
     title: 'Colors',
-    heading: 'Label2',
+    itemId: '#level1.1',
     subNav: [
       {
         title: 'Primary',
@@ -35,58 +29,35 @@ const nav = [
   {
     title: 'Sizing',
     itemId: '#level1.2',
-    heading: 'Label2',
   },
   {
     title: 'Typography',
     itemId: '#level1.3',
-    heading: 'Label2',
   },
 ];
 
-const customTheme = createTheme(
-  {
-    ...lightThemePrimitives,
-    primary400: '#3e9920',
-  },
-  {},
-);
-
-const renderItem = function(item, itemProps) {
-  const {onSelect, onClick, onKeyDown, ...restProps} = itemProps;
-  const Heading = heading[item.heading];
-  const renderedItem = (
-    <StyledNavLink
-      href={item.itemId}
-      onClick={item.itemId ? onClick : null}
-      onKeyDown={item.itemId ? onKeyDown : null}
-      {...restProps}
-    >
-      <StyledNavItem {...restProps}>
-        {item.title}
-        {item.itemId ? ` (${item.itemId})` : ''}
-      </StyledNavItem>
-    </StyledNavLink>
-  );
-  return Heading ? (
-    <Heading overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
-      {renderedItem}
-    </Heading>
-  ) : (
-    renderedItem
-  );
-};
-
-export default function() {
+export default () => {
   const [location, setLocation] = useState('#level1.1.1');
   return (
-    <ThemeProvider theme={customTheme}>
-      <Navigation
-        items={nav}
-        activeItemId={location}
-        onChange={({item}) => setLocation(item.itemId)}
-        renderItem={renderItem}
-      />
-    </ThemeProvider>
+    <Navigation
+      items={nav}
+      activeItemId={location}
+      onChange={({item}) => setLocation(item.itemId)}
+      overrides={{
+        NavItem: {
+          style: ({$active, $theme}) => {
+            if (!$active) return {};
+            return {
+              background: $theme.colors.positive400,
+              borderLeftColor: $theme.colors.mono800,
+              color: $theme.colors.mono100,
+              ':hover': {
+                color: $theme.colors.mono100,
+              },
+            };
+          },
+        },
+      }}
+    />
   );
-}
+};

--- a/src/side-navigation/__tests__/__snapshots__/stateful-nav.test.js.snap
+++ b/src/side-navigation/__tests__/__snapshots__/stateful-nav.test.js.snap
@@ -33,7 +33,6 @@ exports[`Navigation basic render: renders <Navigation/> as a child 1`] = `
   }
   onChange={[Function]}
   overrides={Object {}}
-  renderItem={null}
 />
 `;
 

--- a/src/side-navigation/nav-item.js
+++ b/src/side-navigation/nav-item.js
@@ -34,18 +34,9 @@ export default class NavItem extends React.Component<NavItemPropsT> {
   };
 
   render() {
-    const {item, onSelect, overrides, renderItem, ...sharedProps} = this.props;
+    const {item, overrides, ...sharedProps} = this.props;
     const [NavItem, itemProps] = getOverrides(overrides.NavItem, StyledNavItem);
     const [NavLink, linkProps] = getOverrides(overrides.NavLink, StyledNavLink);
-    const navItemProps = {
-      ...sharedProps,
-      onSelect: onSelect,
-      onClick: this.handleClick,
-      onKeyDown: this.handleKeyDown,
-    };
-    if (typeof renderItem === 'function') {
-      return renderItem(item, navItemProps);
-    }
     return (
       <NavLink
         href={item.itemId}

--- a/src/side-navigation/nav.js
+++ b/src/side-navigation/nav.js
@@ -22,7 +22,6 @@ export default class SideNav extends React.Component<NavPropsT> {
     activePredicate: null,
     items: [],
     overrides: {},
-    renderItem: null,
   };
 
   activePredicate = (item: Item) => {
@@ -36,7 +35,6 @@ export default class SideNav extends React.Component<NavPropsT> {
       items,
       onChange,
       overrides,
-      renderItem,
     } = this.props;
     const navLevel = 1;
 
@@ -70,7 +68,7 @@ export default class SideNav extends React.Component<NavPropsT> {
             <NavItem
               item={item}
               onSelect={onChange}
-              renderItem={renderItem}
+              overrides={overrides}
               {...sharedProps}
             />
             {item.subNav ? (

--- a/src/side-navigation/types.js
+++ b/src/side-navigation/types.js
@@ -31,15 +31,6 @@ export type SharedPropsT = {
   $selectable: boolean,
 };
 
-type renderItemT = (
-  item: *,
-  props: SharedPropsT & {
-    onSelect?: ({item: *, event: Event | KeyboardEvent}) => mixed,
-    onClick?: (event: Event) => mixed,
-    onKeyDown?: (event: KeyboardEvent) => mixed,
-  },
-) => React.Node;
-
 export type NavPropsT = {
   /** Defines the current active itemId. Used for the default calculation of the $active prop */
   activeItemId: string,
@@ -60,8 +51,6 @@ export type NavPropsT = {
     NavItem?: OverrideT<*>,
     SubNavContainer?: OverrideT<*>,
   },
-  /** Optional render function that is called instead default item rendering */
-  renderItem: ?renderItemT,
 };
 
 export type Item = {
@@ -85,7 +74,6 @@ export type NavItemPropsT = SharedPropsT & {
     NavLink?: OverrideT<*>,
     NavItem?: OverrideT<*>,
   },
-  renderItem?: ?renderItemT,
 };
 
 export type StatefulContainerPropsT = {


### PR DESCRIPTION
`renderItem` is not necessary since it's identical to `overrides.NavLink.component`. However, overrides were not previously passed to `NavLink` and `NavItem` components. Also, simplifying the override example to focus on `style` rather than swapping the whole complicated component.

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [x] Major: Breaking Change
