### PR TITLE
fix(select): show placeholder when value is empty string

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -442,7 +442,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
    */
   getValueArray(value: ValueT): Array<OptionT> {
     if (!Array.isArray(value)) {
-      if (value === null || value === undefined) return [];
+      if (value === '' || value === null || value === undefined) return [];
       value = [value];
     }
     return value.map(value => expandValue(value, this.props));


### PR DESCRIPTION
#### Description

Properly show the Select placeholder when value is an empty string. This happens when integrating the Select component with ReduxForm, following the pattern described in #150.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
