### PR TITLE
feat(select): update search icon color based on state

### DIFF
--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -330,12 +330,18 @@ export const getLoadingIconStyles = (props: SharedStylePropsT) => {
 };
 
 export const StyledSearchIcon = styled('div', (props: SharedStylePropsT) => {
-  const {$disabled, $theme} = props;
+  const {$disabled, $error, $isFocused, $isPseudoFocused, $theme} = props;
   const {colors, sizing} = $theme;
   return {
     // $FlowFixMe
     ...getSvgStyles(props),
-    color: $disabled ? colors.inputTextDisabled : colors.foregroundAlt,
+    color: $disabled
+      ? colors.inputTextDisabled
+      : $error
+        ? colors.negative400
+        : $isFocused || $isPseudoFocused
+          ? colors.primary400
+          : colors.foregroundAlt,
     cursor: $disabled ? 'not-allowed' : 'pointer',
     position: 'absolute',
     left: sizing.scale500,


### PR DESCRIPTION
#### Description

Update search icon color based on state to match StyledControlContainer’s border-color: changes to negative400 on error and primary400 on focus.

<img width="301" alt="Screen Shot 2019-05-08 at 4 38 06 PM" src="https://user-images.githubusercontent.com/1285326/57415097-b0be7c80-71af-11e9-836f-a1ed11bc3dd2.png">

<img width="259" alt="Screen Shot 2019-05-08 at 4 36 24 PM" src="https://user-images.githubusercontent.com/1285326/57415100-b320d680-71af-11e9-8008-16e33c79f135.png">


#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
