### PR TITLE
fix(docs): update react router sidenav example

### DIFF
--- a/documentation-site/pages/components/sidenav.mdx
+++ b/documentation-site/pages/components/sidenav.mdx
@@ -57,9 +57,9 @@ const App = ({history, location}) => {
         },
       ]}
       activeItemId={location.pathname}
-      onChange={({e, item}) => {
+      onChange={({event, item}) => {
         // prevent page reload
-        e.preventDefault();
+        event.preventDefault();
         history.push(item.itemId);
       }}
     />


### PR DESCRIPTION
#### Description

Fixes wrong destructuring naming in the React Router side navigation example. This should be correct unless the example should rather be in the `onChange={({event: e, item}) => {` form.

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
