### PR TITLE
docs(theming-values): add example borders

### DIFF
--- a/documentation-site/components/theming-values/borders.js
+++ b/documentation-site/components/theming-values/borders.js
@@ -13,7 +13,7 @@ import {Block} from 'baseui/block';
 
 import {Header, ExampleWrapper} from './common';
 
-const StyledBorderBox = styled('div', ({$theme, $border = ''}) => {
+const StyledBorderBox = styled('div', ({$theme, $border = {}}) => {
   return {
     marginTop: $theme.sizing.scale200,
     height: $theme.sizing.scale4800,

--- a/documentation-site/components/theming-values/borders.js
+++ b/documentation-site/components/theming-values/borders.js
@@ -1,0 +1,63 @@
+/*
+Copyright (c) 2018 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {styled, LightTheme} from 'baseui';
+import {Block} from 'baseui/block';
+
+import {Header, ExampleWrapper} from './common';
+
+const StyledBorderBox = styled('div', ({$theme, $border = ''}) => {
+  return {
+    marginTop: $theme.sizing.scale200,
+    height: $theme.sizing.scale4800,
+    backgroundColor: $theme.colors.mono100,
+    borderRadius: $theme.borders.radius200,
+    ...$border,
+  };
+});
+
+function BorderPreview({name, border}) {
+  return (
+    <Block width="250px" margin="scale800">
+      <Block font="font400">
+        {name} ({border.borderWidth} {border.borderStyle} {border.borderColor})
+      </Block>
+      <StyledBorderBox $border={border} />
+    </Block>
+  );
+}
+
+function Borders() {
+  const borders = {
+    border100: LightTheme.borders.border100,
+    border200: LightTheme.borders.border200,
+    border300: LightTheme.borders.border300,
+    border400: LightTheme.borders.border400,
+    border500: LightTheme.borders.border500,
+    border600: LightTheme.borders.border600,
+  };
+
+  return (
+    <div>
+      <Header>Borders</Header>
+      <ExampleWrapper>
+        {Object.keys(borders).map(bordersKey => (
+          <BorderPreview
+            key={bordersKey}
+            name={bordersKey}
+            border={borders[bordersKey]}
+          />
+        ))}
+      </ExampleWrapper>
+    </div>
+  );
+}
+
+export default Borders;

--- a/documentation-site/pages/theming/theming-values.mdx
+++ b/documentation-site/pages/theming/theming-values.mdx
@@ -2,6 +2,7 @@ import Layout from '../../components/layout';
 import Colors from '../../components/theming-values/colors';
 import Sizing from '../../components/theming-values/sizing';
 import Lighting from '../../components/theming-values/lighting';
+import Borders from '../../components/theming-values/borders';
 import Typography from '../../components/theming-values/typography';
 
 export default Layout;
@@ -11,4 +12,5 @@ export default Layout;
 <Colors />
 <Sizing />
 <Lighting />
+<Borders />
 <Typography />


### PR DESCRIPTION
#### Description

Add example borders to documentation

<img width="410" alt="Screen Shot 2019-05-13 at 6 10 45 PM" src="https://user-images.githubusercontent.com/1285326/57663950-1002ff00-75ab-11e9-8a4a-4bfff7bbc2f9.png">

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
