### PR TITLE
fix(toast): add tabIndex to <Toast/> body so it can be focused

### DIFF
--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -164,7 +164,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
             {...sharedProps}
             {...bodyProps}
             // the properties below have to go after overrides
-            tabIndex={0}
+            tabIndex={-1}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onMouseEnter={this.onMouseEnter}

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -164,6 +164,7 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
             {...sharedProps}
             {...bodyProps}
             // the properties below have to go after overrides
+            tabIndex={0}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onMouseEnter={this.onMouseEnter}

--- a/src/toast/toast.js
+++ b/src/toast/toast.js
@@ -161,10 +161,10 @@ class Toast extends React.Component<ToastPropsT, ToastPrivateStateT> {
           <Body
             role="alert"
             data-baseweb={this.props['data-baseweb'] || 'toast'}
+            tabIndex={-1}
             {...sharedProps}
             {...bodyProps}
             // the properties below have to go after overrides
-            tabIndex={-1}
             onBlur={this.onBlur}
             onFocus={this.onFocus}
             onMouseEnter={this.onMouseEnter}


### PR DESCRIPTION
#### Description

Adds a `tabIndex` attribute to the `<Toast/>` body so it can be focused and allow the the `onFocus`/`onBlur` event handlers to work correctly.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
