### PR TITLE
feat(block): add backgroundColor prop to Block

### DIFF
--- a/src/block/__tests__/block.test.js
+++ b/src/block/__tests__/block.test.js
@@ -31,6 +31,20 @@ describe('Block', () => {
     });
   });
 
+  it('renders themed backgroundColor if provided', () => {
+    expect(
+      retrieveStyles(<Block backgroundColor="primary200">test</Block>),
+    ).toMatchObject({backgroundColor: '$theme.colors.primary200'});
+  });
+
+  it('renders provided backgroundColor if no matching themeable value is found', () => {
+    expect(
+      retrieveStyles(<Block backgroundColor="red">test</Block>),
+    ).toMatchObject({
+      backgroundColor: 'red',
+    });
+  });
+
   it('renders themed font if provided', () => {
     expect(retrieveStyles(<Block font="font200">test</Block>)).toMatchObject({
       fontFamily: '$theme.typography.font200.fontFamily',

--- a/src/block/block.js
+++ b/src/block/block.js
@@ -17,6 +17,7 @@ function Block({
   as,
   overrides,
   color,
+  backgroundColor,
   font,
   alignContent,
   alignItems,
@@ -83,6 +84,7 @@ function Block({
     <BaseBlock
       $as={as}
       $color={color}
+      $backgroundColor={backgroundColor}
       $font={font}
       $alignContent={alignContent}
       $alignItems={alignItems}

--- a/src/block/styled-components.js
+++ b/src/block/styled-components.js
@@ -78,6 +78,11 @@ export const StyledBlock = styled('div', (props: StyledBlockPropsT) => {
     value: get(props, '$color'),
     transform: color => colors[color] || color,
   });
+  styles.apply({
+    property: 'backgroundColor',
+    value: get(props, '$backgroundColor'),
+    transform: backgroundColor => colors[backgroundColor] || backgroundColor,
+  });
 
   styles.apply({
     property: 'fontFamily',

--- a/src/block/types.js
+++ b/src/block/types.js
@@ -228,6 +228,8 @@ export type BlockPropsT = {
   overrides?: OverridesT,
   /** Accepts all themeable color properties (`primary200`, etc.). */
   color?: ResponsiveT<string>,
+  /** Accepts all themeable color properties (`primary200`, etc.). */
+  backgroundColor?: ResponsiveT<string>,
   /** Accepts all themeable font properties (`font200`, etc.). */
   font?: string | Array<string>,
   /** available values: https://developer.mozilla.org/en-US/docs/Web/CSS/align-content */
@@ -319,6 +321,7 @@ export type StyledBlockPropsT = {
   $theme: ThemeT,
   $as?: ElementType,
   $color?: ResponsiveT<string>,
+  $backgroundColor?: ResponsiveT<string>,
   $font?: ResponsiveT<string>,
   $alignContent?: ResponsiveT<AlignContentT>,
   $alignItems?: ResponsiveT<AlignItemsT>,


### PR DESCRIPTION
Fixes #859

#### Description

Add backgroundColor prop to Block, following the pattern of the color prop

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
