### PR TITLE
chore: consistently import React

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {configure, addDecorator} from '@storybook/react';
 
 import {Provider as StyletronProvider} from 'styletron-react';

--- a/documentation-site/components/api.js
+++ b/documentation-site/components/api.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import Props from 'pretty-proptypes';
 
 import {Block} from 'baseui/block';

--- a/documentation-site/components/blog.js
+++ b/documentation-site/components/blog.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/components/contributors.js
+++ b/documentation-site/components/contributors.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {Avatar} from 'baseui/avatar';
 import {Block} from 'baseui/block';
 import {H2} from './markdown-elements';

--- a/documentation-site/components/meta.js
+++ b/documentation-site/components/meta.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* global process */
 
-import React from 'react';
+import * as React from 'react';
 
 const title =
   process.env.WEBSITE_ENV === 'production'

--- a/documentation-site/components/overrides.js
+++ b/documentation-site/components/overrides.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Radio, RadioGroup} from 'baseui/radio';
 import {DocLink} from './markdown-elements';

--- a/documentation-site/components/posts.js
+++ b/documentation-site/components/posts.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Card, StyledBody, StyledAction} from 'baseui/card';
 import {Button, KIND} from 'baseui/button';

--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import {
   Navigation,
   StyledNavItem as NavItem,

--- a/documentation-site/components/theming-values/borders.js
+++ b/documentation-site/components/theming-values/borders.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {styled, LightTheme} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/components/theming-values/colors.js
+++ b/documentation-site/components/theming-values/colors.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {styled, LightTheme} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/components/theming-values/lighting.js
+++ b/documentation-site/components/theming-values/lighting.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {styled, LightTheme} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/components/theming-values/sizing.js
+++ b/documentation-site/components/theming-values/sizing.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {styled, LightTheme} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/components/theming-values/typography.js
+++ b/documentation-site/components/theming-values/typography.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {LightTheme} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 /* eslint-disable flowtype/require-valid-file-annotation */
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import {
   BaseProvider,
   DarkTheme,

--- a/documentation-site/pages/_document.js
+++ b/documentation-site/pages/_document.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 /* eslint-disable flowtype/require-valid-file-annotation */
 
-import React from 'react';
+import * as React from 'react';
 import Document, {Head, Main, NextScript} from 'next/document';
 import {Provider as StyletronProvider} from 'styletron-react';
 

--- a/documentation-site/pages/index.js
+++ b/documentation-site/pages/index.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* global process */
 
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {H1} from '../components/markdown-elements';

--- a/documentation-site/pages/theming/understanding-overrides.mdx
+++ b/documentation-site/pages/theming/understanding-overrides.mdx
@@ -177,7 +177,7 @@ To better understand it, let's take a look at the example of the `Select` compon
 So far we demonstrated how to **override styles or add additional props** but you can also **completely replace subcomponents**. This means you can alter the behavior and appearance of all Base Web components. For example, **we can enhance our textual Label and add a cloning functionality**:
 
 ```jsx
-import React from 'react';
+import * as React from 'react';
 import {List, arrayMove} from 'baseui/dnd-list';
 
 export default class Example extends React.Component {

--- a/documentation-site/static/examples/accordion/basic.js
+++ b/documentation-site/static/examples/accordion/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Accordion, Panel} from 'baseui/accordion';
 
 const content =

--- a/documentation-site/static/examples/accordion/stateful.js
+++ b/documentation-site/static/examples/accordion/stateful.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulPanel} from 'baseui/accordion';
 
 const content =

--- a/documentation-site/static/examples/avatar/error.js
+++ b/documentation-site/static/examples/avatar/error.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Avatar} from 'baseui/avatar';
 
 export default () => (

--- a/documentation-site/static/examples/avatar/override.js
+++ b/documentation-site/static/examples/avatar/override.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Avatar} from 'baseui/avatar';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/static/examples/avatar/sizes.js
+++ b/documentation-site/static/examples/avatar/sizes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Avatar} from 'baseui/avatar';
 
 export default () => (

--- a/documentation-site/static/examples/block/basic.js
+++ b/documentation-site/static/examples/block/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 
 export default () => {

--- a/documentation-site/static/examples/block/flexbox.js
+++ b/documentation-site/static/examples/block/flexbox.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 
 export default () => {

--- a/documentation-site/static/examples/block/fonts.js
+++ b/documentation-site/static/examples/block/fonts.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 
 export default () => {

--- a/documentation-site/static/examples/block/grid.js
+++ b/documentation-site/static/examples/block/grid.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/static/examples/block/override.js
+++ b/documentation-site/static/examples/block/override.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 
 export default () => {

--- a/documentation-site/static/examples/block/responsive.js
+++ b/documentation-site/static/examples/block/responsive.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 
 export default () => {

--- a/documentation-site/static/examples/breadcrumbs/basic.js
+++ b/documentation-site/static/examples/breadcrumbs/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Breadcrumbs} from 'baseui/breadcrumbs';
 import {StyledLink as Link} from 'baseui/link';
 

--- a/documentation-site/static/examples/button-group/basic.js
+++ b/documentation-site/static/examples/button-group/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';
 import Upload from 'baseui/icon/upload.js';

--- a/documentation-site/static/examples/button-group/checkbox-mode.js
+++ b/documentation-site/static/examples/button-group/checkbox-mode.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import {StatefulButtonGroup} from 'baseui/button-group';
 

--- a/documentation-site/static/examples/button-group/controlled.js
+++ b/documentation-site/static/examples/button-group/controlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';

--- a/documentation-site/static/examples/button-group/disabled.js
+++ b/documentation-site/static/examples/button-group/disabled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';

--- a/documentation-site/static/examples/button-group/dropdown.js
+++ b/documentation-site/static/examples/button-group/dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';
 import Down from 'baseui/icon/triangle-down.js';

--- a/documentation-site/static/examples/button-group/radio-mode.js
+++ b/documentation-site/static/examples/button-group/radio-mode.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import {StatefulButtonGroup} from 'baseui/button-group';
 

--- a/documentation-site/static/examples/button/as-an-anchor.js
+++ b/documentation-site/static/examples/button/as-an-anchor.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 
 export default () => (

--- a/documentation-site/static/examples/button/basic-compact.js
+++ b/documentation-site/static/examples/button/basic-compact.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, SIZE} from 'baseui/button';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/static/examples/button/basic.js
+++ b/documentation-site/static/examples/button/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, KIND} from 'baseui/button';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/static/examples/button/dropdown.js
+++ b/documentation-site/static/examples/button/dropdown.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import ArrowDown from 'baseui/icon/arrow-down';
 import {StatefulPopover, PLACEMENT} from 'baseui/popover';

--- a/documentation-site/static/examples/button/shapes.js
+++ b/documentation-site/static/examples/button/shapes.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, SHAPE} from 'baseui/button';
 import Upload from 'baseui/icon/upload';
 

--- a/documentation-site/static/examples/button/states.js
+++ b/documentation-site/static/examples/button/states.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, KIND} from 'baseui/button';
 import {Block} from 'baseui/block';
 

--- a/documentation-site/static/examples/button/with-enhancers.js
+++ b/documentation-site/static/examples/button/with-enhancers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import Upload from 'baseui/icon/upload';
 import ArrowRight from 'baseui/icon/arrow-right';

--- a/documentation-site/static/examples/card/basic.js
+++ b/documentation-site/static/examples/card/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Card, StyledBody} from 'baseui/card';
 
 export default () => (

--- a/documentation-site/static/examples/card/image-cta.js
+++ b/documentation-site/static/examples/card/image-cta.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Card, StyledBody, StyledAction} from 'baseui/card';
 import {Button} from 'baseui/button';
 

--- a/documentation-site/static/examples/card/thumbnail-cta.js
+++ b/documentation-site/static/examples/card/thumbnail-cta.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Card, StyledBody, StyledAction, StyledThumbnail} from 'baseui/card';
 import {Button} from 'baseui/button';
 

--- a/documentation-site/static/examples/checkbox/alignment.js
+++ b/documentation-site/static/examples/checkbox/alignment.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/basic-uncontrolled.js
+++ b/documentation-site/static/examples/checkbox/basic-uncontrolled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/component-overrides.js
+++ b/documentation-site/static/examples/checkbox/component-overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {StatefulCheckbox} from 'baseui/checkbox';
 import Alert from 'baseui/icon/alert';

--- a/documentation-site/static/examples/checkbox/disabled.js
+++ b/documentation-site/static/examples/checkbox/disabled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/error.js
+++ b/documentation-site/static/examples/checkbox/error.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/focus.js
+++ b/documentation-site/static/examples/checkbox/focus.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, SIZE} from 'baseui/button';
 import {StatefulCheckbox} from 'baseui/checkbox';
 

--- a/documentation-site/static/examples/checkbox/indeterminate.js
+++ b/documentation-site/static/examples/checkbox/indeterminate.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Checkbox} from 'baseui/checkbox';
 

--- a/documentation-site/static/examples/checkbox/multiline.js
+++ b/documentation-site/static/examples/checkbox/multiline.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/overrides.js
+++ b/documentation-site/static/examples/checkbox/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/checkbox/toggle.js
+++ b/documentation-site/static/examples/checkbox/toggle.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCheckbox, STYLE_TYPE} from 'baseui/checkbox';
 
 export default () => (

--- a/documentation-site/static/examples/datepicker/basic.js
+++ b/documentation-site/static/examples/datepicker/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCalendar} from 'baseui/datepicker';
 
 export default () => <StatefulCalendar />;

--- a/documentation-site/static/examples/datepicker/in-popover.js
+++ b/documentation-site/static/examples/datepicker/in-popover.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulDatepicker} from 'baseui/datepicker';
 import {Block} from 'baseui/block';
 import {addDays} from 'date-fns';

--- a/documentation-site/static/examples/datepicker/quick-select.js
+++ b/documentation-site/static/examples/datepicker/quick-select.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCalendar} from 'baseui/datepicker';
 
 export default () => <StatefulCalendar range quickSelect />;

--- a/documentation-site/static/examples/datepicker/timezone-picker.js
+++ b/documentation-site/static/examples/datepicker/timezone-picker.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {TimezonePicker} from 'baseui/datepicker';
 import {FormControl} from 'baseui/form-control';

--- a/documentation-site/static/examples/datepicker/with-overrides.js
+++ b/documentation-site/static/examples/datepicker/with-overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulCalendar} from 'baseui/datepicker';
 
 const selectOverrides = {

--- a/documentation-site/static/examples/dnd-list/basic.js
+++ b/documentation-site/static/examples/dnd-list/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/customDragHandle.js
+++ b/documentation-site/static/examples/dnd-list/customDragHandle.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 import {styled} from 'baseui';
 import ArrowRight from 'baseui/icon/arrow-right';

--- a/documentation-site/static/examples/dnd-list/overrideLabel.js
+++ b/documentation-site/static/examples/dnd-list/overrideLabel.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/overrides_short.js
+++ b/documentation-site/static/examples/dnd-list/overrides_short.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/overrides_state_props.js
+++ b/documentation-site/static/examples/dnd-list/overrides_state_props.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/overrides_style.js
+++ b/documentation-site/static/examples/dnd-list/overrides_style.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/overrides_whole_subcomponent.js
+++ b/documentation-site/static/examples/dnd-list/overrides_whole_subcomponent.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {List, arrayMove, StyledLabel} from 'baseui/dnd-list';
 
 export default class Example extends React.Component {

--- a/documentation-site/static/examples/dnd-list/removable.js
+++ b/documentation-site/static/examples/dnd-list/removable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/dnd-list/stateless.js
+++ b/documentation-site/static/examples/dnd-list/stateless.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {List, arrayMove} from 'baseui/dnd-list';
 
 export default class Example extends React.Component {

--- a/documentation-site/static/examples/dnd-list/varyingHeights.js
+++ b/documentation-site/static/examples/dnd-list/varyingHeights.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulList} from 'baseui/dnd-list';
 
 export default () => (

--- a/documentation-site/static/examples/form-control/basic.js
+++ b/documentation-site/static/examples/form-control/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {FormControl} from 'baseui/form-control';
 import {StatefulInput, SIZE} from 'baseui/input';
 import {StatefulTextarea} from 'baseui/textarea';

--- a/documentation-site/static/examples/header-navigation/basic.js
+++ b/documentation-site/static/examples/header-navigation/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   HeaderNavigation,
   ALIGN,

--- a/documentation-site/static/examples/header-navigation/with-search.js
+++ b/documentation-site/static/examples/header-navigation/with-search.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   HeaderNavigation,
   ALIGN,

--- a/documentation-site/static/examples/icon/basic.js
+++ b/documentation-site/static/examples/icon/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import ArrowUp from 'baseui/icon/arrow-up';
 import ArrowRight from 'baseui/icon/arrow-right';

--- a/documentation-site/static/examples/icon/button.js
+++ b/documentation-site/static/examples/icon/button.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button, SHAPE} from 'baseui/button';
 

--- a/documentation-site/static/examples/icon/list.js
+++ b/documentation-site/static/examples/icon/list.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import * as Icons from 'baseui/icon/icon-exports';
 

--- a/documentation-site/static/examples/input/available-states.js
+++ b/documentation-site/static/examples/input/available-states.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {StatefulInput} from 'baseui/input';
 

--- a/documentation-site/static/examples/input/basic-controlled.js
+++ b/documentation-site/static/examples/input/basic-controlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Input} from 'baseui/input';
 
 export default class ControlledInput extends React.Component {

--- a/documentation-site/static/examples/input/basic-uncontrolled-default-value.js
+++ b/documentation-site/static/examples/input/basic-uncontrolled-default-value.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulInput} from 'baseui/input';
 
 export default () => (

--- a/documentation-site/static/examples/input/basic-uncontrolled.js
+++ b/documentation-site/static/examples/input/basic-uncontrolled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulInput} from 'baseui/input';
 
 export default () => <StatefulInput placeholder="Uncontrolled Input" />;

--- a/documentation-site/static/examples/input/before-after.js
+++ b/documentation-site/static/examples/input/before-after.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Search} from 'baseui/icon';
 import {StatefulInput} from 'baseui/input';

--- a/documentation-site/static/examples/input/compact-size.js
+++ b/documentation-site/static/examples/input/compact-size.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulInput, SIZE} from 'baseui/input';
 
 export default () => (

--- a/documentation-site/static/examples/input/enhancers.js
+++ b/documentation-site/static/examples/input/enhancers.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Search} from 'baseui/icon';
 import {StatefulInput} from 'baseui/input';

--- a/documentation-site/static/examples/input/focus.js
+++ b/documentation-site/static/examples/input/focus.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulInput} from 'baseui/input';

--- a/documentation-site/static/examples/input/mask.js
+++ b/documentation-site/static/examples/input/mask.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {MaskedInput} from 'baseui/input';
 
 export default () => (

--- a/documentation-site/static/examples/input/overrides.js
+++ b/documentation-site/static/examples/input/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {StatefulInput, StyledInputContainer} from 'baseui/input';
 

--- a/documentation-site/static/examples/input/with-tags.js
+++ b/documentation-site/static/examples/input/with-tags.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';
 import {Input, StyledInput, SIZE} from 'baseui/input';

--- a/documentation-site/static/examples/internationalization/example.js
+++ b/documentation-site/static/examples/internationalization/example.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {LocaleProvider} from 'baseui';
 import {StatefulPagination} from 'baseui/pagination';
 

--- a/documentation-site/static/examples/layer/basic-tether.js
+++ b/documentation-site/static/examples/layer/basic-tether.js
@@ -1,5 +1,5 @@
 /* global document */
-import React from 'react';
+import * as React from 'react';
 import {Layer, TetherBehavior, TETHER_PLACEMENT} from 'baseui/layer';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';

--- a/documentation-site/static/examples/layer/basic.js
+++ b/documentation-site/static/examples/layer/basic.js
@@ -1,5 +1,5 @@
 /* global document */
-import React from 'react';
+import * as React from 'react';
 import {Layer} from 'baseui/layer';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';

--- a/documentation-site/static/examples/link/basic.js
+++ b/documentation-site/static/examples/link/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StyledLink} from 'baseui/link';
 
 export default () => (

--- a/documentation-site/static/examples/menu/basic.js
+++ b/documentation-site/static/examples/menu/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Menu} from 'baseui/menu';
 
 const ITEMS = [

--- a/documentation-site/static/examples/menu/child.js
+++ b/documentation-site/static/examples/menu/child.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulMenu, NestedMenus} from 'baseui/menu';
 
 const OPEN_RECENT = 'Open Recent ->';

--- a/documentation-site/static/examples/menu/compact.js
+++ b/documentation-site/static/examples/menu/compact.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Menu} from 'baseui/menu';
 
 const ITEMS = [

--- a/documentation-site/static/examples/menu/profile.js
+++ b/documentation-site/static/examples/menu/profile.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Menu, OptionProfile} from 'baseui/menu';
 
 const ITEMS = [...new Array(4)].map(() => ({

--- a/documentation-site/static/examples/menu/stateful.js
+++ b/documentation-site/static/examples/menu/stateful.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulMenu} from 'baseui/menu';
 
 const ITEMS = [

--- a/documentation-site/static/examples/menu/virtual-list.js
+++ b/documentation-site/static/examples/menu/virtual-list.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {StatefulMenu, OptionList, StyledList} from 'baseui/menu';
 import List from 'react-virtualized/dist/commonjs/List';

--- a/documentation-site/static/examples/modal/basic.js
+++ b/documentation-site/static/examples/modal/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 import {
   Modal,

--- a/documentation-site/static/examples/notification/basic.js
+++ b/documentation-site/static/examples/notification/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Notification} from 'baseui/notification';
 
 export default () => <Notification>Default info notification</Notification>;

--- a/documentation-site/static/examples/notification/closeable.js
+++ b/documentation-site/static/examples/notification/closeable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Notification} from 'baseui/notification';
 
 export default () => (

--- a/documentation-site/static/examples/notification/custom-dismiss.js
+++ b/documentation-site/static/examples/notification/custom-dismiss.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, SIZE} from 'baseui/button';
 import {Notification} from 'baseui/notification';
 

--- a/documentation-site/static/examples/notification/full-width.js
+++ b/documentation-site/static/examples/notification/full-width.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Notification} from 'baseui/notification';
 
 export default () => (

--- a/documentation-site/static/examples/notification/kinds.js
+++ b/documentation-site/static/examples/notification/kinds.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Notification, KIND} from 'baseui/notification';
 
 export default () => (

--- a/documentation-site/static/examples/notification/overrides.js
+++ b/documentation-site/static/examples/notification/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Notification} from 'baseui/notification';
 import DeleteAlt from 'baseui/icon/delete-alt';
 

--- a/documentation-site/static/examples/overrides/component.js
+++ b/documentation-site/static/examples/overrides/component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 
 function customButton(props) {

--- a/documentation-site/static/examples/overrides/props.js
+++ b/documentation-site/static/examples/overrides/props.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 
 export default () => (

--- a/documentation-site/static/examples/overrides/style-with-theme.js
+++ b/documentation-site/static/examples/overrides/style-with-theme.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 
 export default () => (

--- a/documentation-site/static/examples/overrides/style.js
+++ b/documentation-site/static/examples/overrides/style.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button} from 'baseui/button';
 
 export default () => (

--- a/documentation-site/static/examples/pagination/controlled.js
+++ b/documentation-site/static/examples/pagination/controlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Pagination} from 'baseui/pagination';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/pagination/labels.js
+++ b/documentation-site/static/examples/pagination/labels.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulPagination} from 'baseui/pagination';
 
 export default () => (

--- a/documentation-site/static/examples/pagination/overrides.js
+++ b/documentation-site/static/examples/pagination/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Button, KIND} from 'baseui/button';
 import {StatefulPagination} from 'baseui/pagination';
 

--- a/documentation-site/static/examples/pagination/uncontrolled.js
+++ b/documentation-site/static/examples/pagination/uncontrolled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulPagination} from 'baseui/pagination';
 
 export default () => <StatefulPagination numPages={10} />;

--- a/documentation-site/static/examples/popover/clipping.js
+++ b/documentation-site/static/examples/popover/clipping.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulPopover, PLACEMENT} from 'baseui/popover';

--- a/documentation-site/static/examples/popover/dismiss.js
+++ b/documentation-site/static/examples/popover/dismiss.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulPopover} from 'baseui/popover';

--- a/documentation-site/static/examples/popover/overrides.js
+++ b/documentation-site/static/examples/popover/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulPopover} from 'baseui/popover';

--- a/documentation-site/static/examples/popover/placements.js
+++ b/documentation-site/static/examples/popover/placements.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';

--- a/documentation-site/static/examples/popover/ref-handling.js
+++ b/documentation-site/static/examples/popover/ref-handling.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';
 import {Label1} from 'baseui/typography';

--- a/documentation-site/static/examples/popover/stateful-click.js
+++ b/documentation-site/static/examples/popover/stateful-click.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulPopover} from 'baseui/popover';

--- a/documentation-site/static/examples/popover/stateful-hover.js
+++ b/documentation-site/static/examples/popover/stateful-hover.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {StatefulPopover, TRIGGER_TYPE} from 'baseui/popover';
 

--- a/documentation-site/static/examples/popover/stateless.js
+++ b/documentation-site/static/examples/popover/stateless.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Popover} from 'baseui/popover';
 

--- a/documentation-site/static/examples/popover/with-arrow.js
+++ b/documentation-site/static/examples/popover/with-arrow.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button} from 'baseui/button';
 import {StatefulPopover} from 'baseui/popover';

--- a/documentation-site/static/examples/progress-bar/basic.js
+++ b/documentation-site/static/examples/progress-bar/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 100;

--- a/documentation-site/static/examples/progress-bar/custom-label.js
+++ b/documentation-site/static/examples/progress-bar/custom-label.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 100;

--- a/documentation-site/static/examples/progress-bar/negative.js
+++ b/documentation-site/static/examples/progress-bar/negative.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 100;

--- a/documentation-site/static/examples/progress-bar/overrides.js
+++ b/documentation-site/static/examples/progress-bar/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 100;

--- a/documentation-site/static/examples/progress-bar/success-value.js
+++ b/documentation-site/static/examples/progress-bar/success-value.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 400;

--- a/documentation-site/static/examples/progress-bar/with-label.js
+++ b/documentation-site/static/examples/progress-bar/with-label.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressBar} from 'baseui/progress-bar';
 
 const SUCCESS_VALUE = 100;

--- a/documentation-site/static/examples/progress-steps/dotted.js
+++ b/documentation-site/static/examples/progress-steps/dotted.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressSteps, Step} from 'baseui/progress-steps';
 import {Button} from 'baseui/button';
 import {Block} from 'baseui/block';

--- a/documentation-site/static/examples/progress-steps/numbered.js
+++ b/documentation-site/static/examples/progress-steps/numbered.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {ProgressSteps, NumberedStep} from 'baseui/progress-steps';
 import {Button} from 'baseui/button';
 import {Block} from 'baseui/block';

--- a/documentation-site/static/examples/radio/basic.js
+++ b/documentation-site/static/examples/radio/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Radio, RadioGroup} from 'baseui/radio';
 
 export default class Stateless extends React.Component {

--- a/documentation-site/static/examples/radio/disabled.js
+++ b/documentation-site/static/examples/radio/disabled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Radio, RadioGroup} from 'baseui/radio';
 
 export default function Disabled() {

--- a/documentation-site/static/examples/radio/error.js
+++ b/documentation-site/static/examples/radio/error.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Radio, RadioGroup} from 'baseui/radio';
 
 export default class Stateless extends React.Component {

--- a/documentation-site/static/examples/radio/horizontal-align.js
+++ b/documentation-site/static/examples/radio/horizontal-align.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Radio, RadioGroup} from 'baseui/radio';
 
 export default class Stateless extends React.Component {

--- a/documentation-site/static/examples/radio/overrides.js
+++ b/documentation-site/static/examples/radio/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Radio, RadioGroup} from 'baseui/radio';
 

--- a/documentation-site/static/examples/radio/stateful.js
+++ b/documentation-site/static/examples/radio/stateful.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Radio, StatefulRadioGroup} from 'baseui/radio';
 
 export default () => (

--- a/documentation-site/static/examples/rating/emoticon.js
+++ b/documentation-site/static/examples/rating/emoticon.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {EmoticonRating} from 'baseui/rating';
 
 class EmoticonExample extends React.Component {

--- a/documentation-site/static/examples/rating/star.js
+++ b/documentation-site/static/examples/rating/star.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StarRating} from 'baseui/rating';
 
 class StarExample extends React.Component {

--- a/documentation-site/static/examples/select/basic.js
+++ b/documentation-site/static/examples/select/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect} from 'baseui/select';
 
 export default () => (

--- a/documentation-site/static/examples/select/controlled.js
+++ b/documentation-site/static/examples/select/controlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Select} from 'baseui/select';
 
 export default class Container extends React.Component {

--- a/documentation-site/static/examples/select/creatable-multi.js
+++ b/documentation-site/static/examples/select/creatable-multi.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect} from 'baseui/select';
 
 export default () => (

--- a/documentation-site/static/examples/select/creatable.js
+++ b/documentation-site/static/examples/select/creatable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect} from 'baseui/select';
 
 export default () => (

--- a/documentation-site/static/examples/select/label.js
+++ b/documentation-site/static/examples/select/label.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Select} from 'baseui/select';
 

--- a/documentation-site/static/examples/select/overridden.js
+++ b/documentation-site/static/examples/select/overridden.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Select} from 'baseui/select';
 
 export default class Container extends React.Component {

--- a/documentation-site/static/examples/select/overriden-tag.js
+++ b/documentation-site/static/examples/select/overriden-tag.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect, TYPE} from 'baseui/select';
 
 export default class Container extends React.Component {

--- a/documentation-site/static/examples/select/search-multi-pick.js
+++ b/documentation-site/static/examples/select/search-multi-pick.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect, TYPE} from 'baseui/select';
 
 export default () => (

--- a/documentation-site/static/examples/select/search-single-pick.js
+++ b/documentation-site/static/examples/select/search-single-pick.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSelect, TYPE} from 'baseui/select';
 
 export default () => (

--- a/documentation-site/static/examples/select/with-many-options.js
+++ b/documentation-site/static/examples/select/with-many-options.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {StatefulSelect, StyledDropdownListItem} from 'baseui/select';
 import {StyledList} from 'baseui/menu';

--- a/documentation-site/static/examples/slider/basic.js
+++ b/documentation-site/static/examples/slider/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/slider/custom-ticks.js
+++ b/documentation-site/static/examples/slider/custom-ticks.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 import {styled} from 'baseui';
 

--- a/documentation-site/static/examples/slider/disabled.js
+++ b/documentation-site/static/examples/slider/disabled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/slider/overrides.js
+++ b/documentation-site/static/examples/slider/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/slider/range.js
+++ b/documentation-site/static/examples/slider/range.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/slider/stateful.js
+++ b/documentation-site/static/examples/slider/stateful.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulSlider} from 'baseui/slider';
 
 export default () => <StatefulSlider />;

--- a/documentation-site/static/examples/slider/step-min-max.js
+++ b/documentation-site/static/examples/slider/step-min-max.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Slider} from 'baseui/slider';
 
 export default class Basic extends React.Component {

--- a/documentation-site/static/examples/spinner/basic.js
+++ b/documentation-site/static/examples/spinner/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Spinner} from 'baseui/spinner';
 
 export default () => <Spinner />;

--- a/documentation-site/static/examples/spinner/negative.js
+++ b/documentation-site/static/examples/spinner/negative.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Spinner} from 'baseui/spinner';
 
 export default () => (

--- a/documentation-site/static/examples/spinner/with-overrides.js
+++ b/documentation-site/static/examples/spinner/with-overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Spinner} from 'baseui/spinner';
 
 export default () => (

--- a/documentation-site/static/examples/spinner/with-size.js
+++ b/documentation-site/static/examples/spinner/with-size.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Spinner} from 'baseui/spinner';
 
 export default () => <Spinner size={96} />;

--- a/documentation-site/static/examples/styled/basic.js
+++ b/documentation-site/static/examples/styled/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 
 const BlueDiv = styled('div', ({$theme}) => ({

--- a/documentation-site/static/examples/styled/overrides.js
+++ b/documentation-site/static/examples/styled/overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Button} from 'baseui/button';
 

--- a/documentation-site/static/examples/table/basic.js
+++ b/documentation-site/static/examples/table/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Table} from 'baseui/table';
 
 const DATA = [

--- a/documentation-site/static/examples/table/cells.js
+++ b/documentation-site/static/examples/table/cells.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {styled} from 'baseui';
 import {Block} from 'baseui/block';

--- a/documentation-site/static/examples/table/filter.js
+++ b/documentation-site/static/examples/table/filter.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Checkbox} from 'baseui/checkbox';
 import {

--- a/documentation-site/static/examples/table/fixed-width-column.js
+++ b/documentation-site/static/examples/table/fixed-width-column.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {
   StyledTable,

--- a/documentation-site/static/examples/table/graph.js
+++ b/documentation-site/static/examples/table/graph.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import Head from 'next/head';
 import {

--- a/documentation-site/static/examples/table/horizontal-scroll.js
+++ b/documentation-site/static/examples/table/horizontal-scroll.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Table} from 'baseui/table';
 

--- a/documentation-site/static/examples/table/pagination.js
+++ b/documentation-site/static/examples/table/pagination.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Block} from 'baseui/block';
 import {Button, KIND} from 'baseui/button';
 import TriangleDown from 'baseui/icon/triangle-down';

--- a/documentation-site/static/examples/table/sortable.js
+++ b/documentation-site/static/examples/table/sortable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 
 import {
   StyledTable,

--- a/documentation-site/static/examples/table/vertical-scroll.js
+++ b/documentation-site/static/examples/table/vertical-scroll.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {Table} from 'baseui/table';
 

--- a/documentation-site/static/examples/table/virtual-horizontal-scroll.js
+++ b/documentation-site/static/examples/table/virtual-horizontal-scroll.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {
   StyledTable,

--- a/documentation-site/static/examples/table/virtual.js
+++ b/documentation-site/static/examples/table/virtual.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {styled} from 'baseui';
 import {
   StyledTable,

--- a/documentation-site/static/examples/tabs/basic.js
+++ b/documentation-site/static/examples/tabs/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTabs, Tab} from 'baseui/tabs';
 
 export default () => (

--- a/documentation-site/static/examples/tabs/controlled.js
+++ b/documentation-site/static/examples/tabs/controlled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tabs, Tab} from 'baseui/tabs';
 
 export default () => <ControlledTabsStory />;

--- a/documentation-site/static/examples/tabs/vertical.js
+++ b/documentation-site/static/examples/tabs/vertical.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTabs, Tab, ORIENTATION} from 'baseui/tabs';
 
 export default () => (

--- a/documentation-site/static/examples/tag/basic.js
+++ b/documentation-site/static/examples/tag/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag} from 'baseui/tag';
 
 export default () => (

--- a/documentation-site/static/examples/tag/clickable-non-closeable.js
+++ b/documentation-site/static/examples/tag/clickable-non-closeable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 const kinds = Object.keys(KIND).filter(kind => kind !== KIND.custom);

--- a/documentation-site/static/examples/tag/clickable.js
+++ b/documentation-site/static/examples/tag/clickable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 const kinds = Object.keys(KIND).filter(kind => kind !== KIND.custom);

--- a/documentation-site/static/examples/tag/custom-color.js
+++ b/documentation-site/static/examples/tag/custom-color.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 export default () => (

--- a/documentation-site/static/examples/tag/disabled.js
+++ b/documentation-site/static/examples/tag/disabled.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 const kinds = Object.keys(KIND).filter(kind => kind !== KIND.custom);

--- a/documentation-site/static/examples/tag/kinds.js
+++ b/documentation-site/static/examples/tag/kinds.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 const kinds = Object.keys(KIND).filter(kind => kind !== KIND.custom);

--- a/documentation-site/static/examples/tag/non-closeable.js
+++ b/documentation-site/static/examples/tag/non-closeable.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Tag, KIND, VARIANT} from 'baseui/tag';
 
 const kinds = Object.keys(KIND).filter(kind => kind !== KIND.custom);

--- a/documentation-site/static/examples/textarea/basic.js
+++ b/documentation-site/static/examples/textarea/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTextarea as Textarea, SIZE} from 'baseui/textarea';
 
 export default () => (

--- a/documentation-site/static/examples/textarea/ref.js
+++ b/documentation-site/static/examples/textarea/ref.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTextarea as Textarea} from 'baseui/textarea';
 import {Button} from 'baseui/button';
 

--- a/documentation-site/static/examples/theme/icon-overrides.js
+++ b/documentation-site/static/examples/theme/icon-overrides.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulPagination} from 'baseui/pagination';
 
 import {createTheme, lightThemePrimitives} from 'baseui';

--- a/documentation-site/static/examples/toast/basic.js
+++ b/documentation-site/static/examples/toast/basic.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {toaster, ToasterContainer, PLACEMENT} from 'baseui/toast';
 import {Button} from 'baseui/button';
 

--- a/documentation-site/static/examples/toast/toast-notification.js
+++ b/documentation-site/static/examples/toast/toast-notification.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Toast, KIND} from 'baseui/toast';
 import {Button, SIZE as BUTTON_SIZE, KIND as BUTTON_KIND} from 'baseui/button';
 

--- a/documentation-site/static/examples/tooltip/stateful-complex-content.js
+++ b/documentation-site/static/examples/tooltip/stateful-complex-content.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTooltip} from 'baseui/tooltip';
 import {styled} from 'baseui';
 

--- a/documentation-site/static/examples/tooltip/stateful.js
+++ b/documentation-site/static/examples/tooltip/stateful.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {StatefulTooltip} from 'baseui/tooltip';
 import {styled} from 'baseui';
 

--- a/documentation-site/static/examples/typography/display.js
+++ b/documentation-site/static/examples/typography/display.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {Display} from 'baseui/typography';
 
 const textString = 'We ignite opportunity by setting the world in motion.';

--- a/documentation-site/static/examples/typography/heading.js
+++ b/documentation-site/static/examples/typography/heading.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {H1, H2, H3, H4, H5, H6} from 'baseui/typography';
 
 const textString = 'We ignite opportunity by setting the world in motion.';

--- a/documentation-site/static/examples/typography/text.js
+++ b/documentation-site/static/examples/typography/text.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Label1,
   Label2,

--- a/proposals/datetime-picker-tools.md
+++ b/proposals/datetime-picker-tools.md
@@ -40,7 +40,7 @@ Updated API:
 ## Component Examples
 
 ```js
-import React from 'react';
+import * as React from 'react';
 import {Datepicker, Timepicker, TimezonePicker} from 'baseui/datepicker';
 
 function DatepickerCustomQuickSelect() {

--- a/src/accordion/__tests__/accordion-expanded.scenario.js
+++ b/src/accordion/__tests__/accordion-expanded.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Accordion, StatefulPanel, Panel} from '../index.js';
 

--- a/src/accordion/__tests__/accordion.scenario.js
+++ b/src/accordion/__tests__/accordion.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Accordion, Panel} from '../index.js';
 

--- a/src/accordion/__tests__/panel.test.js
+++ b/src/accordion/__tests__/panel.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {
   Panel,

--- a/src/accordion/__tests__/stateful-panel-container.test.js
+++ b/src/accordion/__tests__/stateful-panel-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulPanelContainer, STATE_CHANGE_TYPE} from '../index.js';
 

--- a/src/accordion/__tests__/stateful-panel.test.js
+++ b/src/accordion/__tests__/stateful-panel.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StatefulPanel, StatefulPanelContainer, Panel} from '../index.js';
 

--- a/src/avatar/__tests__/avatar-error.scenario.js
+++ b/src/avatar/__tests__/avatar-error.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Avatar} from '../index.js';
 

--- a/src/avatar/__tests__/avatar-nosrc.scenario.js
+++ b/src/avatar/__tests__/avatar-nosrc.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Avatar} from '../index.js';
 

--- a/src/avatar/__tests__/avatar.scenario.js
+++ b/src/avatar/__tests__/avatar.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Avatar} from '../index.js';
 import imageFile from './static/adorable.png';

--- a/src/avatar/__tests__/avatar.test.js
+++ b/src/avatar/__tests__/avatar.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Avatar, StyledInitials} from '../index.js';

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {getOverrides} from '../helpers/overrides.js';
 

--- a/src/block/block.js
+++ b/src/block/block.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import type {BlockPropsT} from './types.js';
 import {StyledBlock} from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';

--- a/src/breadcrumbs/__tests__/breadcrumbs.scenario.js
+++ b/src/breadcrumbs/__tests__/breadcrumbs.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StyledLink} from '../../link/index.js';
 import {Breadcrumbs} from '../index.js';

--- a/src/breadcrumbs/__tests__/breadcrumbs.test.js
+++ b/src/breadcrumbs/__tests__/breadcrumbs.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StyledLink} from '../../link/index.js';
 import {BreadcrumbsRoot as Breadcrumbs} from '../breadcrumbs.js';

--- a/src/button-group/__tests__/button-group-checkbox.scenario.js
+++ b/src/button-group/__tests__/button-group-checkbox.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button} from '../../button/index.js';
 import {StatefulButtonGroup, MODE} from '../index.js';

--- a/src/button-group/__tests__/button-group-radio.scenario.js
+++ b/src/button-group/__tests__/button-group-radio.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button} from '../../button/index.js';
 import {StatefulButtonGroup, MODE} from '../index.js';

--- a/src/button-group/__tests__/button-group.test.js
+++ b/src/button-group/__tests__/button-group.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 
 import {Button} from '../../button/index.js';

--- a/src/button-group/__tests__/stateful-button-group.test.js
+++ b/src/button-group/__tests__/stateful-button-group.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Button} from '../../button/index.js';

--- a/src/button-group/__tests__/stateful-container.test.js
+++ b/src/button-group/__tests__/stateful-container.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {StatefulContainer, MODE} from '../index.js';

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {KIND, SIZE, SHAPE} from '../button/index.js';
 import {getOverrides} from '../helpers/overrides.js';

--- a/src/button-group/stateful-button-group.js
+++ b/src/button-group/stateful-button-group.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import ButtonGroup from './button-group.js';
 import StatefulContainer from './stateful-container.js';

--- a/src/button/__tests__/button-enhancers-compact.scenario.js
+++ b/src/button/__tests__/button-enhancers-compact.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button, SIZE} from '../index.js';
 import ArrowRight from '../../icon/arrow-right.js';

--- a/src/button/__tests__/button-enhancers.scenario.js
+++ b/src/button/__tests__/button-enhancers.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button} from '../index.js';
 import ArrowRight from '../../icon/arrow-right.js';

--- a/src/button/__tests__/button.scenario.js
+++ b/src/button/__tests__/button.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button} from '../index.js';
 import ArrowRight from '../../icon/arrow-right.js';

--- a/src/button/__tests__/button.test.js
+++ b/src/button/__tests__/button.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {
   StartEnhancer,

--- a/src/card/__tests__/card-image-link.scenario.js
+++ b/src/card/__tests__/card-image-link.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Card, StyledAction, StyledBody} from '../index.js';
 import {StyledLink} from '../../link/index.js';

--- a/src/card/__tests__/card-text-only.scenario.js
+++ b/src/card/__tests__/card-text-only.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Card, StyledBody} from '../index.js';
 import {styled} from '../../styles/index.js';

--- a/src/card/__tests__/card.scenario.js
+++ b/src/card/__tests__/card.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   Card,

--- a/src/card/__tests__/card.test.js
+++ b/src/card/__tests__/card.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Card} from '../index.js';
 import {header as headerImg, thumbnail as thumbnailImg} from '../images.js';

--- a/src/card/card.js
+++ b/src/card/card.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 /* @flow */
 
-import React from 'react';
+import * as React from 'react';
 import {getOverride, getOverrideProps} from '../helpers/overrides.js';
 import {
   Action as StyledAction,

--- a/src/checkbox/__tests__/checkbox-indeterminite.scenario.js
+++ b/src/checkbox/__tests__/checkbox-indeterminite.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Block} from '../../block/index.js';
 import {Checkbox} from '../index.js';

--- a/src/checkbox/__tests__/checkbox-toggle.scenario.js
+++ b/src/checkbox/__tests__/checkbox-toggle.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulCheckbox, STYLE_TYPE} from '../index.js';
 

--- a/src/checkbox/__tests__/checkbox.scenario.js
+++ b/src/checkbox/__tests__/checkbox.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulCheckbox} from '../index.js';
 

--- a/src/checkbox/__tests__/checkbox.test.js
+++ b/src/checkbox/__tests__/checkbox.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-env node */
-import React from 'react';
+import * as React from 'react';
 import {mount, shallow} from 'enzyme';
 
 import {

--- a/src/checkbox/__tests__/stateful-checkbox-container.test.js
+++ b/src/checkbox/__tests__/stateful-checkbox-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {STATE_TYPE} from '../constants.js';
 

--- a/src/checkbox/__tests__/stateful-checkbox.test.js
+++ b/src/checkbox/__tests__/stateful-checkbox.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 describe('Stateful checkbox', function() {

--- a/src/checkbox/checkbox.js
+++ b/src/checkbox/checkbox.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {getOverride, getOverrideProps} from '../helpers/overrides.js';
 import type {PropsT, DefaultPropsT, StatelessStateT} from './types.js';
 import {

--- a/src/checkbox/stateful-checkbox-container.js
+++ b/src/checkbox/stateful-checkbox-container.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {STATE_TYPE} from './constants.js';
 import type {
   StatefulContainerPropsT,

--- a/src/checkbox/stateful-checkbox.js
+++ b/src/checkbox/stateful-checkbox.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 // eslint-disable-next-line import/no-named-default
 import {default as StatefulContainer} from './stateful-checkbox-container.js';
 // eslint-disable-next-line import/no-named-default

--- a/src/datepicker/__tests__/calendar.test.js
+++ b/src/datepicker/__tests__/calendar.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {
   Calendar,

--- a/src/datepicker/__tests__/datepicker.test.js
+++ b/src/datepicker/__tests__/datepicker.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Datepicker, Calendar} from '../index.js';
 import {Input} from '../../input/index.js';

--- a/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulCalendar} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-calendar.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulCalendar} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-calendar.test.js
+++ b/src/datepicker/__tests__/stateful-calendar.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StatefulCalendar, Calendar} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-container.test.js
+++ b/src/datepicker/__tests__/stateful-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer, STATE_CHANGE_TYPE} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-datepicker-quick-select.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulDatepicker} from '../index.js';
 import {addDays} from '../utils/index.js';

--- a/src/datepicker/__tests__/stateful-datepicker.scenario.js
+++ b/src/datepicker/__tests__/stateful-datepicker.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulDatepicker} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-datepicker.test.js
+++ b/src/datepicker/__tests__/stateful-datepicker.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Datepicker, StatefulDatepicker} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-range-datepicker.scenario.js
+++ b/src/datepicker/__tests__/stateful-range-datepicker.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulDatepicker} from '../index.js';
 

--- a/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
+++ b/src/datepicker/__tests__/stateful-range-quick-select.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulCalendar} from '../index.js';
 

--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {Button, KIND} from '../button/index.js';
 import CalendarHeader from './calendar-header.js';
 import Month from './month.js';

--- a/src/datepicker/datepicker.js
+++ b/src/datepicker/datepicker.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {Input} from '../input/index.js';
 import {Popover, PLACEMENT} from '../popover/index.js';
 import Calendar from './calendar.js';

--- a/src/datepicker/timepicker.js
+++ b/src/datepicker/timepicker.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
 import {LocaleContext} from '../locale/index.js';

--- a/src/datepicker/timezone-picker.js
+++ b/src/datepicker/timezone-picker.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // global Intl
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {
   findTimeZone,
   getZonedTime,

--- a/src/dnd-list/__tests__/dnd-list.scenario.js
+++ b/src/dnd-list/__tests__/dnd-list.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulList} from '../index.js';
 

--- a/src/dnd-list/__tests__/list.test.js
+++ b/src/dnd-list/__tests__/list.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {List, StyledItem} from '../index.js';
 

--- a/src/dnd-list/__tests__/stateful-list-container.test.js
+++ b/src/dnd-list/__tests__/stateful-list-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulListContainer, STATE_CHANGE_TYPE} from '../index.js';
 

--- a/src/dnd-list/__tests__/stateful-list.test.js
+++ b/src/dnd-list/__tests__/stateful-list.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulList} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-disabled.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-disabled.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-error.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-error.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-post-drop.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-post-drop.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-pre-drop.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-pre-drop.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-progress-bar.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-progress-bar.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader-spinner.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader-spinner.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader.scenario.js
+++ b/src/file-uploader/__tests__/file-uploader.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FileUploader} from '../index.js';
 

--- a/src/file-uploader/__tests__/file-uploader.test.js
+++ b/src/file-uploader/__tests__/file-uploader.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {

--- a/src/file-uploader/file-uploader.js
+++ b/src/file-uploader/file-uploader.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import Dropzone from 'react-dropzone';
 
 import {LocaleContext} from '../locale/index.js';

--- a/src/form-control/__tests__/form-control.scenario.js
+++ b/src/form-control/__tests__/form-control.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {FormControl} from '../index.js';
 import {StatefulCheckbox} from '../../checkbox/index.js';

--- a/src/form-control/__tests__/form-control.test.js
+++ b/src/form-control/__tests__/form-control.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import FormControl from '../form-control.js';
 import {Label, Caption, ControlContainer} from '../styled-components.js';

--- a/src/header-navigation/__tests__/header-navigation.scenario.js
+++ b/src/header-navigation/__tests__/header-navigation.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   HeaderNavigation,

--- a/src/header-navigation/__tests__/header-navigation.test.js
+++ b/src/header-navigation/__tests__/header-navigation.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {styled} from '../../styles/index.js';

--- a/src/header-navigation/header-navigation.js
+++ b/src/header-navigation/header-navigation.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 
 import {getOverrides} from '../helpers/overrides.js';
 import type {PropsT} from './types.js';

--- a/src/icon/__tests__/icon-buttons.scenario.js
+++ b/src/icon/__tests__/icon-buttons.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button, SHAPE} from '../../button/index.js';
 import Upload from '../upload.js';

--- a/src/icon/__tests__/icon.test.js
+++ b/src/icon/__tests__/icon.test.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {Icon} from '../index.js';
 import {Svg} from '../styled-components.js';

--- a/src/input/__tests__/base-input.test.js
+++ b/src/input/__tests__/base-input.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {BaseInput} from '../index.js';
 

--- a/src/input/__tests__/input-before-after.scenario.js
+++ b/src/input/__tests__/input-before-after.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulInput} from '../index.js';
 import {Block} from '../../block/index.js';

--- a/src/input/__tests__/input-states.scenario.js
+++ b/src/input/__tests__/input-states.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulInput} from '../index.js';
 

--- a/src/input/__tests__/input.scenario.js
+++ b/src/input/__tests__/input.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulInput, SIZE} from '../index.js';
 

--- a/src/input/__tests__/input.test.js
+++ b/src/input/__tests__/input.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Input, StyledInputContainer} from '../index.js';

--- a/src/input/__tests__/masked-input.test.js
+++ b/src/input/__tests__/masked-input.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {MaskedInput} from '../index.js';
 

--- a/src/input/__tests__/stateful-container.test.js
+++ b/src/input/__tests__/stateful-container.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* global document */
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer, STATE_CHANGE_TYPE} from '../index.js';
 

--- a/src/input/__tests__/stateful-input.test.js
+++ b/src/input/__tests__/stateful-input.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow, mount} from 'enzyme';
 import {StatefulInput, StyledInput, StatefulContainer} from '../index.js';
 

--- a/src/input/masked-input.js
+++ b/src/input/masked-input.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import InputMask from 'react-input-mask';
 
 import Input from './input.js';

--- a/src/input/stateful-input.js
+++ b/src/input/stateful-input.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import StatefulContainer from './stateful-container.js';
 import Input from './input.js';
 import type {StatefulInputPropsT} from './types.js';

--- a/src/layer/__tests__/layer.test.js
+++ b/src/layer/__tests__/layer.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Layer, LayersManager} from '../index.js';
 

--- a/src/layer/__tests__/tether.test.js
+++ b/src/layer/__tests__/tether.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import Popper from 'popper.js';
 import {TetherBehavior} from '../index.js';
 import {mount} from 'enzyme';

--- a/src/layer/layer.js
+++ b/src/layer/layer.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* global document */
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {Consumer} from './layers-manager.js';
 import type {LayerPropsT, LayerComponentPropsT, LayerStateT} from './types.js';

--- a/src/layer/tether.js
+++ b/src/layer/tether.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import Popper from 'popper.js';
 import {toPopperPlacement, parsePopperOffset} from './utils.js';
 import {TETHER_PLACEMENT} from './constants.js';

--- a/src/link/__tests__/link.scenario.js
+++ b/src/link/__tests__/link.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StyledLink} from '../index.js';
 

--- a/src/menu/__tests__/maybe-child-menu.test.js
+++ b/src/menu/__tests__/maybe-child-menu.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import MaybeChildMenu from '../maybe-child-menu.js';

--- a/src/menu/__tests__/menu-child.scenario.js
+++ b/src/menu/__tests__/menu-child.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulMenu, NestedMenus} from '../index.js';
 

--- a/src/menu/__tests__/menu-empty.scenario.js
+++ b/src/menu/__tests__/menu-empty.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {Menu} from '../index.js';
 
 export const name = 'menu-empty';

--- a/src/menu/__tests__/menu-stateful.scenario.js
+++ b/src/menu/__tests__/menu-stateful.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulMenu} from '../index.js';
 

--- a/src/menu/__tests__/menu.scenario.js
+++ b/src/menu/__tests__/menu.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Menu} from '../index.js';
 

--- a/src/menu/__tests__/menu.test.js
+++ b/src/menu/__tests__/menu.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StyledList} from '../styled-components.js';
 import OptionList from '../option-list.js';

--- a/src/menu/__tests__/option-list.test.js
+++ b/src/menu/__tests__/option-list.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StyledListItem} from '../styled-components.js';
 import OptionList from '../option-list.js';

--- a/src/menu/__tests__/option-profile.test.js
+++ b/src/menu/__tests__/option-profile.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {
   StyledListItemProfile,

--- a/src/menu/__tests__/stateful-container.test.js
+++ b/src/menu/__tests__/stateful-container.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-env browser */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import StatefulContainer from '../stateful-container.js';
 import {KEY_STRINGS, STATE_CHANGE_TYPES} from '../constants.js';

--- a/src/menu/__tests__/stateful-menu.test.js
+++ b/src/menu/__tests__/stateful-menu.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import StatefulMenu from '../stateful-menu.js';
 import StatefulContainer from '../stateful-container.js';

--- a/src/modal/__tests__/modal-button.test.js
+++ b/src/modal/__tests__/modal-button.test.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {ModalButton} from '../index.js';
 import {Button, KIND} from '../../button/index.js';

--- a/src/modal/__tests__/modal.test.js
+++ b/src/modal/__tests__/modal.test.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {mount} from 'enzyme';
 import {

--- a/src/notification/__tests__/notification.scenario.js
+++ b/src/notification/__tests__/notification.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Notification, KIND} from '../index.js';
 

--- a/src/notification/__tests__/notification.test.js
+++ b/src/notification/__tests__/notification.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Notification} from '../index.js';

--- a/src/pagination/__tests__/pagination.test.js
+++ b/src/pagination/__tests__/pagination.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-env browser */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import * as StyledComponents from '../styled-components.js';
 import {Button} from '../../button/index.js';

--- a/src/pagination/__tests__/stateful-container.test.js
+++ b/src/pagination/__tests__/stateful-container.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-env browser */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {STATE_CHANGE_TYPE} from '../constants.js';
 import StatefulContainer from '../stateful-container.js';

--- a/src/pagination/__tests__/stateful-pagination.test.js
+++ b/src/pagination/__tests__/stateful-pagination.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import StatefulPagination from '../stateful-pagination.js';
 import StatefulContainer from '../stateful-container.js';

--- a/src/popover/__tests__/popover.test.js
+++ b/src/popover/__tests__/popover.test.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-env browser */
 
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {Layer, TetherBehavior} from '../../layer/index.js';
 import {mount} from 'enzyme';

--- a/src/popover/__tests__/stateful-container.test.js
+++ b/src/popover/__tests__/stateful-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {
   StatefulContainer,

--- a/src/popover/__tests__/stateful-popover.test.js
+++ b/src/popover/__tests__/stateful-popover.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulPopover, PLACEMENT, TRIGGER_TYPE} from '../index.js';
 

--- a/src/progress-bar/__tests__/progressbar-negative.scenario.js
+++ b/src/progress-bar/__tests__/progressbar-negative.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {ProgressBar} from '../index.js';
 

--- a/src/progress-bar/__tests__/progressbar.scenario.js
+++ b/src/progress-bar/__tests__/progressbar.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {ProgressBar} from '../index.js';
 

--- a/src/progress-bar/__tests__/progressbar.test.js
+++ b/src/progress-bar/__tests__/progressbar.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {ProgressBar, StyledLabel} from '../index.js';
 import {styled} from '../../styles/index.js';

--- a/src/progress-steps/__tests__/progress-steps.scenario.js
+++ b/src/progress-steps/__tests__/progress-steps.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import Screener, {Steps} from 'screener-storybook/src/screener.js';
 
 import {Block} from '../../block/index.js';

--- a/src/radio/__tests__/radio.scenario.js
+++ b/src/radio/__tests__/radio.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulRadioGroup, Radio} from '../index.js';
 

--- a/src/radio/__tests__/radio.test.js
+++ b/src/radio/__tests__/radio.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-env node */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Radio, StyledRoot, StyledInput, StyledDescription} from '../index.js';

--- a/src/radio/__tests__/radiogroup.test.js
+++ b/src/radio/__tests__/radiogroup.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 
 import {RadioGroup, Radio} from '../index.js';

--- a/src/radio/__tests__/stateful-radiogroup-container.test.js
+++ b/src/radio/__tests__/stateful-radiogroup-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {STATE_TYPE} from '../constants.js';
 

--- a/src/radio/__tests__/stateful-radiogroup.test.js
+++ b/src/radio/__tests__/stateful-radiogroup.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {StatefulRadioGroup, Radio} from '../index.js';

--- a/src/radio/radio.js
+++ b/src/radio/radio.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {getOverrides} from '../helpers/overrides.js';
 

--- a/src/radio/radiogroup.js
+++ b/src/radio/radiogroup.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 
 import {getOverrides} from '../helpers/overrides.js';
 

--- a/src/radio/radiomark.js
+++ b/src/radio/radiomark.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {RadioMarkOuter, RadioMarkInner} from './styled-components.js';
 

--- a/src/radio/stateful-radiogroup-container.js
+++ b/src/radio/stateful-radiogroup-container.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {STATE_TYPE} from './constants.js';
 import type {
   StatefulContainerPropsT,

--- a/src/radio/stateful-radiogroup.js
+++ b/src/radio/stateful-radiogroup.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 // eslint-disable-next-line import/no-named-default
 import StatefulContainer from './stateful-radiogroup-container.js';
 // eslint-disable-next-line import/no-named-default

--- a/src/radio/styled-radio.js
+++ b/src/radio/styled-radio.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Checkbox} from '../checkbox/index.js';
 import StyledRadioMark from './radiomark.js';

--- a/src/rating/emoticon-rating.js
+++ b/src/rating/emoticon-rating.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import type {EmoticonRatingPropsT, RatingStateT} from './types.js';
 import {StyledRoot, StyledEmoticon} from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';

--- a/src/rating/star-rating.js
+++ b/src/rating/star-rating.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import type {StarRatingPropsT, RatingStateT} from './types.js';
 import {StyledRoot, StyledStar} from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';

--- a/src/select/__tests__/autosize-input.test.js
+++ b/src/select/__tests__/autosize-input.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import AutosizeInput from '../autosize-input.js';
 import {StyledInput, StyledInputSizer} from '../styled-components.js';

--- a/src/select/__tests__/dropdown.test.js
+++ b/src/select/__tests__/dropdown.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import SelectDropdown from '../dropdown.js';
 import {SIZE, TYPE} from '../constants.js';

--- a/src/select/__tests__/multi-value.test.js
+++ b/src/select/__tests__/multi-value.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import MultiValue from '../multi-value.js';
 import {Tag} from '../../tag/index.js';

--- a/src/select/__tests__/select-creatable-multi.scenario.js
+++ b/src/select/__tests__/select-creatable-multi.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSelect} from '../index.js';
 

--- a/src/select/__tests__/select-creatable.scenario.js
+++ b/src/select/__tests__/select-creatable.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSelect} from '../index.js';
 

--- a/src/select/__tests__/select-overridden-menu.scenario.js
+++ b/src/select/__tests__/select-overridden-menu.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSelect, TYPE} from '../index.js';
 

--- a/src/select/__tests__/select-search-multi.scenario.js
+++ b/src/select/__tests__/select-search-multi.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSelect, TYPE} from '../index.js';
 

--- a/src/select/__tests__/select-search-single.scenario.js
+++ b/src/select/__tests__/select-search-single.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import Screener, {Steps} from 'screener-storybook/src/screener.js';
 
 import {StatefulSelect, TYPE} from '../index.js';

--- a/src/select/__tests__/select.scenario.js
+++ b/src/select/__tests__/select.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSelect} from '../index.js';
 

--- a/src/select/__tests__/select.test.js
+++ b/src/select/__tests__/select.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Select} from '../index.js';
 import {STATE_CHANGE_TYPE, TYPE} from '../constants.js';

--- a/src/select/__tests__/stateful-select-container.test.js
+++ b/src/select/__tests__/stateful-select-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StatefulSelectContainer} from '../index.js';
 import {STATE_CHANGE_TYPE} from '../constants.js';

--- a/src/select/__tests__/stateful-select.test.js
+++ b/src/select/__tests__/stateful-select.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {
   StatefulSelect,

--- a/src/select/__tests__/value.test.js
+++ b/src/select/__tests__/value.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import SingleValue from '../value.js';
 import {StyledSingleValue} from '../styled-components.js';

--- a/src/select/autosize-input.js
+++ b/src/select/autosize-input.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {StyledInput, StyledInputSizer} from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';
 import type {AutosizeInputPropsT, AutosizeInputStateT} from './types.js';

--- a/src/select/stateful-select-container.js
+++ b/src/select/stateful-select-container.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import type {
   StatefulContainerPropsT,
   StateReducerT,

--- a/src/select/stateful-select.js
+++ b/src/select/stateful-select.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import StatefulContainer from './stateful-select-container.js';
 import Select from './select.js';
 import defaultProps from './default-props.js';

--- a/src/side-navigation/__tests__/nav.scenario.js
+++ b/src/side-navigation/__tests__/nav.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Navigation} from '../index.js';
 

--- a/src/side-navigation/__tests__/nav.test.js
+++ b/src/side-navigation/__tests__/nav.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Navigation, StyledNavItemContainer, NavItem} from '../index.js';
 

--- a/src/side-navigation/__tests__/stateful-container.test.js
+++ b/src/side-navigation/__tests__/stateful-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import StatefulContainer from '../stateful-container.js';
 import {STATE_CHANGE_TYPE} from '../constants.js';

--- a/src/side-navigation/__tests__/stateful-nav.test.js
+++ b/src/side-navigation/__tests__/stateful-nav.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import StatefulNavigation from '../stateful-nav.js';
 

--- a/src/side-navigation/stateful-nav.js
+++ b/src/side-navigation/stateful-nav.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import StatefulContainer from './stateful-container.js';
 import Navigation from './nav.js';
 import type {StatefulNavPropsT} from './types.js';

--- a/src/slider/__tests__/slider-disabled.scenario.js
+++ b/src/slider/__tests__/slider-disabled.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-disable react/display-name*/
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSlider} from '../index.js';
 

--- a/src/slider/__tests__/slider-range.scenario.js
+++ b/src/slider/__tests__/slider-range.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-disable react/display-name*/
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSlider} from '../index.js';
 

--- a/src/slider/__tests__/slider-step.scenario.js
+++ b/src/slider/__tests__/slider-step.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* eslint-disable react/display-name*/
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSlider} from '../index.js';
 

--- a/src/slider/__tests__/slider.scenario.js
+++ b/src/slider/__tests__/slider.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulSlider} from '../index.js';
 

--- a/src/slider/__tests__/stateful-slider-container.test.js
+++ b/src/slider/__tests__/stateful-slider-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer as StatefulSliderContainer} from '../index.js';
 import {STATE_CHANGE_TYPE} from '../constants.js';

--- a/src/slider/__tests__/stateful-slider.test.js
+++ b/src/slider/__tests__/stateful-slider.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 describe('Stateful slider', function() {

--- a/src/slider/stateful-slider-container.js
+++ b/src/slider/stateful-slider-container.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {STATE_CHANGE_TYPE} from './constants.js';
 import type {
   StatefulContainerPropsT,

--- a/src/slider/stateful-slider.js
+++ b/src/slider/stateful-slider.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import StatefulSliderContainer from './stateful-slider-container.js';
 import Slider from './slider.js';
 import type {StatefulSliderPropsT} from './types.js';

--- a/src/spinner/__tests__/component.test.js
+++ b/src/spinner/__tests__/component.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Spinner} from '../index.js';
 import {Icon} from '../../icon/index.js';

--- a/src/spinner/__tests__/spinner-negative.scenario.js
+++ b/src/spinner/__tests__/spinner-negative.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Spinner} from '../index.js';
 

--- a/src/spinner/__tests__/spinner.scenario.js
+++ b/src/spinner/__tests__/spinner.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Spinner} from '../index.js';
 

--- a/src/styles/__mocks__/styled.js
+++ b/src/styles/__mocks__/styled.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {LightTheme} from '../../themes/index.js';
 import createMockTheme from '../../test/create-mock-theme.js';
 import type {ThemeT} from '../../styles/types.js';

--- a/src/styles/__tests__/styled.test.js
+++ b/src/styles/__tests__/styled.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 /* eslint-disable */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import styled from '../styled.js';

--- a/src/styles/__tests__/theme-provider.test.js
+++ b/src/styles/__tests__/theme-provider.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 /* eslint-disable */
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import ThemeProvider from '../theme-provider.js';

--- a/src/table/__tests__/filter.test.js
+++ b/src/table/__tests__/filter.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import {Button} from '../../button/index.js';

--- a/src/table/__tests__/sortable-head-cell.test.js
+++ b/src/table/__tests__/sortable-head-cell.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 
 import TriangleDown from '../../icon/triangle-down.js';

--- a/src/table/__tests__/table-cells.scenario.js
+++ b/src/table/__tests__/table-cells.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {styled} from '../../styles/index.js';
 import {Block} from '../../block/index.js';

--- a/src/table/__tests__/table-few-rows.scenario.js
+++ b/src/table/__tests__/table-few-rows.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Table} from '../index.js';
 

--- a/src/table/__tests__/table-filter.scenario.js
+++ b/src/table/__tests__/table-filter.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {styled} from '../../styles/index.js';
 import {Checkbox} from '../../checkbox/index.js';
 import {

--- a/src/table/__tests__/table-pagination.scenario.js
+++ b/src/table/__tests__/table-pagination.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Block} from '../../block/index.js';
 import {Button, KIND} from '../../button/index.js';

--- a/src/table/__tests__/table-scroll.scenario.js
+++ b/src/table/__tests__/table-scroll.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Table} from '../index.js';
 

--- a/src/table/__tests__/table-sortable.scenario.js
+++ b/src/table/__tests__/table-sortable.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   StyledTable,

--- a/src/table/__tests__/table.test.js
+++ b/src/table/__tests__/table.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount, shallow} from 'enzyme';
 
 import {

--- a/src/table/index.js
+++ b/src/table/index.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 
 export {default as SortableHeadCell} from './sortable-head-cell.js';
 export {default as Table} from './table.js';

--- a/src/table/styled-components.js
+++ b/src/table/styled-components.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 
 import {styled} from '../styles/index.js';
 import type {SharedStylePropsT} from './types.js';

--- a/src/table/table.js
+++ b/src/table/table.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   StyledTable,

--- a/src/tabs/__tests__/stateful-tabs.test.js
+++ b/src/tabs/__tests__/stateful-tabs.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StatefulTabs, Tab, StyledTab, StyledTabContent} from '../index.js';
 import {STATE_CHANGE_TYPE} from '../constants.js';

--- a/src/tabs/__tests__/tab.test.js
+++ b/src/tabs/__tests__/tab.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {StyledTab} from '../index.js';
 

--- a/src/tabs/__tests__/tabs.scenario.js
+++ b/src/tabs/__tests__/tabs.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulTabs, Tab} from '../index.js';
 

--- a/src/tag/__tests__/tag-long-text.scenario.js
+++ b/src/tag/__tests__/tag-long-text.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Tag} from '../index.js';
 

--- a/src/tag/__tests__/tag.scenario.js
+++ b/src/tag/__tests__/tag.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Tag, KIND} from '../index.js';
 

--- a/src/tag/__tests__/tag.test.js
+++ b/src/tag/__tests__/tag.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Tag, StyledAction} from '../index.js';
 

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {getOverrides} from '../helpers/overrides.js';
 import {
   Action as StyledAction,

--- a/src/template-component/__tests__/component.test.js
+++ b/src/template-component/__tests__/component.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Component, StyledRoot} from '../index.js';
 

--- a/src/template-component/__tests__/stateful-component.test.js
+++ b/src/template-component/__tests__/stateful-component.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulComponent} from '../index.js';
 

--- a/src/template-component/__tests__/stateful-container.test.js
+++ b/src/template-component/__tests__/stateful-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer, STATE_CHANGE_TYPE} from '../index.js';
 

--- a/src/template-component/__tests__/template-component.scenario.js
+++ b/src/template-component/__tests__/template-component.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Component} from '../index.js';
 

--- a/src/textarea/__tests__/stateful-textarea.test.js
+++ b/src/textarea/__tests__/stateful-textarea.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow, mount} from 'enzyme';
 import {StyledTextarea, StatefulTextarea, StatefulContainer} from '../index.js';
 describe('StatefulTextarea', () => {

--- a/src/textarea/__tests__/textarea.scenario.js
+++ b/src/textarea/__tests__/textarea.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulTextarea} from '../index.js';
 

--- a/src/textarea/__tests__/textarea.test.js
+++ b/src/textarea/__tests__/textarea.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import Textarea from '../textarea.js';
 import {Textarea as StyledTextarea} from '../styled-components.js';

--- a/src/textarea/stateful-textarea.js
+++ b/src/textarea/stateful-textarea.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import StatefulContainer from './stateful-container.js';
 import Textarea from './textarea.js';
 import type {StatefulTextareaPropsT, TextareaPropsT} from './types.js';

--- a/src/toast/__tests__/toast.scenario.js
+++ b/src/toast/__tests__/toast.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Button, KIND as BUTTON_KIND, SIZE} from '../../button/index.js';
 import {Toast, KIND} from '../index.js';

--- a/src/toast/__tests__/toast.test.js
+++ b/src/toast/__tests__/toast.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {mount} from 'enzyme';
 import {Toast, StyledBody, StyledCloseIcon, KIND} from '../index.js';
 

--- a/src/toast/__tests__/toaster.test.js
+++ b/src/toast/__tests__/toaster.test.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import ReactDOM from 'react-dom';
 import {mount} from 'enzyme';
 import {

--- a/src/tooltip/__tests__/stateful-tooltip-container.test.js
+++ b/src/tooltip/__tests__/stateful-tooltip-container.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer as StatefulPopoverContainer} from '../../popover/index.js';
 import {

--- a/src/tooltip/__tests__/stateful-tooltip.test.js
+++ b/src/tooltip/__tests__/stateful-tooltip.test.js
@@ -5,7 +5,7 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import React from 'react';
+import * as React from 'react';
 import {shallow} from 'enzyme';
 import {StatefulContainer as StatefulPopoverContainer} from '../../popover/index.js';
 import {Tooltip, StatefulTooltip, PLACEMENT, TRIGGER_TYPE} from '../index.js';

--- a/src/tooltip/__tests__/tooltip.scenario.js
+++ b/src/tooltip/__tests__/tooltip.scenario.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {StatefulTooltip} from '../index.js';
 

--- a/src/typography/__tests__/typography-body.scenario.js
+++ b/src/typography/__tests__/typography-body.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {
   Caption1,

--- a/src/typography/__tests__/typography-display.scenario.js
+++ b/src/typography/__tests__/typography-display.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {Display} from '../index.js';
 

--- a/src/typography/__tests__/typography-heading.scenario.js
+++ b/src/typography/__tests__/typography-heading.scenario.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 
 import {H6, H5, H4, H3, H2, H1} from '../index.js';
 

--- a/src/typography/index.js
+++ b/src/typography/index.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import Block from '../block/block.js';
 import type {BlockPropsT} from '../block/types.js';
 


### PR DESCRIPTION
Always import React with
```js
import * as React from 'react';
```
This is mainly for consistency, since sometimes we need `* as React` in order to access Flow types like React.Node (see https://flow.org/en/docs/react/types/)

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
