### PR TITLE
fix(menu): add aria-activedescendant

### DIFF
--- a/documentation-site/pages/components/menu.mdx
+++ b/documentation-site/pages/components/menu.mdx
@@ -40,6 +40,12 @@ The menus themselves share the functionality and display of select menus.
 - `KeyDown / KeyUp` cycles down / up the menu list, highlighting items as needed.
 - `Enter` selects the currently highlighted item. If no item is highlighted, select the first item in the menu list.
 
+## Accessibility
+
+In order to have the `aria-activedescendant` attribute set on the menu you need to provide menu item id
+as one of the properties returned from the `getRequiredItemProps` function that is called for each rendered item.
+The provided id will be set as a value for the item container's `id` attribute therefore it has to be unique on a page.
+
 <Example title="Menu Basic Usage" path="examples/menu/basic.js">
   <Basic />
 </Example>

--- a/src/menu/__tests__/stateful-container.test.js
+++ b/src/menu/__tests__/stateful-container.test.js
@@ -146,7 +146,7 @@ describe('Menu StatefulContainer', () => {
     expect(props.stateReducer.mock.calls[0]).toEqual([
       STATE_CHANGE_TYPES.moveUp,
       {highlightedIndex: 0},
-      {highlightedIndex: -1, isFocused: false},
+      {activedescendantId: null, highlightedIndex: -1, isFocused: false},
     ]);
 
     const parent = React.createRef();
@@ -168,7 +168,7 @@ describe('Menu StatefulContainer', () => {
     expect(props.stateReducer.mock.calls[1]).toEqual([
       STATE_CHANGE_TYPES.moveDown,
       {highlightedIndex: 1},
-      {highlightedIndex: 0, isFocused: false},
+      {activedescendantId: null, highlightedIndex: 0, isFocused: false},
     ]);
   });
 

--- a/src/menu/menu.js
+++ b/src/menu/menu.js
@@ -17,6 +17,7 @@ import type {LocaleT} from '../locale/types.js';
 
 export default function Menu(props: StatelessMenuPropsT) {
   const {
+    activedescendantId,
     getRequiredItemProps = (item, index) => ({}),
     items,
     noResultsMsg,
@@ -32,11 +33,11 @@ export default function Menu(props: StatelessMenuPropsT) {
     overrides.EmptyState,
     StyledEmptyState,
   );
-
   return (
     <LocaleContext.Consumer>
       {(locale: LocaleT) => (
         <List
+          aria-activedescendant={activedescendantId || null}
           role="listbox"
           $ref={rootRef}
           onMouseEnter={focusMenu}

--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -27,6 +27,7 @@ export default class MenuStatefulContainer extends React.Component<
       // Defaults to -1 so no item is highlighted
       highlightedIndex: -1,
       isFocused: false,
+      activedescendantId: null,
     },
     stateReducer: (
       changeType: ?$PropertyType<StateReducerFnT, 'changeType'>,
@@ -180,6 +181,14 @@ export default class MenuStatefulContainer extends React.Component<
       itemRef = React.createRef();
       this.refList[index] = itemRef;
     }
+    const requiredItemProps = this.props.getRequiredItemProps(item, index);
+    const activedescendantId = requiredItemProps.id || null;
+    if (
+      this.state.highlightedIndex === index &&
+      this.state.activedescendantId !== activedescendantId
+    ) {
+      this.setState({activedescendantId});
+    }
     return {
       disabled: !!item.disabled,
       ref: itemRef,
@@ -190,16 +199,21 @@ export default class MenuStatefulContainer extends React.Component<
           this.props.onItemSelect({item});
           this.internalSetState(STATE_CHANGE_TYPES.click, {
             highlightedIndex: index,
+            activedescendantId,
           });
         }
       },
       onMouseEnter: () => {
         this.internalSetState(STATE_CHANGE_TYPES.mouseEnter, {
           highlightedIndex: index,
+          activedescendantId,
         });
       },
       resetMenu: this.resetMenu,
-      ...this.props.getRequiredItemProps(item, index),
+      ...(this.state.highlightedIndex === index
+        ? {id: activedescendantId}
+        : {}),
+      ...requiredItemProps,
     };
   };
 
@@ -232,6 +246,7 @@ export default class MenuStatefulContainer extends React.Component<
     this.internalSetState(STATE_CHANGE_TYPES.reset, {
       isFocused: false,
       highlightedIndex: -1,
+      activedescendantId: null,
     });
   };
 
@@ -253,6 +268,7 @@ export default class MenuStatefulContainer extends React.Component<
       ({
         ...restProps,
         rootRef: this.props.rootRef ? this.props.rootRef : this.rootRef,
+        activedescendantId: this.state.activedescendantId,
         getRequiredItemProps: this.getRequiredItemProps,
         highlightedIndex: this.state.highlightedIndex,
         isFocused: this.state.isFocused,

--- a/src/menu/stateful-menu.js
+++ b/src/menu/stateful-menu.js
@@ -20,6 +20,7 @@ export default class StatefulMenu extends React.PureComponent<
   static defaultProps = {
     // Mostly to satisfy flow
     initialState: {
+      activedescendantId: null,
       isFocused: false,
       // We start the index at -1 to indicate that no highlighting exists initially
       highlightedIndex: -1,

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -52,6 +52,7 @@ export type ProfileOverridesT = {
 export type RenderItemPropsT = {
   disabled?: boolean,
   ref?: React$ElementRef<*>,
+  id?: ?string,
   isFocused?: boolean,
   // indicates when the item is visually focused
   isHighlighted?: boolean,
@@ -70,6 +71,8 @@ export type StateReducerFnT = (
 ) => StatefulContainerStateT;
 
 export type StatefulContainerStateT = {
+  // id of the currently highlighted item (from keyboard control)
+  activedescendantId?: ?string,
   // index of currently highlighted item (from keyboard control)
   highlightedIndex: number,
   // indicates when the menu can be navigated by keyboard and affects menu item option rendering
@@ -135,6 +138,8 @@ export type MenuProfilePropsT = {
 };
 
 export type SharedStatelessPropsT = {
+  /** Id of the highlighted menu item. */
+  activedescendantId?: ?string,
   /** Function to get props for each rendered item. This will have some defaults needed for keyboard
    * bindings to work properly. Every rendered item should call this.
    */


### PR DESCRIPTION
`aria-activedescendant` has to be an `id` of the active menu element. In the current PR I added a simple default id values for the menu items. 
I propose we don't add id values by default but put the functionality in place to handle it if there are ids provided for the items through `getRequiredItemProps` handler. It's due to the `id` attribute value has to be unique on a page, with SSR using `Math.random` or UUIDs will result in invalid checksum warnings.