### PR TITLE
fix(nav-item): add missing item prop and update doc site sidebar

### DIFF
--- a/documentation-site/components/sidebar.js
+++ b/documentation-site/components/sidebar.js
@@ -41,9 +41,9 @@ const removeSlash = path => {
   return path;
 };
 
-function renderItem(item, itemProps) {
-  const {onSelect, onClick, onKeyDown, ...sharedProps} = itemProps;
-  const Label = itemProps.$level === 1 ? Label2 : Label1;
+function CustomNavItem(props) {
+  const {item, onSelect, onClick, onKeyDown, ...sharedProps} = props;
+  const Label = props.$level === 1 ? Label2 : Label1;
 
   const NavLink = ({item}) => (
     <Link passHref={true} href={item.itemId} prefetch>
@@ -53,7 +53,7 @@ function renderItem(item, itemProps) {
     </Link>
   );
 
-  if (item.itemId && itemProps.$level === 1)
+  if (item.itemId && props.$level === 1)
     return (
       <Label overrides={{Block: {style: {textTransform: 'uppercase'}}}}>
         <NavLink item={item} />
@@ -84,7 +84,11 @@ export default ({path}) => {
       activeItemId={path}
       activePredicate={activePredicate}
       items={Routes}
-      renderItem={renderItem}
+      overrides={{
+        NavItem: {
+          component: CustomNavItem,
+        },
+      }}
     />
   );
 };

--- a/src/side-navigation/nav-item.js
+++ b/src/side-navigation/nav-item.js
@@ -49,7 +49,7 @@ export default class NavItem extends React.Component<NavItemPropsT> {
             }
           : {})}
       >
-        <NavItem {...sharedProps} {...itemProps}>
+        <NavItem item={item} {...sharedProps} {...itemProps}>
           {item.title}
         </NavItem>
       </NavLink>


### PR DESCRIPTION
#### Description

Initial problem: The documentation site sidebar looks wrong.

<img width="268" alt="Screen Shot 2019-05-17 at 10 34 38 AM" src="https://user-images.githubusercontent.com/1939257/57945702-64e69400-788f-11e9-9fce-65def971487c.png">

Turns out the sidebar was still using a now deleted `renderItem` property on the `Navigation` component to customize each item in the nav.

This PR fixes the issue by updating the sidebar to use the `NavItem` override on `Navigation`.

There is also a tangential fix to pass through a missing `item` property to the `NavItem`. This was already in the `NavItemPropsT` type but was not being passed through.

<img width="287" alt="Screen Shot 2019-05-17 at 10 38 15 AM" src="https://user-images.githubusercontent.com/1939257/57945906-e63e2680-788f-11e9-9a77-26cdeb983926.png">

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
