### PR TITLE
feat(menu): pass event to onItemSelect when called with onClick

### DIFF
--- a/src/menu/__tests__/stateful-container.test.js
+++ b/src/menu/__tests__/stateful-container.test.js
@@ -85,6 +85,9 @@ describe('Menu StatefulContainer', () => {
     const component = mount(<StatefulContainer {...getSharedProps()} />);
     const item = mockItems[0];
     const props = component.instance().getRequiredItemProps(item, 0);
+    const event = {
+      preventDefault: jest.fn(),
+    };
 
     expect(props).toHaveProperty('disabled', false);
     expect(props).toHaveProperty('isFocused', false);
@@ -94,9 +97,10 @@ describe('Menu StatefulContainer', () => {
     expect(props).toHaveProperty('ref');
     expect(props).toHaveProperty('resetMenu');
 
-    props.onClick();
+    props.onClick(event);
     expect(mockItemSelect.mock.calls[0][0]).toEqual({
       item,
+      event,
     });
   });
 

--- a/src/menu/stateful-container.js
+++ b/src/menu/stateful-container.js
@@ -194,9 +194,9 @@ export default class MenuStatefulContainer extends React.Component<
       ref: itemRef,
       isFocused: this.state.isFocused,
       isHighlighted: this.state.highlightedIndex === index,
-      onClick: () => {
+      onClick: (event: SyntheticMouseEvent<HTMLElement>) => {
         if (this.props.onItemSelect && !item.disabled) {
-          this.props.onItemSelect({item});
+          this.props.onItemSelect({item, event});
           this.internalSetState(STATE_CHANGE_TYPES.click, {
             highlightedIndex: index,
             activedescendantId,


### PR DESCRIPTION
#### Description

Passes the click event through onItemSelect when stateful container items are clicked to allow users to intercept the event. The use case I have is for a button dropdown nested inside of another clickable element. This is my first PR to baseui, any comments/suggestions are would be great 😄

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
