### PR TITLE
fix(masked-input): avoid passing overrides to MaskOverride

### DIFF
--- a/src/input/__tests__/__snapshots__/masked-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/masked-input.test.js.snap
@@ -63,50 +63,6 @@ Object {
   "onKeyUp": [MockFunction],
   "onMouseDown": [Function],
   "onPaste": [Function],
-  "overrides": Object {
-    "After": [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "$adjoined": "none",
-            "$disabled": false,
-            "$error": false,
-            "$isFocused": false,
-            "$required": false,
-            "$size": "default",
-          },
-          Object {},
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": <span />,
-        },
-      ],
-    },
-    "Before": [MockFunction] {
-      "calls": Array [
-        Array [
-          Object {
-            "$adjoined": "none",
-            "$disabled": false,
-            "$error": false,
-            "$isFocused": false,
-            "$required": false,
-            "$size": "default",
-          },
-          Object {},
-        ],
-      ],
-      "results": Array [
-        Object {
-          "type": "return",
-          "value": <span />,
-        },
-      ],
-    },
-  },
   "placeholder": "Placeholder",
   "required": false,
   "size": "default",

--- a/src/input/masked-input.js
+++ b/src/input/masked-input.js
@@ -11,17 +11,9 @@ import InputMask from 'react-input-mask';
 
 import Input from './input.js';
 import {Input as StyledInput} from './styled-components.js';
-import type {InputPropsT} from './types.js';
+import type {MaskedInputPropsT} from './types.js';
 
-type PropsT = {
-  ...InputPropsT,
-  /** See pattern examples here: https://github.com/sanniassin/react-input-mask */
-  mask?: string,
-  /** Character to render for unfilled mask element. */
-  maskChar?: string,
-};
-
-function MaskOverride(props: PropsT) {
+function MaskOverride(props: MaskedInputPropsT) {
   return (
     <InputMask {...props}>
       {({startEnhancer, endEnhancer, error, ...maskProps}) => {
@@ -31,14 +23,18 @@ function MaskOverride(props: PropsT) {
   );
 }
 
-export default function MaskedInput(props: PropsT) {
-  const {overrides = {}} = props;
+export default function MaskedInput(props: MaskedInputPropsT) {
+  const {
+    overrides: {Input: inputOverride, ...restOverrides} = {},
+    ...restProps
+  } = props;
   const nextOverrides = {
-    // seems similar to the issue described in overrides.js
-    // https://github.com/uber-web/baseui/blob/master/src/helpers/overrides.js#L32
-    // eslint-disable-next-line flowtype/no-weak-types
-    Input: ({component: MaskOverride, props}: any),
-    ...overrides,
+    Input: {
+      component: MaskOverride,
+      props: restProps,
+      ...(typeof inputOverride === 'object' ? inputOverride : {}),
+    },
+    ...restOverrides,
   };
 
   return <Input {...props} overrides={nextOverrides} />;

--- a/src/input/types.js
+++ b/src/input/types.js
@@ -117,6 +117,14 @@ export type InputPropsT = {
   onBlur: (e: SyntheticFocusEvent<HTMLInputElement>) => mixed,
 };
 
+export type MaskedInputPropsT = {
+  /** See pattern examples here: https://github.com/sanniassin/react-input-mask */
+  mask?: string,
+  /** Character to render for unfilled mask element. */
+  maskChar?: string,
+  ...InputPropsT,
+};
+
 export type StatefulContainerPropsT<T> = {
   children: (props: PropsT) => React.Node,
   /** Initial state of an uncontrolled input component. */


### PR DESCRIPTION
Avoid passing overrides to MaskOverride. These overrides do nothing here and show up in the DOM and cause React warnings.

Note that the snapshot `MaskedInput - basic functionality: Masked input has correct props 1` now matches `Input - basic functionality: input has correct props 1`.

Also:
* Still allows for `{Input: {style}}` overrides
* Export MaskedInputPropsT type
* Remove weak Flow type

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
