### PR TITLE
Release v6.19.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "baseui",
-  "version": "6.19.2",
+  "version": "6.19.3",
   "description": "A React Component library implementing the Base design language",
   "keywords": [
     "react",


### PR DESCRIPTION
v6.19.2 has some issues with the currently published version. Publish a new release so folks will skip the mis-published version.