### PR TITLE
fix(masked-input): pass props to input

### DIFF
--- a/src/input/__tests__/__snapshots__/masked-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/masked-input.test.js.snap
@@ -53,6 +53,7 @@ Object {
   "aria-required": false,
   "autoComplete": "on",
   "autoFocus": false,
+  "disabled": false,
   "id": undefined,
   "name": "",
   "onBlur": [Function],
@@ -68,5 +69,6 @@ Object {
   "size": "default",
   "styled-component": "true",
   "type": "text",
+  "value": "(123) 456-7890",
 }
 `;

--- a/src/input/__tests__/masked-input.test.js
+++ b/src/input/__tests__/masked-input.test.js
@@ -12,6 +12,7 @@ import {MaskedInput} from '../index.js';
 
 test('MaskedInput - basic functionality', () => {
   const props = {
+    value: '(123) 456-7890',
     mask: '(999) 999-9999',
     placeholder: 'Placeholder',
     onFocus: jest.fn(),

--- a/src/input/masked-input.js
+++ b/src/input/masked-input.js
@@ -13,12 +13,36 @@ import Input from './input.js';
 import {Input as StyledInput} from './styled-components.js';
 import type {MaskedInputPropsT} from './types.js';
 
-function MaskOverride(props: MaskedInputPropsT) {
+function MaskOverride({
+  startEnhancer,
+  endEnhancer,
+  error,
+  onChange,
+  onFocus,
+  onBlur,
+  value,
+  disabled,
+  ...restProps
+}: MaskedInputPropsT) {
   return (
-    <InputMask {...props}>
-      {({startEnhancer, endEnhancer, error, ...maskProps}) => {
-        return <StyledInput {...maskProps} />;
-      }}
+    <InputMask
+      onChange={onChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      value={value}
+      disabled={disabled}
+      {...restProps}
+    >
+      {props => (
+        <StyledInput
+          onChange={onChange}
+          onFocus={onFocus}
+          onBlur={onBlur}
+          value={value}
+          disabled={disabled}
+          {...props}
+        />
+      )}
     </InputMask>
   );
 }


### PR DESCRIPTION
Properly pass props to the `<input>` element in a MaskedInput component. According to the docs, react-input-mask does not pass down [certain props](https://github.com/sanniassin/react-input-mask#children--function) to its children. This broken behavior is easily reproduced by trying to disable a MaskedInput, and explicitly passing these to its children resolves the issue.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
