### PR TITLE
fix: updating Select/StyledValueContainer to fix text color in dark mode

### DIFF
--- a/src/select/styled-components.js
+++ b/src/select/styled-components.js
@@ -252,7 +252,7 @@ export const StyledInput = styled(
   'input',
   (props: SharedStylePropsT & {$width: string}) => {
     const {
-      $theme: {typography},
+      $theme: {typography, colors},
       $size,
       $disabled,
       $searchable,
@@ -260,6 +260,7 @@ export const StyledInput = styled(
     } = props;
     return {
       ...getFont($size, typography),
+      color: $disabled ? colors.foregroundAlt : colors.foreground,
       boxSizing: 'content-box',
       fontSize: '16px', // prevents iOS to zoom in when focused
       width: $disabled || !$searchable ? '1px' : $width || '100%',


### PR DESCRIPTION

#### Description
In dark mode color of the input blends with the background , so one can't see what is the value

![iQ1hC9fWjT](https://user-images.githubusercontent.com/1284223/58353439-5d8d3080-7e23-11e9-93e7-f8ffaeeac28d.gif)


#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
