### PR TITLE
fix(timezone-picker): fix select overrides

### DIFF
--- a/src/datepicker/timezone-picker.js
+++ b/src/datepicker/timezone-picker.js
@@ -93,6 +93,8 @@ class TimezonePicker extends React.Component<
       // $FlowFixMe
       selectProps && selectProps.overrides,
     );
+    // $FlowFixMe
+    selectProps.overrides = selectOverrides;
 
     return (
       <LocaleContext.Consumer>
@@ -106,7 +108,7 @@ class TimezonePicker extends React.Component<
               this.props.onChange && this.props.onChange(params);
             }}
             value={this.props.value || this.state.value || []}
-            overrides={selectOverrides}
+            {...selectProps}
           />
         )}
       </LocaleContext.Consumer>


### PR DESCRIPTION
#### Description
I needed to make the TimezonePicker disabled in the project I am working on and found that it was impossible to do it through the overrides prop. The TimezonePicker supports overriding the Select element, but the overridden props were not properly passed to the Select element. 

I have now added the select overrides to the OverriddenSelect element.
#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
