### PR TITLE
docs: deemphasize version selector

### DIFF
--- a/documentation-site/components/header-navigation.js
+++ b/documentation-site/components/header-navigation.js
@@ -29,7 +29,6 @@ import {StatefulTooltip} from 'baseui/tooltip';
 import {StatefulPopover, PLACEMENT as PopoverPlacement} from 'baseui/popover';
 import {StatefulMenu} from 'baseui/menu';
 import {Button, KIND} from 'baseui/button';
-import ChevronDown from 'baseui/icon/chevron-down.js';
 
 export const HEADER_BREAKPOINT = '@media screen and (min-width: 640px)';
 

--- a/documentation-site/components/header-navigation.js
+++ b/documentation-site/components/header-navigation.js
@@ -28,7 +28,7 @@ import Bulb from './bulb';
 import {StatefulTooltip} from 'baseui/tooltip';
 import {StatefulPopover, PLACEMENT as PopoverPlacement} from 'baseui/popover';
 import {StatefulMenu} from 'baseui/menu';
-import {Button} from 'baseui/button';
+import {Button, KIND} from 'baseui/button';
 import ChevronDown from 'baseui/icon/chevron-down.js';
 
 export const HEADER_BREAKPOINT = '@media screen and (min-width: 640px)';
@@ -101,7 +101,7 @@ const Navigation = ({toggleSidebar, toggleTheme}: PropsT) => {
                   overrides={{Block: {style: {cursor: 'pointer'}}}}
                 />
               </Link>
-              <Block marginLeft="scale800">
+              <Block marginLeft="scale300">
                 <StatefulPopover
                   placement={PopoverPlacement.bottomLeft}
                   content={({close}) => (
@@ -121,11 +121,8 @@ const Navigation = ({toggleSidebar, toggleTheme}: PropsT) => {
                     />
                   )}
                 >
-                  <Button
-                    size="compact"
-                    endEnhancer={() => <ChevronDown size={24} />}
-                  >
-                    {version}
+                  <Button size="compact" kind={KIND.minimal}>
+                    v{version}
                   </Button>
                 </StatefulPopover>
               </Block>


### PR DESCRIPTION
It's probably not used very often but it stands out a lot. Changed the KIND from `primary` to `minimal` and removed the chevron since that's [not a pattern](https://baseweb.design/components/popover/#popover-opens-on-click) in our design system.

## Before

<img width="570" alt="Screen Shot 2019-05-31 at 3 10 10 PM" src="https://user-images.githubusercontent.com/1387913/58737975-9c3d6080-83b8-11e9-92d2-59c0fb3891f9.png">
<img width="611" alt="Screen Shot 2019-05-31 at 3 28 40 PM" src="https://user-images.githubusercontent.com/1387913/58738021-cb53d200-83b8-11e9-8ffd-faca3fc60d12.png">

## After

<img width="561" alt="Screen Shot 2019-05-31 at 3 21 27 PM" src="https://user-images.githubusercontent.com/1387913/58737991-a4959b80-83b8-11e9-9e8e-9fec06c0cbb0.png">
<img width="499" alt="Screen Shot 2019-05-31 at 3 23 08 PM" src="https://user-images.githubusercontent.com/1387913/58738025-d149b300-83b8-11e9-8940-567d527e65f8.png">

