### PR TITLE
docs: dark theme for code examples

### DIFF
--- a/documentation-site/components/blog.js
+++ b/documentation-site/components/blog.js
@@ -19,7 +19,7 @@ const Image = styled('img', props => ({
 }));
 
 const Caption = styled('figcaption', ({$theme}) => ({
-  color: $theme.colors.mono800,
+  color: $theme.colors.foregroundAlt,
   fontFamily: $theme.typography.font100.fontFamily,
   fontSize: $theme.sizing.scale500,
   fontWeight: 300,
@@ -52,7 +52,7 @@ const Title = styled('h1', ({$theme}) => ({
 }));
 
 const Tagline = styled('h2', ({$theme}) => ({
-  color: $theme.colors.mono800,
+  color: $theme.colors.foregroundAlt,
   fontFamily: $theme.typography.font100.fontFamily,
   fontSize: $theme.sizing.scale800,
   fontWeight: 300,
@@ -60,10 +60,10 @@ const Tagline = styled('h2', ({$theme}) => ({
 }));
 
 const AuthorLink = styled('a', ({$theme}) => ({
-  color: $theme.colors.mono800,
+  color: $theme.colors.foregroundAlt,
   fontFamily: $theme.typography.font100.fontFamily,
   ':hover': {
-    color: $theme.colors.mono700,
+    color: $theme.colors.foreground,
   },
 }));
 
@@ -83,7 +83,7 @@ export const Meta = ({data: {title, tagline, author, authorLink, date}}) => (
       overrides={{
         Block: {
           style: ({$theme}) => ({
-            color: $theme.colors.mono800,
+            color: $theme.colors.foregroundAlt,
             fontFamily: $theme.typography.font100.fontFamily,
             margin: `${$theme.sizing.scale400} 0`,
           }),

--- a/documentation-site/components/posts.js
+++ b/documentation-site/components/posts.js
@@ -8,6 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 import {Block} from 'baseui/block';
+import Link from 'next/link';
 import {Card, StyledBody, StyledAction} from 'baseui/card';
 import {Button, KIND} from 'baseui/button';
 import {styled} from 'baseui';
@@ -75,19 +76,20 @@ const Index = () => {
               <MetaData>{`${p.author} - ${p.date}`}</MetaData>
               <StyledBody />
               <StyledAction>
-                <Button
-                  kind={KIND.secondary}
-                  $as="a"
-                  href={p.path}
-                  rel="noreferrer noopener"
-                  overrides={{
-                    BaseButton: {
-                      style: {boxSizing: 'border-box', width: '100%'},
-                    },
-                  }}
-                >
-                  Read
-                </Button>
+                <Link href={p.path}>
+                  <Button
+                    kind={KIND.secondary}
+                    $as="a"
+                    rel="noreferrer noopener"
+                    overrides={{
+                      BaseButton: {
+                        style: {boxSizing: 'border-box', width: '100%'},
+                      },
+                    }}
+                  >
+                    Read
+                  </Button>
+                </Link>
               </StyledAction>
             </Card>
           );

--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -24,7 +24,8 @@ import Router from 'next/router';
 
 import {styletron} from '../helpers/styletron';
 import {trackPageView} from '../helpers/ga';
-import '../prism-coy.css';
+import '../prism-coy.css'; // light theme code highlighting
+import '../tomorrow-night.css'; // dark theme code highlighting
 
 const themes = {
   LightTheme,
@@ -145,6 +146,12 @@ export default class MyApp extends App {
 
     if (config.font === 'move') {
       themeName += 'Move';
+    }
+
+    if (config.theme === 'dark') {
+      document.body.classList.add('darktheme');
+    } else {
+      document.body.classList.remove('darktheme');
     }
 
     this.setState({

--- a/documentation-site/tomorrow-night.css
+++ b/documentation-site/tomorrow-night.css
@@ -1,0 +1,133 @@
+/* PrismJS 1.16.0
+https://prismjs.com/download.html#themes=prism-tomorrow&languages=markup+css+clike+javascript */
+/**
+ * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
+ * Based on https://github.com/chriskempson/tomorrow-theme
+ * @author Rose Pritchard
+ */
+
+.darktheme code[class*='language-'],
+.darktheme .hljs > code,
+.darktheme pre[class*='language-'] {
+  color: #ccc;
+  background: none;
+  font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
+  font-size: 14px;
+  text-align: left;
+  white-space: pre;
+  word-spacing: normal;
+  word-break: normal;
+  word-wrap: normal;
+  line-height: 1.5;
+
+  -moz-tab-size: 4;
+  -o-tab-size: 4;
+  tab-size: 4;
+
+  -webkit-hyphens: none;
+  -moz-hyphens: none;
+  -ms-hyphens: none;
+  hyphens: none;
+}
+
+/* Code blocks */
+.darktheme .hljs,
+.darktheme pre[class*='language-'] {
+  padding: 1em;
+  margin: 0.5em 0;
+  overflow: auto;
+  margin-top: 1.5em;
+  margin-bottom: 1.5em;
+  overflow: scroll;
+  max-width: 100%;
+  padding: 1em 1em 1em 1.5em;
+  border-left: 5px solid #555;
+}
+
+.darktheme :not(pre) > code[class*='language-'],
+.darktheme .hljs,
+.darktheme pre[class*='language-'] {
+  background: rgb(41, 41, 41);
+}
+
+/* Inline code */
+.darktheme :not(pre) > code[class*='language-'] {
+  padding: 0.1em;
+  border-radius: 0.3em;
+  white-space: normal;
+}
+
+.darktheme .token.comment,
+.darktheme .token.block-comment,
+.darktheme .token.prolog,
+.darktheme .token.doctype,
+.darktheme .token.cdata {
+  color: #999;
+}
+
+.darktheme .token.punctuation {
+  color: #ccc;
+}
+
+.darktheme .token.tag,
+.darktheme .token.attr-name,
+.darktheme .token.namespace,
+.darktheme .token.deleted {
+  color: #e2777a;
+}
+
+.darktheme .token.function-name {
+  color: #6196cc;
+}
+
+.darktheme .token.boolean,
+.darktheme .token.number,
+.darktheme .token.function {
+  color: #f08d49;
+}
+
+.darktheme .token.property,
+.darktheme .token.class-name,
+.darktheme .token.constant,
+.darktheme .token.symbol {
+  color: #f8c555;
+}
+
+.darktheme .token.selector,
+.darktheme .token.important,
+.darktheme .token.atrule,
+.darktheme .token.keyword,
+.darktheme .token.builtin {
+  color: #cc99cd;
+}
+
+.darktheme .token.string,
+.darktheme .token.char,
+.darktheme .token.attr-value,
+.darktheme .token.regex,
+.darktheme .token.variable {
+  color: #7ec699;
+}
+
+.darktheme .token.operator,
+.darktheme .token.entity,
+.darktheme .token.url {
+  color: #67cdcc;
+  background: none;
+}
+
+.darktheme .token.important,
+.darktheme .token.bold {
+  font-weight: bold;
+}
+.darktheme .token.italic {
+  font-style: italic;
+}
+
+.darktheme .token.entity {
+  cursor: help;
+}
+
+.darktheme .token.inserted {
+  color: green;
+}


### PR DESCRIPTION
It was a huge eyesore. 

## Before

<img width="713" alt="Screen Shot 2019-05-31 at 6 07 32 PM" src="https://user-images.githubusercontent.com/1387913/58741558-2d1f3680-83cf-11e9-89a7-6c7e461066d8.png">

## After

<img width="702" alt="Screen Shot 2019-05-31 at 6 06 56 PM" src="https://user-images.githubusercontent.com/1387913/58741559-31e3ea80-83cf-11e9-8997-737d80f630ce.png">

Also some minor dark theme fixes in the blog section:

- meta text (author, date, subttitle) were invisible
- `Read` button did a full page reload (unnecessary and the flashing white background looked really bad)