### PR TITLE
fix(datepicker): remove rounded corners, fix overrides example

### DIFF
--- a/documentation-site/static/examples/datepicker/with-overrides.js
+++ b/documentation-site/static/examples/datepicker/with-overrides.js
@@ -1,22 +1,6 @@
 import * as React from 'react';
 import {StatefulCalendar} from 'baseui/datepicker';
 
-const selectOverrides = {
-  ControlContainer: {
-    style: ({$theme, $isFocused, $isPseudoFocused}) => ({
-      backgroundColor:
-        $isFocused || $isPseudoFocused
-          ? $theme.colors.positive500
-          : $theme.colors.positive,
-    }),
-  },
-  OptionContent: {
-    style: ({$theme, $isHighlighted}) => ({
-      color: $isHighlighted ? $theme.colors.positive : $theme.colors.foreground,
-    }),
-  },
-};
-
 const arrowBtnOverrides = ({$theme}) => {
   return {
     ':focus': {
@@ -39,8 +23,13 @@ export default () => (
           backgroundColor: $theme.colors.positive,
         }),
       },
-      MonthYearSelect: {
-        props: {overrides: selectOverrides},
+      MonthYearSelectButton: {
+        style: ({$theme}) => ({
+          ':focus': {
+            backgroundColor: $theme.colors.positive500,
+            outline: 'none',
+          },
+        }),
       },
       PrevButton: {
         style: arrowBtnOverrides,

--- a/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
+++ b/src/datepicker/__tests__/stateful-calendar-overrides.scenario.js
@@ -12,22 +12,6 @@ import {StatefulCalendar} from '../index.js';
 
 export const name = 'Stateful calendar overrides';
 
-const selectOverrides = {
-  ControlContainer: {
-    style: ({$theme, $isFocused, $isPseudoFocused}) => ({
-      backgroundColor:
-        $isFocused || $isPseudoFocused
-          ? $theme.colors.positive500
-          : $theme.colors.positive,
-    }),
-  },
-  OptionContent: {
-    style: ({$theme, $isHighlighted}) => ({
-      color: $isHighlighted ? $theme.colors.positive : $theme.colors.foreground,
-    }),
-  },
-};
-
 const arrowBtnOverrides = ({$theme}) => {
   return {
     ':focus': {
@@ -45,8 +29,18 @@ export const component = () => (
           backgroundColor: $theme.colors.positive,
         }),
       },
-      MonthYearSelect: {
-        props: {overrides: selectOverrides},
+      MonthHeader: {
+        style: ({$theme}) => ({
+          backgroundColor: $theme.colors.positive,
+        }),
+      },
+      MonthYearSelectButton: {
+        style: ({$theme}) => ({
+          ':focus': {
+            backgroundColor: $theme.colors.positive500,
+            outline: 'none',
+          },
+        }),
       },
       PrevButton: {
         style: arrowBtnOverrides,

--- a/src/datepicker/styled-components.js
+++ b/src/datepicker/styled-components.js
@@ -58,9 +58,8 @@ export const StyledSelectorContainer = styled<SharedStylePropsT>(
 
 export const StyledCalendarHeader = styled<SharedStylePropsT>('div', props => {
   const {
-    $theme: {colors, sizing, borders},
+    $theme: {colors, sizing},
   } = props;
-  const borderRadius = borders.useRoundedCorners ? borders.radius200 : '0px';
   return {
     color: colors.white,
     display: 'flex',
@@ -71,10 +70,6 @@ export const StyledCalendarHeader = styled<SharedStylePropsT>('div', props => {
     paddingLeft: sizing.scale600,
     paddingRight: sizing.scale600,
     backgroundColor: colors.primary,
-    borderTopLeftRadius: borderRadius,
-    borderTopRightRadius: borderRadius,
-    borderBottomRightRadius: 0,
-    borderBottomLeftRadius: 0,
   };
 });
 
@@ -108,9 +103,6 @@ export const StyledMonthYearSelectIconContainer = styled<{}>('span', props => {
 });
 
 function getArrowBtnStyle({$theme, $disabled}) {
-  const borderRadius = $theme.borders.useRoundedCorners
-    ? $theme.sizing.scale100
-    : 0;
   return {
     boxSizing: 'border-box',
     height: '22px',
@@ -129,10 +121,6 @@ function getArrowBtnStyle({$theme, $disabled}) {
       ? {}
       : {
           backgroundColor: $theme.colors.primary500,
-          borderTopLeftRadius: borderRadius,
-          borderTopRightRadius: borderRadius,
-          borderBottomRightRadius: borderRadius,
-          borderBottomLeftRadius: borderRadius,
         },
   };
 }

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -164,6 +164,7 @@ exports[`Select component renders component in search mode and false for multipl
                       aria-haspopup="false"
                       role="combobox"
                       styled-component="true"
+                      tabindex="0"
                       test-style="[object Object]"
                       value=""
                     />
@@ -571,6 +572,7 @@ exports[`Select component renders component in search mode and false for multipl
                               }
                               required={null}
                               role="combobox"
+                              tabIndex={0}
                               value=""
                             >
                               <ForwardRef
@@ -603,6 +605,7 @@ exports[`Select component renders component in search mode and false for multipl
                                 onFocus={[Function]}
                                 required={null}
                                 role="combobox"
+                                tabIndex={0}
                                 value=""
                               >
                                 <MockStyledComponent
@@ -636,6 +639,7 @@ exports[`Select component renders component in search mode and false for multipl
                                   onFocus={[Function]}
                                   required={null}
                                   role="combobox"
+                                  tabIndex={0}
                                   value=""
                                 >
                                   <input
@@ -654,6 +658,7 @@ exports[`Select component renders component in search mode and false for multipl
                                     required={null}
                                     role="combobox"
                                     styled-component="true"
+                                    tabIndex={0}
                                     test-style={
                                       Object {
                                         "background": "transparent",
@@ -939,6 +944,7 @@ exports[`Select component renders component in search mode and true for multiple
                       aria-haspopup="false"
                       role="combobox"
                       styled-component="true"
+                      tabindex="0"
                       test-style="[object Object]"
                       value=""
                     />
@@ -1346,6 +1352,7 @@ exports[`Select component renders component in search mode and true for multiple
                               }
                               required={null}
                               role="combobox"
+                              tabIndex={0}
                               value=""
                             >
                               <ForwardRef
@@ -1378,6 +1385,7 @@ exports[`Select component renders component in search mode and true for multiple
                                 onFocus={[Function]}
                                 required={null}
                                 role="combobox"
+                                tabIndex={0}
                                 value=""
                               >
                                 <MockStyledComponent
@@ -1411,6 +1419,7 @@ exports[`Select component renders component in search mode and true for multiple
                                   onFocus={[Function]}
                                   required={null}
                                   role="combobox"
+                                  tabIndex={0}
                                   value=""
                                 >
                                   <input
@@ -1429,6 +1438,7 @@ exports[`Select component renders component in search mode and true for multiple
                                     required={null}
                                     role="combobox"
                                     styled-component="true"
+                                    tabIndex={0}
                                     test-style={
                                       Object {
                                         "background": "transparent",
@@ -1694,6 +1704,7 @@ exports[`Select component renders component in select mode and false for multipl
                       aria-haspopup="false"
                       role="combobox"
                       styled-component="true"
+                      tabindex="0"
                       test-style="[object Object]"
                       value=""
                     />
@@ -2016,6 +2027,7 @@ exports[`Select component renders component in select mode and false for multipl
                               }
                               required={null}
                               role="combobox"
+                              tabIndex={0}
                               value=""
                             >
                               <ForwardRef
@@ -2048,6 +2060,7 @@ exports[`Select component renders component in select mode and false for multipl
                                 onFocus={[Function]}
                                 required={null}
                                 role="combobox"
+                                tabIndex={0}
                                 value=""
                               >
                                 <MockStyledComponent
@@ -2081,6 +2094,7 @@ exports[`Select component renders component in select mode and false for multipl
                                   onFocus={[Function]}
                                   required={null}
                                   role="combobox"
+                                  tabIndex={0}
                                   value=""
                                 >
                                   <input
@@ -2099,6 +2113,7 @@ exports[`Select component renders component in select mode and false for multipl
                                     required={null}
                                     role="combobox"
                                     styled-component="true"
+                                    tabIndex={0}
                                     test-style={
                                       Object {
                                         "background": "transparent",
@@ -2481,6 +2496,7 @@ exports[`Select component renders component in select mode and true for multiple
                       aria-haspopup="false"
                       role="combobox"
                       styled-component="true"
+                      tabindex="0"
                       test-style="[object Object]"
                       value=""
                     />
@@ -2803,6 +2819,7 @@ exports[`Select component renders component in select mode and true for multiple
                               }
                               required={null}
                               role="combobox"
+                              tabIndex={0}
                               value=""
                             >
                               <ForwardRef
@@ -2835,6 +2852,7 @@ exports[`Select component renders component in select mode and true for multiple
                                 onFocus={[Function]}
                                 required={null}
                                 role="combobox"
+                                tabIndex={0}
                                 value=""
                               >
                                 <MockStyledComponent
@@ -2868,6 +2886,7 @@ exports[`Select component renders component in select mode and true for multiple
                                   onFocus={[Function]}
                                   required={null}
                                   role="combobox"
+                                  tabIndex={0}
                                   value=""
                                 >
                                   <input
@@ -2886,6 +2905,7 @@ exports[`Select component renders component in select mode and true for multiple
                                     required={null}
                                     role="combobox"
                                     styled-component="true"
+                                    tabIndex={0}
                                     test-style={
                                       Object {
                                         "background": "transparent",

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -669,6 +669,7 @@ class Select extends React.Component<PropsT, SelectStateT> {
           required={(this.props.required && !this.props.value.length) || null}
           role="combobox"
           value={value}
+          tabIndex={0}
           {...sharedProps}
         />
       </InputContainer>


### PR DESCRIPTION
Also fixed tabbing order in the datepicker popover with a quick select option.