### PR TITLE
fix(dnd-list): prevent default to avoid double removals

### DIFF
--- a/src/dnd-list/list.js
+++ b/src/dnd-list/list.js
@@ -94,13 +94,14 @@ class StatelessList extends React.Component<ListPropsT> {
                 {removable && (
                   <CloseHandle
                     {...sharedProps}
-                    onClick={() =>
+                    onClick={evt => {
+                      evt.preventDefault();
                       onChange &&
-                      onChange({
-                        oldIndex: typeof index !== 'undefined' ? index : 0,
-                        newIndex: -1,
-                      })
-                    }
+                        onChange({
+                          oldIndex: typeof index !== 'undefined' ? index : 0,
+                          newIndex: -1,
+                        });
+                    }}
                     {...closeHandleProps}
                   >
                     <Delete size={24} color="#CCC" />


### PR DESCRIPTION
#### Description

Fixes scenarios where `onChange` is improperly called multiple times.

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
