### PR TITLE
feat(aspect-ratio-box): add aspect-ratio-box utility component

### DIFF
--- a/documentation-site/pages/components/aspect-ratio-box.mdx
+++ b/documentation-site/pages/components/aspect-ratio-box.mdx
@@ -29,13 +29,19 @@ There are times when it comes in handy to build a box with a specific aspect rat
 
 It can be useful to wrap an image component in an **AspectRatioBox**, so content does not reflow as the image loads. This is useful when building UIs for mobile devices, to avoid content moving around as images load on poor network connections.
 
-<Example title="Image in an AspectRatioBox" path="examples/aspect-ratio-box/image.js">
+<Example
+  title="Image in an AspectRatioBox"
+  path="examples/aspect-ratio-box/image.js"
+>
   <AspectRatioBoxImage />
 </Example>
 
 You could even build a calendar of square buttons with it, that resizes with the window width!
 
-<Example title="Full-width calendar" path="examples/aspect-ratio-box/calendar.js">
+<Example
+  title="Full-width calendar"
+  path="examples/aspect-ratio-box/calendar.js"
+>
   <AspectRatioBoxCalendar />
 </Example>
 
@@ -46,9 +52,7 @@ You could even build a calendar of square buttons with it, that resizes with the
   component={AspectRatioBoxExports}
   renderExample={props => (
     <div style={{width: '200px'}}>
-      <AspectRatioBox
-        overrides={props.overrides}
-      >
+      <AspectRatioBox overrides={props.overrides}>
         Example aspect ratio box
       </AspectRatioBox>
     </div>

--- a/documentation-site/pages/components/aspect-ratio-box.mdx
+++ b/documentation-site/pages/components/aspect-ratio-box.mdx
@@ -1,0 +1,61 @@
+<!--
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+-->
+
+import Example from '../../components/example';
+import API from '../../components/api';
+import Layout from '../../components/layout';
+
+import AspectRatioBoxBasic from 'examples/aspect-ratio-box/basic.js';
+import AspectRatioBoxCalendar from 'examples/aspect-ratio-box/calendar.js';
+import AspectRatioBoxImage from 'examples/aspect-ratio-box/image.js';
+
+import Overrides from '../../components/overrides';
+import {AspectRatioBox} from 'baseui/aspect-ratio-box';
+import * as AspectRatioBoxExports from 'baseui/aspect-ratio-box';
+
+export default Layout;
+
+# AspectRatioBox
+
+There are times when it comes in handy to build a box with a specific aspect ratio, given a certain width. This utility component uses CSS pseudo-elements to achieve set aspect-ratios.
+
+<Example title="Basic usage" path="examples/aspect-ratio-box/basic.js">
+  <AspectRatioBoxBasic />
+</Example>
+
+It can be useful to wrap an image component in an **AspectRatioBox**, so content does not reflow as the image loads. This is useful when building UIs for mobile devices, to avoid content moving around as images load on poor network connections.
+
+<Example title="Image in an AspectRatioBox" path="examples/aspect-ratio-box/image.js">
+  <AspectRatioBoxImage />
+</Example>
+
+You could even build a calendar of square buttons with it, that resizes with the window width!
+
+<Example title="Full-width calendar" path="examples/aspect-ratio-box/calendar.js">
+  <AspectRatioBoxCalendar />
+</Example>
+
+## Overrides
+
+<Overrides
+  name="AspectRatioBox"
+  component={AspectRatioBoxExports}
+  renderExample={props => (
+    <div style={{width: '200px'}}>
+      <AspectRatioBox
+        overrides={props.overrides}
+      >
+        Example aspect ratio box
+      </AspectRatioBox>
+    </div>
+  )}
+/>
+
+<API
+  heading="AspectRatioBox API"
+  api={require('!!@uber-web-ui/extract-react-types-loader!../../../src/aspect-ratio-box/aspect-ratio-box.js')}
+/>

--- a/documentation-site/routes.js
+++ b/documentation-site/routes.js
@@ -261,6 +261,10 @@ const routes = [
         title: 'Utility',
         subNav: [
           {
+            title: 'AspectRatioBox',
+            itemId: '/components/aspect-ratio-box',
+          },
+          {
             title: 'BaseProvider',
             itemId: '/components/base-provider',
           },

--- a/documentation-site/static/examples/aspect-ratio-box/basic.js
+++ b/documentation-site/static/examples/aspect-ratio-box/basic.js
@@ -22,7 +22,7 @@ export default () => (
   <React.Fragment>
     <AspectRatioBox {...props}>Square by default</AspectRatioBox>
     <AspectRatioBox {...props} aspectRatio={16 / 9}>
-      16:9 ratio
+      16:9 aspect ratio
     </AspectRatioBox>
   </React.Fragment>
 );

--- a/documentation-site/static/examples/aspect-ratio-box/basic.js
+++ b/documentation-site/static/examples/aspect-ratio-box/basic.js
@@ -5,7 +5,6 @@ const props = {
   overrides: {
     Root: {
       style: {
-        width: '100%',
         border: 'grey solid 2px',
       },
     },

--- a/documentation-site/static/examples/aspect-ratio-box/basic.js
+++ b/documentation-site/static/examples/aspect-ratio-box/basic.js
@@ -1,0 +1,29 @@
+import * as React from 'react';
+import {AspectRatioBox} from 'baseui/aspect-ratio-box';
+
+const props = {
+  overrides: {
+    Root: {
+      style: {
+        width: '100%',
+        border: 'grey solid 2px',
+      },
+    },
+    Body: {
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    },
+  },
+};
+
+export default () => (
+  <React.Fragment>
+    <AspectRatioBox {...props}>Square by default</AspectRatioBox>
+    <AspectRatioBox {...props} aspectRatio={16 / 9}>
+      16:9 ratio
+    </AspectRatioBox>
+  </React.Fragment>
+);

--- a/documentation-site/static/examples/aspect-ratio-box/calendar.js
+++ b/documentation-site/static/examples/aspect-ratio-box/calendar.js
@@ -1,0 +1,54 @@
+import * as React from 'react';
+import {AspectRatioBox, StyledBody} from 'baseui/aspect-ratio-box';
+import {Block} from 'baseui/block';
+import {Button, KIND} from 'baseui/button';
+
+const CalendarBodyComponent = props => (
+  <StyledBody $as={Button} kind={KIND.minimal} {...props} />
+);
+
+const props = {
+  overrides: {
+    Root: {
+      style: {
+        width: `${100 / 7}%`,
+      },
+    },
+    Body: {
+      component: CalendarBodyComponent,
+    },
+  },
+};
+
+export default () => (
+  <Block display="flex" flexWrap>
+    <AspectRatioBox {...props}>Feb 1</AspectRatioBox>
+    <AspectRatioBox {...props}>2</AspectRatioBox>
+    <AspectRatioBox {...props}>3</AspectRatioBox>
+    <AspectRatioBox {...props}>4</AspectRatioBox>
+    <AspectRatioBox {...props}>5</AspectRatioBox>
+    <AspectRatioBox {...props}>6</AspectRatioBox>
+    <AspectRatioBox {...props}>7</AspectRatioBox>
+    <AspectRatioBox {...props}>8</AspectRatioBox>
+    <AspectRatioBox {...props}>9</AspectRatioBox>
+    <AspectRatioBox {...props}>10</AspectRatioBox>
+    <AspectRatioBox {...props}>11</AspectRatioBox>
+    <AspectRatioBox {...props}>12</AspectRatioBox>
+    <AspectRatioBox {...props}>13</AspectRatioBox>
+    <AspectRatioBox {...props}>14</AspectRatioBox>
+    <AspectRatioBox {...props}>15</AspectRatioBox>
+    <AspectRatioBox {...props}>16</AspectRatioBox>
+    <AspectRatioBox {...props}>17</AspectRatioBox>
+    <AspectRatioBox {...props}>18</AspectRatioBox>
+    <AspectRatioBox {...props}>19</AspectRatioBox>
+    <AspectRatioBox {...props}>20</AspectRatioBox>
+    <AspectRatioBox {...props}>21</AspectRatioBox>
+    <AspectRatioBox {...props}>22</AspectRatioBox>
+    <AspectRatioBox {...props}>23</AspectRatioBox>
+    <AspectRatioBox {...props}>24</AspectRatioBox>
+    <AspectRatioBox {...props}>25</AspectRatioBox>
+    <AspectRatioBox {...props}>26</AspectRatioBox>
+    <AspectRatioBox {...props}>27</AspectRatioBox>
+    <AspectRatioBox {...props}>28</AspectRatioBox>
+  </Block>
+);

--- a/documentation-site/static/examples/aspect-ratio-box/image.js
+++ b/documentation-site/static/examples/aspect-ratio-box/image.js
@@ -1,0 +1,24 @@
+import * as React from 'react';
+import {AspectRatioBox, StyledBody} from 'baseui/aspect-ratio-box';
+
+const ImageBodyComponent = () => (
+  <StyledBody
+    $as="img"
+    src="https://api.adorable.io/avatars/285/11@adorable.io.png"
+  />
+);
+
+const props = {
+  overrides: {
+    Root: {
+      style: ({$theme}) => ({
+        width: $theme.sizing.scale1400,
+      }),
+    },
+    Body: {
+      component: ImageBodyComponent,
+    },
+  },
+};
+
+export default () => <AspectRatioBox {...props} />;

--- a/src/aspect-ratio-box/__tests__/__snapshots__/aspect-ratio-box.test.js.snap
+++ b/src/aspect-ratio-box/__tests__/__snapshots__/aspect-ratio-box.test.js.snap
@@ -1,0 +1,220 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`AspectRatioBox renders: for aspectRatio={1} 1`] = `
+<AspectRatioBox
+  aspectRatio={1}
+  overrides={Object {}}
+>
+  <ForwardRef
+    $aspectRatio={1}
+    data-baseweb="aspect-ratio-box"
+  >
+    <MockStyledComponent
+      $aspectRatio={1}
+      data-baseweb="aspect-ratio-box"
+      forwardedRef={null}
+    >
+      <div
+        data-baseweb="aspect-ratio-box"
+        styled-component="true"
+        test-style={
+          Object {
+            "::after": Object {
+              "clear": "both",
+              "content": "\\"\\"",
+              "display": "table",
+            },
+            "::before": Object {
+              "content": "\\"\\"",
+              "float": "left",
+              "height": 0,
+              "marginLeft": "-1px",
+              "paddingTop": "100%",
+              "pointerEvents": "none",
+              "width": "1px",
+            },
+            "position": "relative",
+            "width": "100%",
+          }
+        }
+      >
+        <ForwardRef>
+          <MockStyledComponent
+            forwardedRef={null}
+          >
+            <div
+              styled-component="true"
+              test-style={
+                Object {
+                  "bottom": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </MockStyledComponent>
+        </ForwardRef>
+      </div>
+    </MockStyledComponent>
+  </ForwardRef>
+</AspectRatioBox>
+`;
+
+exports[`AspectRatioBox renders: for aspectRatio={16 / 9} 1`] = `
+<AspectRatioBox
+  aspectRatio={1.7777777777777777}
+  overrides={Object {}}
+>
+  <ForwardRef
+    $aspectRatio={1.7777777777777777}
+    data-baseweb="aspect-ratio-box"
+  >
+    <MockStyledComponent
+      $aspectRatio={1.7777777777777777}
+      data-baseweb="aspect-ratio-box"
+      forwardedRef={null}
+    >
+      <div
+        data-baseweb="aspect-ratio-box"
+        styled-component="true"
+        test-style={
+          Object {
+            "::after": Object {
+              "clear": "both",
+              "content": "\\"\\"",
+              "display": "table",
+            },
+            "::before": Object {
+              "content": "\\"\\"",
+              "float": "left",
+              "height": 0,
+              "marginLeft": "-1px",
+              "paddingTop": "56.25%",
+              "pointerEvents": "none",
+              "width": "1px",
+            },
+            "position": "relative",
+            "width": "100%",
+          }
+        }
+      >
+        <ForwardRef>
+          <MockStyledComponent
+            forwardedRef={null}
+          >
+            <div
+              styled-component="true"
+              test-style={
+                Object {
+                  "bottom": 0,
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </MockStyledComponent>
+        </ForwardRef>
+      </div>
+    </MockStyledComponent>
+  </ForwardRef>
+</AspectRatioBox>
+`;
+
+exports[`AspectRatioBox renders: with overridden styles 1`] = `
+<AspectRatioBox
+  aspectRatio={1.7777777777777777}
+  overrides={
+    Object {
+      "Body": Object {
+        "style": Object {
+          "color": "red",
+        },
+      },
+      "Root": Object {
+        "style": Object {
+          "marginBottom": "10px",
+        },
+      },
+    }
+  }
+>
+  <ForwardRef
+    $aspectRatio={1.7777777777777777}
+    $style={
+      Object {
+        "marginBottom": "10px",
+      }
+    }
+    data-baseweb="aspect-ratio-box"
+  >
+    <MockStyledComponent
+      $aspectRatio={1.7777777777777777}
+      $style={
+        Object {
+          "marginBottom": "10px",
+        }
+      }
+      data-baseweb="aspect-ratio-box"
+      forwardedRef={null}
+    >
+      <div
+        data-baseweb="aspect-ratio-box"
+        styled-component="true"
+        test-style={
+          Object {
+            "::after": Object {
+              "clear": "both",
+              "content": "\\"\\"",
+              "display": "table",
+            },
+            "::before": Object {
+              "content": "\\"\\"",
+              "float": "left",
+              "height": 0,
+              "marginLeft": "-1px",
+              "paddingTop": "56.25%",
+              "pointerEvents": "none",
+              "width": "1px",
+            },
+            "marginBottom": "10px",
+            "position": "relative",
+            "width": "100%",
+          }
+        }
+      >
+        <ForwardRef
+          $style={
+            Object {
+              "color": "red",
+            }
+          }
+        >
+          <MockStyledComponent
+            $style={
+              Object {
+                "color": "red",
+              }
+            }
+            forwardedRef={null}
+          >
+            <div
+              styled-component="true"
+              test-style={
+                Object {
+                  "bottom": 0,
+                  "color": "red",
+                  "position": "absolute",
+                  "top": 0,
+                  "width": "100%",
+                }
+              }
+            />
+          </MockStyledComponent>
+        </ForwardRef>
+      </div>
+    </MockStyledComponent>
+  </ForwardRef>
+</AspectRatioBox>
+`;

--- a/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
+++ b/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
@@ -16,7 +16,6 @@ const props = {
   overrides: {
     Root: {
       style: {
-        width: '100%',
         border: 'grey solid 2px',
       },
     },

--- a/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
+++ b/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
@@ -33,7 +33,7 @@ export const component = () => (
   <React.Fragment>
     <AspectRatioBox {...props}>Square by default</AspectRatioBox>
     <AspectRatioBox {...props} aspectRatio={16 / 9}>
-      16:9 ratio
+      16:9 aspect ratio
     </AspectRatioBox>
   </React.Fragment>
 );

--- a/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
+++ b/src/aspect-ratio-box/__tests__/aspect-ratio-box-basic.scenario.js
@@ -1,0 +1,40 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {AspectRatioBox} from '../index.js';
+
+export const name = 'aspect-ratio-basic';
+
+const props = {
+  overrides: {
+    Root: {
+      style: {
+        width: '100%',
+        border: 'grey solid 2px',
+      },
+    },
+    Body: {
+      style: {
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+      },
+    },
+  },
+};
+
+export const component = () => (
+  <React.Fragment>
+    <AspectRatioBox {...props}>Square by default</AspectRatioBox>
+    <AspectRatioBox {...props} aspectRatio={16 / 9}>
+      16:9 ratio
+    </AspectRatioBox>
+  </React.Fragment>
+);

--- a/src/aspect-ratio-box/__tests__/aspect-ratio-box.test.js
+++ b/src/aspect-ratio-box/__tests__/aspect-ratio-box.test.js
@@ -1,0 +1,30 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+import {mount} from 'enzyme';
+
+import AspectRatioBox from '../aspect-ratio-box.js';
+
+describe('AspectRatioBox', () => {
+  it('renders', () => {
+    const wrapper = mount(<AspectRatioBox />);
+    expect(wrapper).toMatchSnapshot('for aspectRatio={1}');
+
+    wrapper.setProps({aspectRatio: 16 / 9});
+    expect(wrapper).toMatchSnapshot('for aspectRatio={16 / 9}');
+
+    wrapper.setProps({
+      overrides: {
+        Body: {style: {color: 'red'}},
+        Root: {style: {marginBottom: '10px'}},
+      },
+    });
+    expect(wrapper).toMatchSnapshot('with overridden styles');
+  });
+});

--- a/src/aspect-ratio-box/aspect-ratio-box.js
+++ b/src/aspect-ratio-box/aspect-ratio-box.js
@@ -1,0 +1,44 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {Body as StyledBody, Root as StyledRoot} from './styled-components.js';
+import {getOverride, getOverrideProps} from '../helpers/overrides.js';
+import type {AspectRatioBoxPropsT} from './types.js';
+
+const AspectRatioBox = ({
+  aspectRatio,
+  children,
+  overrides,
+  ...restProps
+}: AspectRatioBoxPropsT) => {
+  const {Body: BodyOverride, Root: RootOverride} = overrides;
+
+  const Body = getOverride(BodyOverride) || StyledBody;
+  const Root = getOverride(RootOverride) || StyledRoot;
+
+  return (
+    <Root
+      data-baseweb="aspect-ratio-box"
+      $aspectRatio={aspectRatio}
+      {...restProps}
+      {...getOverrideProps(RootOverride)}
+    >
+      <Body {...getOverrideProps(BodyOverride)}>{children}</Body>
+    </Root>
+  );
+};
+
+AspectRatioBox.defaultProps = {
+  children: null,
+  aspectRatio: 1,
+  overrides: {},
+};
+
+export default AspectRatioBox;

--- a/src/aspect-ratio-box/index.js
+++ b/src/aspect-ratio-box/index.js
@@ -1,0 +1,11 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+export {default as AspectRatioBox} from './aspect-ratio-box.js';
+export {Body as StyledBody, Root as StyledRoot} from './styled-components.js';
+export * from './types.js';

--- a/src/aspect-ratio-box/styled-components.js
+++ b/src/aspect-ratio-box/styled-components.js
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import {styled} from '../styles/index.js';
+
+export const Root = styled<{$aspectRatio: number}>('div', ({$aspectRatio}) => ({
+  width: '100%',
+  position: 'relative',
+  '::before': {
+    content: '""',
+    width: '1px',
+    marginLeft: '-1px',
+    float: 'left',
+    height: 0,
+    paddingTop: `${100 / $aspectRatio}%`,
+    pointerEvents: 'none',
+  },
+  '::after': {
+    content: '""',
+    display: 'table',
+    clear: 'both',
+  },
+}));
+
+export const Body = styled<{}>('div', () => ({
+  position: 'absolute',
+  top: 0,
+  bottom: 0,
+  width: '100%',
+}));

--- a/src/aspect-ratio-box/types.js
+++ b/src/aspect-ratio-box/types.js
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import type {OverrideT} from '../helpers/overrides.js';
+
+export type AspectRatioBoxComponentsT = {
+  Body?: OverrideT<?{}>,
+  Root?: OverrideT<?{}>,
+};
+
+export type AspectRatioBoxPropsT = {
+  /** Aspect ratio is width divided by height. */
+  +aspectRatio?: number,
+  /** Content to be rendered in the Body. */
+  +children?: React.Node,
+  +overrides: AspectRatioBoxComponentsT,
+};


### PR DESCRIPTION
#### Description

Add AspectRatioBox component, which allows you to create a container with a given aspect ratio. Useful for wrapping images with known aspect ratios from causing reflows as images load, or building UIs with using squares of unknown width.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
