### PR TITLE
docs: resolve #1348 by including resizable textarea example

### DIFF
--- a/documentation-site/pages/components/textarea.mdx
+++ b/documentation-site/pages/components/textarea.mdx
@@ -11,6 +11,7 @@ import Layout from '../../components/layout';
 
 import TextareaBasic from 'examples/textarea/basic.js';
 import TextareaRef from 'examples/textarea/ref.js';
+import TextareaResizable from 'examples/textarea/resizable.js';
 
 import Overrides from '../../components/overrides';
 import {StatefulTextarea as Textarea, SIZE} from 'baseui/textarea';
@@ -26,6 +27,10 @@ export default Layout;
 
 <Example title="Textarea with ref" path="examples/textarea/ref.js">
   <TextareaRef />
+</Example>
+
+<Example title="Resizable Textarea with restrictions" path="examples/textarea/resizable.js">
+  <TextareaResizable />
 </Example>
 
 ## Overrides

--- a/documentation-site/static/examples/textarea/resizable.js
+++ b/documentation-site/static/examples/textarea/resizable.js
@@ -1,0 +1,17 @@
+import * as React from 'react';
+import {StatefulTextarea as Textarea} from 'baseui/textarea';
+
+export default () => (
+  <Textarea
+    placeholder="Resizable > 100px & < 300px"
+    overrides={{
+      Input: {
+        style: {
+          maxHeight: '300px',
+          minHeight: '100px',
+          resize: 'both',
+        },
+      },
+    }}
+  />
+);


### PR DESCRIPTION
Resolves #1348 by showing docs example of a resizable textarea with restrictions.

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
