### PR TITLE
feat(popover): accepting popperOptions

### DIFF
--- a/src/popover/popover.js
+++ b/src/popover/popover.js
@@ -432,7 +432,11 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
 
   render() {
     const rendered = [this.renderAnchor()];
-
+    const defaultPopperOptions = {
+      modifiers: {
+        preventOverflow: {enabled: !this.props.ignoreBoundary},
+      },
+    };
     // Only render popover on the browser (portals aren't supported server-side)
     if (__BROWSER__) {
       if (this.state.isMounted && this.props.isOpen) {
@@ -450,9 +454,8 @@ class Popover extends React.Component<PopoverPropsT, PopoverPrivateStateT> {
               // Remove the `ignoreBoundary` prop in the next major version
               // and have it replaced with the TetherBehavior props overrides
               popperOptions={{
-                modifiers: {
-                  preventOverflow: {enabled: !this.props.ignoreBoundary},
-                },
+                ...defaultPopperOptions,
+                ...this.props.popperOptions,
               }}
               onPopperUpdate={this.onPopperUpdate}
               placement={this.state.placement}

--- a/src/popover/types.js
+++ b/src/popover/types.js
@@ -80,7 +80,8 @@ export type BasePopoverPropsT = {
   mountNode?: HTMLElement,
   /** How long should be fade out animation in ms, default 0ms */
   animateOutTime?: number,
-  /** Popper options override */
+  /** Popper options override
+   * https://popper.js.org/popper-documentation.html#Popper.Defaults */
   // eslint-disable-next-line flowtype/no-weak-types
   popperOptions?: any,
 };

--- a/src/popover/types.js
+++ b/src/popover/types.js
@@ -80,6 +80,9 @@ export type BasePopoverPropsT = {
   mountNode?: HTMLElement,
   /** How long should be fade out animation in ms, default 0ms */
   animateOutTime?: number,
+  /** Popper options override */
+  // eslint-disable-next-line flowtype/no-weak-types
+  popperOptions?: any,
 };
 
 // Props for stateless render logic


### PR DESCRIPTION
#### Description
- Resolves #1152 by supporting `popperOptions` on `Popover` component
- adds `popperOptions?: any` to types. Similar to how `Tether` is doing so.
- Extends current default options passed in.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
