### PR TITLE
docs(aspect-ratio-box): remove padding from calendar example

### DIFF
--- a/documentation-site/static/examples/aspect-ratio-box/calendar.js
+++ b/documentation-site/static/examples/aspect-ratio-box/calendar.js
@@ -3,9 +3,26 @@ import {AspectRatioBox, AspectRatioBoxBody} from 'baseui/aspect-ratio-box';
 import {Block} from 'baseui/block';
 import {Button, KIND} from 'baseui/button';
 
+const CalendarButton = props => (
+  <Button
+    kind={KIND.minimal}
+    overrides={{
+      BaseButton: {
+        style: {
+          paddingTop: 0,
+          paddingRight: 0,
+          paddingBottom: 0,
+          paddingLeft: 0,
+        },
+      },
+    }}
+    {...props}
+  />
+);
+
 const DateBox = props => (
   <AspectRatioBox width={`${100 / 7}%`}>
-    <AspectRatioBoxBody as={Button} kind={KIND.minimal} {...props} />
+    <AspectRatioBoxBody as={CalendarButton} {...props} />
   </AspectRatioBox>
 );
 


### PR DESCRIPTION
#### Description

Remove padding from calendar example so it doesn’t wrap on mobile.

Before: ![calendar-before](https://user-images.githubusercontent.com/1285326/59798610-3be66400-927e-11e9-9fc9-21ef03b8b075.png)
After: ![calendar-after](https://user-images.githubusercontent.com/1285326/59798618-40ab1800-927e-11e9-8cbe-c1afb4216f00.png)

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
