### PR TITLE
docs: add TypeScript info, don't wrap code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ export default function Hello() {
 }
 ```
 
+Both Base Web and Styletron are [flow typed](https://flow.org/) out of the box. **Do you use [TypeScript](https://www.typescriptlang.org/index.html)**? We provide external declarations:
+
+```bash
+yarn add @types/baseui @types/styletron-standard @types/styletron-react @types/styletron-engine-atomic
+```
+
 ## Example
 
 An example of an application using Base Web can be found [here](https://github.com/tajo/fusion-baseui). You can also check how it works on [CodeSandbox](https://codesandbox.io/s/patient-sky-nn8t7).

--- a/documentation-site/components/markdown-elements.js
+++ b/documentation-site/components/markdown-elements.js
@@ -36,7 +36,7 @@ const getText = children => {
 
 export const cleanAnchor = (anchor: React.Node) => slugify(getText(anchor));
 
-const Code = (props: Props) => <Block>{props.children}</Block>;
+const Code = (props: Props) => <Block whiteSpace="pre">{props.children}</Block>;
 
 export const Heading = ({
   element,

--- a/documentation-site/pages/getting-started/installation.mdx
+++ b/documentation-site/pages/getting-started/installation.mdx
@@ -21,6 +21,17 @@ yarn add baseui styletron-engine-atomic styletron-react
 npm install baseui styletron-engine-atomic styletron-react
 ```
 
+Both Base Web and Styletron are [flow typed](https://flow.org/) out of the box. **Do you use [TypeScript](https://www.typescriptlang.org/index.html)**? We provide external declarations:
+
+```bash
+yarn add @types/baseui
+yarn add @types/styletron-standard
+yarn add @types/styletron-react
+yarn add @types/styletron-engine-atomic
+```
+
+Our React components don't use [PropTypes](https://reactjs.org/docs/typechecking-with-proptypes.html).
+
 [Styletron](https://www.styletron.org/) is a toolkit for component-oriented styling, part of the CSS in JS family. Base Web uses Styletron as a peer dependency to style all the elements, so you need to add them as dependencies too.
 
 **The next step is to setup Styletron in your application.** There are detailed guides for


### PR DESCRIPTION
## Before
<img width="641" alt="Screen Shot 2019-06-20 at 1 36 21 PM" src="https://user-images.githubusercontent.com/1387913/59880535-1f235c80-9362-11e9-841a-14e659704f2c.png">

## After
<img width="648" alt="Screen Shot 2019-06-20 at 1 44 36 PM" src="https://user-images.githubusercontent.com/1387913/59880549-264a6a80-9362-11e9-88fe-409298af761e.png">

(scroll instead)
