### PR TITLE
fix: random day highlight onMonthChange for DatePicker

### DIFF
--- a/src/datepicker/calendar.js
+++ b/src/datepicker/calendar.js
@@ -143,7 +143,6 @@ export default class Calendar extends React.Component<
   };
 
   handleMonthChange = (date: Date) => {
-    this.setHighlightedDate(date);
     if (this.props.onMonthChange) {
       this.props.onMonthChange({date});
     }


### PR DESCRIPTION
- Fixes #1141 
- `onMonthChange` will no longer set a highlighted date 👍 

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
