### PR TITLE
fix(modal): allow interaction with select (& other portals)

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,12 +146,12 @@
   "dependencies": {
     "card-validator": "^6.1.0",
     "date-fns": "2.0.0-alpha.37",
-    "focus-trap-react": "^6.0.0",
     "just-extend": "^4.0.2",
     "memoize-one": "^5.0.0",
     "polished": "^3.2.0",
     "popper.js": "^1.14.3",
     "react-dropzone": "^9.0.0",
+    "react-focus-lock": "^2.0.0",
     "react-input-mask": "^2.0.4",
     "react-is": "^16.8.6",
     "react-movable": "^2.0.1",

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -11,209 +11,451 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
   size="default"
 >
   <mockConstructor>
-    <FocusTrap
-      _createFocusTrap={[Function]}
-      active={true}
-      focusTrapOptions={
-        Object {
-          "fallbackFocus": [Function],
-        }
-      }
-      paused={false}
+    <FocusLockCombination
+      autoFocus={true}
+      returnFocus={true}
     >
-      <ForwardRef
-        $animate={true}
-        $closeable={true}
-        $isOpen={true}
-        $isVisible={false}
-        $role="dialog"
-        $size="default"
-        data-baseweb="modal"
+      <FocusLock
+        as="div"
+        autoFocus={true}
+        disabled={false}
+        lockProps={Object {}}
+        noFocusGuards={false}
+        persistentFocus={false}
+        returnFocus={true}
+        sideCar={[Function]}
       >
-        <MockStyledComponent
-          $animate={true}
-          $closeable={true}
-          $isOpen={true}
-          $isVisible={false}
-          $role="dialog"
-          $size="default"
-          data-baseweb="modal"
-          forwardedRef={[Function]}
-        >
-          <Portal>
-            <ForwardRef
+        <Portal
+          key="guard-first"
+        />
+        <Portal
+          key="guard-nearest"
+        />
+        <Portal>
+          <SideEffect(FocusWatcher)
+            autoFocus={true}
+            disabled={false}
+            observed={
+              <div
+                data-focus-lock-disabled="false"
+              >
+                <div
+                  data-baseweb="modal"
+                  styled-component="true"
+                  test-style="[object Object]"
+                >
+                  <div
+                    styled-component="true"
+                    test-style="[object Object]"
+                  />
+                  <div
+                    styled-component="true"
+                    test-style="[object Object]"
+                  >
+                    <div
+                      aria-modal="true"
+                      role="dialog"
+                      styled-component="true"
+                      tabindex="-1"
+                      test-style="[object Object]"
+                    >
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        Hello world
+                      </div>
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        Modal Body
+                      </div>
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        Footer
+                      </div>
+                      <button
+                        aria-label="Close"
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        <svg
+                          height="10"
+                          style="stroke: currentColor;"
+                          viewBox="0 0 10 10"
+                          width="10"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                            stroke-linecap="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            }
+            onActivation={[Function]}
+            onDeactivation={[Function]}
+            persistentFocus={false}
+            returnFocus={[Function]}
+            shards={Array []}
+            sideCar={
+              Object {
+                "assignMedium": [Function],
+                "read": [Function],
+                "useMedium": [Function],
+              }
+            }
+          >
+            <FocusWatcher
+              autoFocus={true}
+              disabled={false}
+              observed={
+                <div
+                  data-focus-lock-disabled="false"
+                >
+                  <div
+                    data-baseweb="modal"
+                    styled-component="true"
+                    test-style="[object Object]"
+                  >
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    />
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      <div
+                        aria-modal="true"
+                        role="dialog"
+                        styled-component="true"
+                        tabindex="-1"
+                        test-style="[object Object]"
+                      >
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Hello world
+                        </div>
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Modal Body
+                        </div>
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Footer
+                        </div>
+                        <button
+                          aria-label="Close"
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          <svg
+                            height="10"
+                            style="stroke: currentColor;"
+                            viewBox="0 0 10 10"
+                            width="10"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                              stroke-linecap="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              }
+              onActivation={[Function]}
+              onDeactivation={[Function]}
+              persistentFocus={false}
+              returnFocus={[Function]}
+              shards={Array []}
+              sideCar={
+                Object {
+                  "assignMedium": [Function],
+                  "read": [Function],
+                  "useMedium": [Function],
+                }
+              }
+            />
+          </SideEffect(FocusWatcher)>
+          <ForwardRef
+            $animate={true}
+            $closeable={true}
+            $isOpen={true}
+            $isVisible={false}
+            $role="dialog"
+            $size="default"
+            data-baseweb="modal"
+          >
+            <MockStyledComponent
               $animate={true}
               $closeable={true}
               $isOpen={true}
               $isVisible={false}
               $role="dialog"
               $size="default"
-              onClick={[Function]}
+              data-baseweb="modal"
+              forwardedRef={
+                Object {
+                  "current": <div
+                    data-baseweb="modal"
+                    styled-component="true"
+                    test-style="[object Object]"
+                  >
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    />
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      <div
+                        aria-modal="true"
+                        role="dialog"
+                        styled-component="true"
+                        tabindex="-1"
+                        test-style="[object Object]"
+                      >
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Hello world
+                        </div>
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Modal Body
+                        </div>
+                        <div
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          Footer
+                        </div>
+                        <button
+                          aria-label="Close"
+                          styled-component="true"
+                          test-style="[object Object]"
+                        >
+                          <svg
+                            height="10"
+                            style="stroke: currentColor;"
+                            viewBox="0 0 10 10"
+                            width="10"
+                            xmlns="http://www.w3.org/2000/svg"
+                          >
+                            <path
+                              d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                              stroke-linecap="round"
+                              stroke-width="2"
+                            />
+                          </svg>
+                        </button>
+                      </div>
+                    </div>
+                  </div>,
+                }
+              }
             >
-              <MockStyledComponent
-                $animate={true}
-                $closeable={true}
-                $isOpen={true}
-                $isVisible={false}
-                $role="dialog"
-                $size="default"
-                forwardedRef={null}
-                onClick={[Function]}
-              >
-                <Portal />
-              </MockStyledComponent>
-            </ForwardRef>
-            <ForwardRef
-              $animate={true}
-              $closeable={true}
-              $isOpen={true}
-              $isVisible={false}
-              $role="dialog"
-              $size="default"
-            >
-              <MockStyledComponent
-                $animate={true}
-                $closeable={true}
-                $isOpen={true}
-                $isVisible={false}
-                $role="dialog"
-                $size="default"
-                forwardedRef={null}
-              >
-                <Portal>
-                  <ForwardRef
+              <Portal>
+                <ForwardRef
+                  $animate={true}
+                  $closeable={true}
+                  $isOpen={true}
+                  $isVisible={false}
+                  $role="dialog"
+                  $size="default"
+                  onClick={[Function]}
+                >
+                  <MockStyledComponent
                     $animate={true}
                     $closeable={true}
                     $isOpen={true}
                     $isVisible={false}
                     $role="dialog"
                     $size="default"
-                    aria-modal="true"
-                    role="dialog"
-                    tabIndex={-1}
+                    forwardedRef={null}
+                    onClick={[Function]}
                   >
-                    <MockStyledComponent
-                      $animate={true}
-                      $closeable={true}
-                      $isOpen={true}
-                      $isVisible={false}
-                      $role="dialog"
-                      $size="default"
-                      aria-modal="true"
-                      forwardedRef={
-                        Object {
-                          "current": <div
-                            aria-modal="true"
-                            role="dialog"
-                            styled-component="true"
-                            tabindex="-1"
-                            test-style="[object Object]"
-                          >
-                            <div
-                              styled-component="true"
-                              test-style="[object Object]"
-                            >
-                              Hello world
-                            </div>
-                            <div
-                              styled-component="true"
-                              test-style="[object Object]"
-                            >
-                              Modal Body
-                            </div>
-                            <div
-                              styled-component="true"
-                              test-style="[object Object]"
-                            >
-                              Footer
-                            </div>
-                            <button
-                              aria-label="Close"
-                              styled-component="true"
-                              test-style="[object Object]"
-                            >
-                              <svg
-                                height="10"
-                                style="stroke: currentColor;"
-                                viewBox="0 0 10 10"
-                                width="10"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
-                                  stroke-linecap="round"
-                                  stroke-width="2"
-                                />
-                              </svg>
-                            </button>
-                          </div>,
-                        }
-                      }
-                      role="dialog"
-                      tabIndex={-1}
-                    >
-                      <Portal>
-                        <ForwardRef>
-                          <MockStyledComponent
-                            forwardedRef={null}
-                          >
-                            <Portal />
-                          </MockStyledComponent>
-                        </ForwardRef>
-                        <ForwardRef>
-                          <MockStyledComponent
-                            forwardedRef={null}
-                          >
-                            <Portal />
-                          </MockStyledComponent>
-                        </ForwardRef>
-                        <ForwardRef>
-                          <MockStyledComponent
-                            forwardedRef={null}
-                          >
-                            <Portal />
-                          </MockStyledComponent>
-                        </ForwardRef>
-                        <ForwardRef
+                    <Portal />
+                  </MockStyledComponent>
+                </ForwardRef>
+                <ForwardRef
+                  $animate={true}
+                  $closeable={true}
+                  $isOpen={true}
+                  $isVisible={false}
+                  $role="dialog"
+                  $size="default"
+                >
+                  <MockStyledComponent
+                    $animate={true}
+                    $closeable={true}
+                    $isOpen={true}
+                    $isVisible={false}
+                    $role="dialog"
+                    $size="default"
+                    forwardedRef={null}
+                  >
+                    <Portal>
+                      <ForwardRef
+                        $animate={true}
+                        $closeable={true}
+                        $isOpen={true}
+                        $isVisible={false}
+                        $role="dialog"
+                        $size="default"
+                        aria-modal="true"
+                        role="dialog"
+                        tabIndex={-1}
+                      >
+                        <MockStyledComponent
                           $animate={true}
                           $closeable={true}
                           $isOpen={true}
                           $isVisible={false}
                           $role="dialog"
                           $size="default"
-                          aria-label="Close"
-                          onClick={[Function]}
+                          aria-modal="true"
+                          forwardedRef={
+                            Object {
+                              "current": <div
+                                aria-modal="true"
+                                role="dialog"
+                                styled-component="true"
+                                tabindex="-1"
+                                test-style="[object Object]"
+                              >
+                                <div
+                                  styled-component="true"
+                                  test-style="[object Object]"
+                                >
+                                  Hello world
+                                </div>
+                                <div
+                                  styled-component="true"
+                                  test-style="[object Object]"
+                                >
+                                  Modal Body
+                                </div>
+                                <div
+                                  styled-component="true"
+                                  test-style="[object Object]"
+                                >
+                                  Footer
+                                </div>
+                                <button
+                                  aria-label="Close"
+                                  styled-component="true"
+                                  test-style="[object Object]"
+                                >
+                                  <svg
+                                    height="10"
+                                    style="stroke: currentColor;"
+                                    viewBox="0 0 10 10"
+                                    width="10"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                  >
+                                    <path
+                                      d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                                      stroke-linecap="round"
+                                      stroke-width="2"
+                                    />
+                                  </svg>
+                                </button>
+                              </div>,
+                            }
+                          }
+                          role="dialog"
+                          tabIndex={-1}
                         >
-                          <MockStyledComponent
-                            $animate={true}
-                            $closeable={true}
-                            $isOpen={true}
-                            $isVisible={false}
-                            $role="dialog"
-                            $size="default"
-                            aria-label="Close"
-                            forwardedRef={null}
-                            onClick={[Function]}
-                          >
-                            <Portal>
-                              <CloseIcon>
+                          <Portal>
+                            <ForwardRef>
+                              <MockStyledComponent
+                                forwardedRef={null}
+                              >
+                                <Portal />
+                              </MockStyledComponent>
+                            </ForwardRef>
+                            <ForwardRef>
+                              <MockStyledComponent
+                                forwardedRef={null}
+                              >
+                                <Portal />
+                              </MockStyledComponent>
+                            </ForwardRef>
+                            <ForwardRef>
+                              <MockStyledComponent
+                                forwardedRef={null}
+                              >
+                                <Portal />
+                              </MockStyledComponent>
+                            </ForwardRef>
+                            <ForwardRef
+                              $animate={true}
+                              $closeable={true}
+                              $isOpen={true}
+                              $isVisible={false}
+                              $role="dialog"
+                              $size="default"
+                              aria-label="Close"
+                              onClick={[Function]}
+                            >
+                              <MockStyledComponent
+                                $animate={true}
+                                $closeable={true}
+                                $isOpen={true}
+                                $isVisible={false}
+                                $role="dialog"
+                                $size="default"
+                                aria-label="Close"
+                                forwardedRef={null}
+                                onClick={[Function]}
+                              >
                                 <Portal>
-                                  <Portal />
+                                  <CloseIcon>
+                                    <Portal>
+                                      <Portal />
+                                    </Portal>
+                                  </CloseIcon>
                                 </Portal>
-                              </CloseIcon>
-                            </Portal>
-                          </MockStyledComponent>
-                        </ForwardRef>
-                      </Portal>
-                    </MockStyledComponent>
-                  </ForwardRef>
-                </Portal>
-              </MockStyledComponent>
-            </ForwardRef>
-          </Portal>
-        </MockStyledComponent>
-      </ForwardRef>
-    </FocusTrap>
+                              </MockStyledComponent>
+                            </ForwardRef>
+                          </Portal>
+                        </MockStyledComponent>
+                      </ForwardRef>
+                    </Portal>
+                  </MockStyledComponent>
+                </ForwardRef>
+              </Portal>
+            </MockStyledComponent>
+          </ForwardRef>
+        </Portal>
+        <Portal />
+      </FocusLock>
+    </FocusLockCombination>
   </mockConstructor>
 </Modal>
 `;

--- a/src/modal/__tests__/modal-select.scenario.js
+++ b/src/modal/__tests__/modal-select.scenario.js
@@ -1,0 +1,41 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {StatefulSelect} from '../../select/index.js';
+import {Modal, ModalBody} from '../index.js';
+
+export const name = 'modal-select';
+
+const Example = () => {
+  return (
+    <div>
+      <Modal closeable={false} isOpen>
+        <ModalBody>
+          <StatefulSelect
+            options={[
+              {id: 'AliceBlue', color: '#F0F8FF'},
+              {id: 'AntiqueWhite', color: '#FAEBD7'},
+              {id: 'Aqua', color: '#00FFFF'},
+              {id: 'Aquamarine', color: '#7FFFD4'},
+              {id: 'Azure', color: '#F0FFFF'},
+              {id: 'Beige', color: '#F5F5DC'},
+            ]}
+            overrides={{ValueContainer: {props: {'data-id': 'selected'}}}}
+            labelKey="id"
+            valueKey="color"
+            placeholder="Start searching"
+          />
+        </ModalBody>
+      </Modal>
+    </div>
+  );
+};
+
+export const component = () => <Example />;

--- a/src/modal/focus-once.js
+++ b/src/modal/focus-once.js
@@ -13,7 +13,7 @@ type Props = {
 
 /**
  * Wrap an element in FocusOnce that would normally not receive tab focus.
- * This is useful for placing initial focus in a Modal or FocusTrap.
+ * This is useful for placing initial focus in a Modal or FocusLock.
  * */
 export default function FocusOnce(props: Props) {
   const [tabIndex, setTabIndex] = React.useState('0');

--- a/src/modal/modal.js
+++ b/src/modal/modal.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 /* global document */
 import * as React from 'react';
-import FocusTrap from 'focus-trap-react';
+import FocusLock from 'react-focus-lock';
 
 import {LocaleContext} from '../locale/index.js';
 import {getOverride, getOverrideProps} from '../helpers/overrides.js';
@@ -241,13 +241,8 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
     return (
       <LocaleContext.Consumer>
         {locale => (
-          <FocusTrap
-            focusTrapOptions={{
-              [this.props.autofocus ? 'fallbackFocus' : 'initialFocus']: () => {
-                return this.getRef('Dialog').current;
-              },
-            }}
-          >
+          // eslint-disable-next-line jsx-a11y/no-autofocus
+          <FocusLock returnFocus autoFocus={this.props.autofocus}>
             <Root
               data-baseweb="modal"
               ref={this.getRef('Root')}
@@ -290,7 +285,7 @@ class Modal extends React.Component<ModalPropsT, ModalStateT> {
                 </Dialog>
               </DialogContainer>
             </Root>
-          </FocusTrap>
+          </FocusLock>
         )}
       </LocaleContext.Consumer>
     );

--- a/src/table/filter.js
+++ b/src/table/filter.js
@@ -7,7 +7,7 @@ LICENSE file in the root directory of this source tree.
 // @flow
 
 import * as React from 'react';
-import FocusTrap from 'focus-trap-react';
+import FocusLock from 'react-focus-lock';
 
 import {Button, KIND, SIZE} from '../button/index.js';
 import {getOverrides} from '../helpers/overrides.js';
@@ -75,33 +75,31 @@ export default function Filter(props: FilterProps) {
         return nextState;
       }}
       content={
-        <FocusTrap>
-          <div>
-            <Heading {...headingProps}>Filter Column</Heading>
-            <Content {...contentProps}>{props.children}</Content>
-            <Footer {...footerProps}>
-              <Button
-                kind={KIND.minimal}
-                size={SIZE.compact}
-                onClick={() => {
-                  onSelectAll();
-                }}
-              >
-                Select All
-              </Button>
+        <FocusLock>
+          <Heading {...headingProps}>Filter Column</Heading>
+          <Content {...contentProps}>{props.children}</Content>
+          <Footer {...footerProps}>
+            <Button
+              kind={KIND.minimal}
+              size={SIZE.compact}
+              onClick={() => {
+                onSelectAll();
+              }}
+            >
+              Select All
+            </Button>
 
-              <Button
-                kind={KIND.minimal}
-                size={SIZE.compact}
-                onClick={() => {
-                  onReset();
-                }}
-              >
-                Reset
-              </Button>
-            </Footer>
-          </div>
-        </FocusTrap>
+            <Button
+              kind={KIND.minimal}
+              size={SIZE.compact}
+              onClick={() => {
+                onReset();
+              }}
+            >
+              Reset
+            </Button>
+          </Footer>
+        </FocusLock>
       }
     >
       <MenuButton {...menuButtonProps}>

--- a/src/table/filter.js
+++ b/src/table/filter.js
@@ -75,7 +75,8 @@ export default function Filter(props: FilterProps) {
         return nextState;
       }}
       content={
-        <FocusLock>
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        <FocusLock autoFocus={false}>
           <Heading {...headingProps}>Filter Column</Heading>
           <Content {...contentProps}>{props.children}</Content>
           <Footer {...footerProps}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,6 +6256,11 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
+detect-node@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
+  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
+
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -7594,20 +7599,10 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-trap-react@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-6.0.0.tgz#3f5a9f68447dd374d22388fb4c50018be83e74a5"
-  integrity sha512-mvEYxmP75PMx0vOqoIAmJHO/qUEvdTAdz6gLlEZyxxODnuKQdnKea2RWTYxghAPrV+ibiIq2o/GTSgQycnAjcw==
-  dependencies:
-    focus-trap "^4.0.2"
-
-focus-trap@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-4.0.2.tgz#4ee2b96547c9ea0e4252a2d4b2cca68944194663"
-  integrity sha512-HtLjfAK7Hp2qbBtLS6wEznID1mPT+48ZnP2nkHzgjpL4kroYHg0CdqJ5cTXk+UO5znAxF5fRUkhdyfgrhh8Lzw==
-  dependencies:
-    tabbable "^3.1.2"
-    xtend "^4.0.1"
+focus-lock@^0.6.4:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
+  integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
 
 for-in@^0.1.3:
   version "0.1.8"
@@ -12437,6 +12432,13 @@ rc@^1.2.7, rc@~1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-clientside-effect@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.1.tgz#feb81abe9531061d4987941c15a00f2b3d0b6071"
+  integrity sha512-foSwZatJak6r+F4OqJ8a+MOWcBi3jwa7/RPdJIDZI1Ck0dn/FJZkkFu7YK+SiZxsCZIrotolxHSobcnBHgIjfw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+
 react-codesandboxer@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/react-codesandboxer/-/react-codesandboxer-3.1.1.tgz#e7af0f00509d0292f91d3730f71565dbf781b0d7"
@@ -12525,6 +12527,17 @@ react-error-overlay@^5.0.5:
   version "5.0.5"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.5.tgz#716ff1a92fda76bb89a39adf9ce046a5d740e71a"
   integrity sha512-ab0HWBgxdIsngHtMGU8+8gYFdTBXpUGd4AE4lN2VZvOIlBmWx9dtaWEViihuGSIGosCKPeHCnzFoRWB42UtnLg==
+
+react-focus-lock@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.0.0.tgz#01e570523f282b637390f45eb7f02f166f702f4b"
+  integrity sha512-Gz5O0z5MXSAElbZPmfjgmw4mM+QvcLH1o6ttmgk3YENqh4lmpksGbFceSV4aYXgPJ3zE48MhaTsDbHmn3OgDEw==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    focus-lock "^0.6.4"
+    prop-types "^15.6.2"
+    react-clientside-effect "^1.2.1"
+    use-sidecar "^0.2.0"
 
 react-fuzzy@^0.5.2:
   version "0.5.2"
@@ -14540,11 +14553,6 @@ symbol.prototype.description@^1.0.0:
   dependencies:
     has-symbols "^1.0.0"
 
-tabbable@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-3.1.2.tgz#f2d16cccd01f400e38635c7181adfe0ad965a4a2"
-  integrity sha512-wjB6puVXTYO0BSFtCmWQubA/KIn7Xvajw0x0l6eJUudMG/EAiJvIUnyNX6xO4NpGrJ16lbD0eUseB9WxW0vlpQ==
-
 table@^5.2.3:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.1.tgz#0691ae2ebe8259858efb63e550b6d5f9300171e8"
@@ -14885,6 +14893,11 @@ tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
+
+tslib@^1.9.3:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
+  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
 
 tty-aware-progress@1.0.3:
   version "1.0.3"
@@ -15244,6 +15257,14 @@ urlobj@0.0.11:
     is-object "^1.0.1"
     is-string "^1.0.4"
     object-assign "^4.1.1"
+
+use-sidecar@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-0.2.0.tgz#4a25c17ccd7d48b763dd6aff82ac36452ef973a5"
+  integrity sha512-Lc/ufC5jwasJwWx+NTDgXzzBCw86XIbydKRieE19auvu5D6nTqE6cz6TT9DNCtVnFprGoV3FzsAYVdc+uLQ0lA==
+  dependencies:
+    detect-node "^2.0.4"
+    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
#### Description

This PR fixes a regression introduced in #1406 which was a new feature in v7.4.0.

You can see the bug in [this codepen](https://codesandbox.io/s/modal-select-bug-x9svk). Basically, you can't interact with the select dropdown using clicks when it is inside a modal.

The issue was that the library we use for focus trapping does not inherently respect react portals. It tests to see where the click event occurred, and if it is outside the container element it cancels the event. This is an issue with portals because the elements in the portal are not descendants of the container element.

The fix in this PR comes from swapping the `focus-trap-react` library out with a different one, `react-focus-lock`, which has built in support for portals.

There should be no noticeable change in the modal a11y experience.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
