### PR TITLE
fix: codesandbox modal examples

### DIFF
--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "polished": "^3.2.0",
     "popper.js": "^1.14.3",
     "react-dropzone": "^9.0.0",
-    "react-focus-lock": "^2.0.0",
+    "react-focus-lock": "^1.9.1",
     "react-input-mask": "^2.0.4",
     "react-is": "^16.8.6",
     "react-movable": "^2.0.1",

--- a/src/modal/__tests__/__snapshots__/modal.test.js.snap
+++ b/src/modal/__tests__/__snapshots__/modal.test.js.snap
@@ -11,28 +11,97 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
   size="default"
 >
   <mockConstructor>
-    <FocusLockCombination
+    <FocusLock
+      as="div"
       autoFocus={true}
+      disabled={false}
+      lockProps={Object {}}
+      noFocusGuards={false}
+      persistentFocus={false}
       returnFocus={true}
     >
-      <FocusLock
-        as="div"
-        autoFocus={true}
-        disabled={false}
-        lockProps={Object {}}
-        noFocusGuards={false}
-        persistentFocus={false}
-        returnFocus={true}
-        sideCar={[Function]}
-      >
-        <Portal
-          key="guard-first"
-        />
-        <Portal
-          key="guard-nearest"
-        />
-        <Portal>
-          <SideEffect(FocusWatcher)
+      <Portal
+        key="guard-first"
+      />
+      <Portal
+        key="guard-nearest"
+      />
+      <Portal>
+        <SideEffect(FocusWatcher)
+          autoFocus={true}
+          disabled={false}
+          observed={
+            <div
+              data-focus-lock-disabled="false"
+            >
+              <div
+                data-baseweb="modal"
+                styled-component="true"
+                test-style="[object Object]"
+              >
+                <div
+                  styled-component="true"
+                  test-style="[object Object]"
+                />
+                <div
+                  styled-component="true"
+                  test-style="[object Object]"
+                >
+                  <div
+                    aria-modal="true"
+                    role="dialog"
+                    styled-component="true"
+                    tabindex="-1"
+                    test-style="[object Object]"
+                  >
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      Hello world
+                    </div>
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      Modal Body
+                    </div>
+                    <div
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      Footer
+                    </div>
+                    <button
+                      aria-label="Close"
+                      styled-component="true"
+                      test-style="[object Object]"
+                    >
+                      <svg
+                        height="10"
+                        style="stroke: currentColor;"
+                        viewBox="0 0 10 10"
+                        width="10"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                          stroke-linecap="round"
+                          stroke-width="2"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+          onActivation={[Function]}
+          onDeactivation={[Function]}
+          persistentFocus={false}
+          shards={Array []}
+        >
+          <FocusWatcher
             autoFocus={true}
             disabled={false}
             observed={
@@ -104,100 +173,19 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
             onActivation={[Function]}
             onDeactivation={[Function]}
             persistentFocus={false}
-            returnFocus={[Function]}
             shards={Array []}
-            sideCar={
-              Object {
-                "assignMedium": [Function],
-                "read": [Function],
-                "useMedium": [Function],
-              }
-            }
-          >
-            <FocusWatcher
-              autoFocus={true}
-              disabled={false}
-              observed={
-                <div
-                  data-focus-lock-disabled="false"
-                >
-                  <div
-                    data-baseweb="modal"
-                    styled-component="true"
-                    test-style="[object Object]"
-                  >
-                    <div
-                      styled-component="true"
-                      test-style="[object Object]"
-                    />
-                    <div
-                      styled-component="true"
-                      test-style="[object Object]"
-                    >
-                      <div
-                        aria-modal="true"
-                        role="dialog"
-                        styled-component="true"
-                        tabindex="-1"
-                        test-style="[object Object]"
-                      >
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Hello world
-                        </div>
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Modal Body
-                        </div>
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Footer
-                        </div>
-                        <button
-                          aria-label="Close"
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          <svg
-                            height="10"
-                            style="stroke: currentColor;"
-                            viewBox="0 0 10 10"
-                            width="10"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
-                              stroke-linecap="round"
-                              stroke-width="2"
-                            />
-                          </svg>
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              }
-              onActivation={[Function]}
-              onDeactivation={[Function]}
-              persistentFocus={false}
-              returnFocus={[Function]}
-              shards={Array []}
-              sideCar={
-                Object {
-                  "assignMedium": [Function],
-                  "read": [Function],
-                  "useMedium": [Function],
-                }
-              }
-            />
-          </SideEffect(FocusWatcher)>
-          <ForwardRef
+          />
+        </SideEffect(FocusWatcher)>
+        <ForwardRef
+          $animate={true}
+          $closeable={true}
+          $isOpen={true}
+          $isVisible={false}
+          $role="dialog"
+          $size="default"
+          data-baseweb="modal"
+        >
+          <MockStyledComponent
             $animate={true}
             $closeable={true}
             $isOpen={true}
@@ -205,122 +193,124 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
             $role="dialog"
             $size="default"
             data-baseweb="modal"
-          >
-            <MockStyledComponent
-              $animate={true}
-              $closeable={true}
-              $isOpen={true}
-              $isVisible={false}
-              $role="dialog"
-              $size="default"
-              data-baseweb="modal"
-              forwardedRef={
-                Object {
-                  "current": <div
-                    data-baseweb="modal"
+            forwardedRef={
+              Object {
+                "current": <div
+                  data-baseweb="modal"
+                  styled-component="true"
+                  test-style="[object Object]"
+                >
+                  <div
+                    styled-component="true"
+                    test-style="[object Object]"
+                  />
+                  <div
                     styled-component="true"
                     test-style="[object Object]"
                   >
                     <div
+                      aria-modal="true"
+                      role="dialog"
                       styled-component="true"
-                      test-style="[object Object]"
-                    />
-                    <div
-                      styled-component="true"
+                      tabindex="-1"
                       test-style="[object Object]"
                     >
                       <div
-                        aria-modal="true"
-                        role="dialog"
                         styled-component="true"
-                        tabindex="-1"
                         test-style="[object Object]"
                       >
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Hello world
-                        </div>
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Modal Body
-                        </div>
-                        <div
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          Footer
-                        </div>
-                        <button
-                          aria-label="Close"
-                          styled-component="true"
-                          test-style="[object Object]"
-                        >
-                          <svg
-                            height="10"
-                            style="stroke: currentColor;"
-                            viewBox="0 0 10 10"
-                            width="10"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
-                              stroke-linecap="round"
-                              stroke-width="2"
-                            />
-                          </svg>
-                        </button>
+                        Hello world
                       </div>
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        Modal Body
+                      </div>
+                      <div
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        Footer
+                      </div>
+                      <button
+                        aria-label="Close"
+                        styled-component="true"
+                        test-style="[object Object]"
+                      >
+                        <svg
+                          height="10"
+                          style="stroke: currentColor;"
+                          viewBox="0 0 10 10"
+                          width="10"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                            stroke-linecap="round"
+                            stroke-width="2"
+                          />
+                        </svg>
+                      </button>
                     </div>
-                  </div>,
-                }
+                  </div>
+                </div>,
               }
-            >
-              <Portal>
-                <ForwardRef
+            }
+          >
+            <Portal>
+              <ForwardRef
+                $animate={true}
+                $closeable={true}
+                $isOpen={true}
+                $isVisible={false}
+                $role="dialog"
+                $size="default"
+                onClick={[Function]}
+              >
+                <MockStyledComponent
                   $animate={true}
                   $closeable={true}
                   $isOpen={true}
                   $isVisible={false}
                   $role="dialog"
                   $size="default"
+                  forwardedRef={null}
                   onClick={[Function]}
                 >
-                  <MockStyledComponent
-                    $animate={true}
-                    $closeable={true}
-                    $isOpen={true}
-                    $isVisible={false}
-                    $role="dialog"
-                    $size="default"
-                    forwardedRef={null}
-                    onClick={[Function]}
-                  >
-                    <Portal />
-                  </MockStyledComponent>
-                </ForwardRef>
-                <ForwardRef
+                  <Portal />
+                </MockStyledComponent>
+              </ForwardRef>
+              <ForwardRef
+                $animate={true}
+                $closeable={true}
+                $isOpen={true}
+                $isVisible={false}
+                $role="dialog"
+                $size="default"
+              >
+                <MockStyledComponent
                   $animate={true}
                   $closeable={true}
                   $isOpen={true}
                   $isVisible={false}
                   $role="dialog"
                   $size="default"
+                  forwardedRef={null}
                 >
-                  <MockStyledComponent
-                    $animate={true}
-                    $closeable={true}
-                    $isOpen={true}
-                    $isVisible={false}
-                    $role="dialog"
-                    $size="default"
-                    forwardedRef={null}
-                  >
-                    <Portal>
-                      <ForwardRef
+                  <Portal>
+                    <ForwardRef
+                      $animate={true}
+                      $closeable={true}
+                      $isOpen={true}
+                      $isVisible={false}
+                      $role="dialog"
+                      $size="default"
+                      aria-modal="true"
+                      role="dialog"
+                      tabIndex={-1}
+                    >
+                      <MockStyledComponent
                         $animate={true}
                         $closeable={true}
                         $isOpen={true}
@@ -328,92 +318,91 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                         $role="dialog"
                         $size="default"
                         aria-modal="true"
+                        forwardedRef={
+                          Object {
+                            "current": <div
+                              aria-modal="true"
+                              role="dialog"
+                              styled-component="true"
+                              tabindex="-1"
+                              test-style="[object Object]"
+                            >
+                              <div
+                                styled-component="true"
+                                test-style="[object Object]"
+                              >
+                                Hello world
+                              </div>
+                              <div
+                                styled-component="true"
+                                test-style="[object Object]"
+                              >
+                                Modal Body
+                              </div>
+                              <div
+                                styled-component="true"
+                                test-style="[object Object]"
+                              >
+                                Footer
+                              </div>
+                              <button
+                                aria-label="Close"
+                                styled-component="true"
+                                test-style="[object Object]"
+                              >
+                                <svg
+                                  height="10"
+                                  style="stroke: currentColor;"
+                                  viewBox="0 0 10 10"
+                                  width="10"
+                                  xmlns="http://www.w3.org/2000/svg"
+                                >
+                                  <path
+                                    d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
+                                    stroke-linecap="round"
+                                    stroke-width="2"
+                                  />
+                                </svg>
+                              </button>
+                            </div>,
+                          }
+                        }
                         role="dialog"
                         tabIndex={-1}
                       >
-                        <MockStyledComponent
-                          $animate={true}
-                          $closeable={true}
-                          $isOpen={true}
-                          $isVisible={false}
-                          $role="dialog"
-                          $size="default"
-                          aria-modal="true"
-                          forwardedRef={
-                            Object {
-                              "current": <div
-                                aria-modal="true"
-                                role="dialog"
-                                styled-component="true"
-                                tabindex="-1"
-                                test-style="[object Object]"
-                              >
-                                <div
-                                  styled-component="true"
-                                  test-style="[object Object]"
-                                >
-                                  Hello world
-                                </div>
-                                <div
-                                  styled-component="true"
-                                  test-style="[object Object]"
-                                >
-                                  Modal Body
-                                </div>
-                                <div
-                                  styled-component="true"
-                                  test-style="[object Object]"
-                                >
-                                  Footer
-                                </div>
-                                <button
-                                  aria-label="Close"
-                                  styled-component="true"
-                                  test-style="[object Object]"
-                                >
-                                  <svg
-                                    height="10"
-                                    style="stroke: currentColor;"
-                                    viewBox="0 0 10 10"
-                                    width="10"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                  >
-                                    <path
-                                      d="M9 1L5 5M1 9L5 5M5 5L1 1M5 5L9 9"
-                                      stroke-linecap="round"
-                                      stroke-width="2"
-                                    />
-                                  </svg>
-                                </button>
-                              </div>,
-                            }
-                          }
-                          role="dialog"
-                          tabIndex={-1}
-                        >
-                          <Portal>
-                            <ForwardRef>
-                              <MockStyledComponent
-                                forwardedRef={null}
-                              >
-                                <Portal />
-                              </MockStyledComponent>
-                            </ForwardRef>
-                            <ForwardRef>
-                              <MockStyledComponent
-                                forwardedRef={null}
-                              >
-                                <Portal />
-                              </MockStyledComponent>
-                            </ForwardRef>
-                            <ForwardRef>
-                              <MockStyledComponent
-                                forwardedRef={null}
-                              >
-                                <Portal />
-                              </MockStyledComponent>
-                            </ForwardRef>
-                            <ForwardRef
+                        <Portal>
+                          <ForwardRef>
+                            <MockStyledComponent
+                              forwardedRef={null}
+                            >
+                              <Portal />
+                            </MockStyledComponent>
+                          </ForwardRef>
+                          <ForwardRef>
+                            <MockStyledComponent
+                              forwardedRef={null}
+                            >
+                              <Portal />
+                            </MockStyledComponent>
+                          </ForwardRef>
+                          <ForwardRef>
+                            <MockStyledComponent
+                              forwardedRef={null}
+                            >
+                              <Portal />
+                            </MockStyledComponent>
+                          </ForwardRef>
+                          <ForwardRef
+                            $animate={true}
+                            $closeable={true}
+                            $isOpen={true}
+                            $isVisible={false}
+                            $role="dialog"
+                            $size="default"
+                            aria-label="Close"
+                            onClick={[Function]}
+                          >
+                            <MockStyledComponent
                               $animate={true}
                               $closeable={true}
                               $isOpen={true}
@@ -421,41 +410,30 @@ exports[`Modal renders portal when open: Rendered Modal 1`] = `
                               $role="dialog"
                               $size="default"
                               aria-label="Close"
+                              forwardedRef={null}
                               onClick={[Function]}
                             >
-                              <MockStyledComponent
-                                $animate={true}
-                                $closeable={true}
-                                $isOpen={true}
-                                $isVisible={false}
-                                $role="dialog"
-                                $size="default"
-                                aria-label="Close"
-                                forwardedRef={null}
-                                onClick={[Function]}
-                              >
-                                <Portal>
-                                  <CloseIcon>
-                                    <Portal>
-                                      <Portal />
-                                    </Portal>
-                                  </CloseIcon>
-                                </Portal>
-                              </MockStyledComponent>
-                            </ForwardRef>
-                          </Portal>
-                        </MockStyledComponent>
-                      </ForwardRef>
-                    </Portal>
-                  </MockStyledComponent>
-                </ForwardRef>
-              </Portal>
-            </MockStyledComponent>
-          </ForwardRef>
-        </Portal>
-        <Portal />
-      </FocusLock>
-    </FocusLockCombination>
+                              <Portal>
+                                <CloseIcon>
+                                  <Portal>
+                                    <Portal />
+                                  </Portal>
+                                </CloseIcon>
+                              </Portal>
+                            </MockStyledComponent>
+                          </ForwardRef>
+                        </Portal>
+                      </MockStyledComponent>
+                    </ForwardRef>
+                  </Portal>
+                </MockStyledComponent>
+              </ForwardRef>
+            </Portal>
+          </MockStyledComponent>
+        </ForwardRef>
+      </Portal>
+      <Portal />
+    </FocusLock>
   </mockConstructor>
 </Modal>
 `;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6256,11 +6256,6 @@ detect-newline@^2.1.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-2.1.0.tgz#f41f1c10be4b00e87b5f13da680759f2c5bfd3e2"
   integrity sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I=
 
-detect-node@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.4.tgz#014ee8f8f669c5c58023da64b8179c083a28c46c"
-  integrity sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw==
-
 detect-port-alt@1.1.6:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/detect-port-alt/-/detect-port-alt-1.1.6.tgz#24707deabe932d4a3cf621302027c2b266568275"
@@ -7599,7 +7594,7 @@ flush-write-stream@^1.0.0:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
 
-focus-lock@^0.6.4:
+focus-lock@^0.6.3:
   version "0.6.5"
   resolved "https://registry.yarnpkg.com/focus-lock/-/focus-lock-0.6.5.tgz#f6eb37832a9b1b205406175f5277396a28c0fce1"
   integrity sha512-i/mVBOoa9o+tl+u9owOJUF8k8L85odZNIsctB+JAK2HFT8jckiBwmk+3uydlm6FN8czgnkIwQtBv6yyAbrzXjw==
@@ -12432,7 +12427,7 @@ rc@^1.2.7, rc@~1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-clientside-effect@^1.2.1:
+react-clientside-effect@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.1.tgz#feb81abe9531061d4987941c15a00f2b3d0b6071"
   integrity sha512-foSwZatJak6r+F4OqJ8a+MOWcBi3jwa7/RPdJIDZI1Ck0dn/FJZkkFu7YK+SiZxsCZIrotolxHSobcnBHgIjfw==
@@ -12528,16 +12523,15 @@ react-error-overlay@^5.0.5:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-5.0.5.tgz#716ff1a92fda76bb89a39adf9ce046a5d740e71a"
   integrity sha512-ab0HWBgxdIsngHtMGU8+8gYFdTBXpUGd4AE4lN2VZvOIlBmWx9dtaWEViihuGSIGosCKPeHCnzFoRWB42UtnLg==
 
-react-focus-lock@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.0.0.tgz#01e570523f282b637390f45eb7f02f166f702f4b"
-  integrity sha512-Gz5O0z5MXSAElbZPmfjgmw4mM+QvcLH1o6ttmgk3YENqh4lmpksGbFceSV4aYXgPJ3zE48MhaTsDbHmn3OgDEw==
+react-focus-lock@^1.9.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-1.19.1.tgz#2f3429793edaefe2d077121f973ce5a3c7a0651a"
+  integrity sha512-TPpfiack1/nF4uttySfpxPk4rGZTLXlaZl7ncZg/ELAk24Iq2B1UUaUioID8H8dneUXqznT83JTNDHDj+kwryw==
   dependencies:
     "@babel/runtime" "^7.0.0"
-    focus-lock "^0.6.4"
+    focus-lock "^0.6.3"
     prop-types "^15.6.2"
-    react-clientside-effect "^1.2.1"
-    use-sidecar "^0.2.0"
+    react-clientside-effect "^1.2.0"
 
 react-fuzzy@^0.5.2:
   version "0.5.2"
@@ -14894,11 +14888,6 @@ tslib@^1.9.0:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
   integrity sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==
 
-tslib@^1.9.3:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.10.0.tgz#c3c19f95973fb0a62973fb09d90d961ee43e5c8a"
-  integrity sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==
-
 tty-aware-progress@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/tty-aware-progress/-/tty-aware-progress-1.0.3.tgz#93fbe86caf0d79c35f6e104e08f3a56c5069d3d6"
@@ -15257,14 +15246,6 @@ urlobj@0.0.11:
     is-object "^1.0.1"
     is-string "^1.0.4"
     object-assign "^4.1.1"
-
-use-sidecar@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/use-sidecar/-/use-sidecar-0.2.0.tgz#4a25c17ccd7d48b763dd6aff82ac36452ef973a5"
-  integrity sha512-Lc/ufC5jwasJwWx+NTDgXzzBCw86XIbydKRieE19auvu5D6nTqE6cz6TT9DNCtVnFprGoV3FzsAYVdc+uLQ0lA==
-  dependencies:
-    detect-node "^2.0.4"
-    tslib "^1.9.3"
 
 use@^3.1.0:
   version "3.1.1"


### PR DESCRIPTION
#### Description

In #1474 I introduced a new dependency, react-focus-lock. There is an issue on codesandbox where it cannot compile v2.0.0 of that library- v1.9.1 works so this PR downgrades to that version.

I opened an [issue](https://github.com/theKashey/react-focus-lock/issues/72) with the library to let them know.

Note, this fix is only to restore the codesandbox modal examples, which won't compile right now. Apps using 8.0.1 of baseui should not have any issues right now.

I'll need to release a new minor version after this PR to update the examples.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
