### PR TITLE
[WIP] feat(blog): add more metadata to blog posts

### DIFF
--- a/documentation-site/components/blog.js
+++ b/documentation-site/components/blog.js
@@ -62,14 +62,49 @@ const AuthorLink = styled('a', ({$theme}) => ({
   },
 }));
 
-const Date = styled('span', ({$theme}) => ({
+const ArticleDate = styled('span', ({$theme}) => ({
   color: $theme.colors.foregroundAlt,
 }));
 
-export const Meta = ({data: {title, tagline, author, authorLink, date}}) => (
+export const Meta = ({
+  data: {
+    title,
+    tagline,
+    author,
+    authorLink,
+    date,
+    coverImage,
+    coverImageWidth,
+    coverImageHeight,
+    keyWords = [],
+  },
+}) => (
   <React.Fragment>
     <Head>
-      <meta key="description" name="description" content={tagline} />
+      <meta property="og:title" content={title} name="title" />
+      <meta property="og:type" content="article" />
+      <meta
+        property="og:description"
+        content={tagline}
+        key="description"
+        name="description"
+      />
+      <meta property="article:author" content={author} name="author" />
+      {keyWords.map(kw => (
+        <meta property="article:tag" content={kw} key={`article:tag:${kw}`} />
+      ))}
+      <meta
+        property="article:published_time"
+        content={new Date(date).toISOString()}
+      />
+      <meta property="og:image" content={coverImage} />
+      {/* Best practice to specify these, but will usually work regardless. Ideal dimensions are 1200x630. */}
+      {coverImageWidth ? (
+        <meta property="og:image:width" content={coverImageWidth} />
+      ) : null}
+      {coverImageHeight ? (
+        <meta property="og:image:height" content={coverImageHeight} />
+      ) : null}
     </Head>
     <Block
       overrides={{
@@ -101,7 +136,7 @@ export const Meta = ({data: {title, tagline, author, authorLink, date}}) => (
         >
           {author}
         </AuthorLink>{' '}
-        <Date> - {date}</Date>
+        <ArticleDate> - {date}</ArticleDate>
       </Block>
     </Block>
   </React.Fragment>

--- a/documentation-site/pages/blog/base-web-v7/metadata.json
+++ b/documentation-site/pages/blog/base-web-v7/metadata.json
@@ -4,5 +4,8 @@
   "title": "What's changed in Base Web 7?",
   "tagline": "Let's take a look at all the changes Base Web 7 brings",
   "date": "10 May 2019",
-  "coverImage": "https://res.cloudinary.com/dawr8pobn/image/upload/c_scale,w_600/v1558459904/base-web-7_vpigth.png"
+  "coverImage": "https://res.cloudinary.com/dawr8pobn/image/upload/c_scale,w_600/v1558459904/base-web-7_vpigth.png",
+  "coverImageWidth": 600,
+  "coverImageHeight": 450,
+  "keyWords": ["Base Web", "Design System", "React", "Changelog"]
 }

--- a/documentation-site/pages/blog/base-web-v8/metadata.json
+++ b/documentation-site/pages/blog/base-web-v8/metadata.json
@@ -4,5 +4,8 @@
   "title": "Type checking improvements in V8",
   "tagline": "Reduce boilerplate and increase confidence with Base Web V8",
   "date": "24 June 2019",
-  "coverImage": "https://i.imgur.com/jK31J9H.png"
+  "coverImage": "https://i.imgur.com/jK31J9H.png",
+  "coverImageWidth": 1584,
+  "coverImageHeight": 1094,
+  "keyWords": ["Base Web", "Design System", "React", "Changelog"]
 }

--- a/documentation-site/pages/blog/getting-started-with-base-web/metadata.json
+++ b/documentation-site/pages/blog/getting-started-with-base-web/metadata.json
@@ -4,5 +4,8 @@
   "title": "Getting Started with Base Web",
   "tagline": "Let's build a password generator!",
   "date": "2 April 2019",
-  "coverImage": "https://cdn.dribbble.com/users/914217/screenshots/4615198/base_ui.png"
+  "coverImage": "https://cdn.dribbble.com/users/914217/screenshots/4615198/base_ui.png",
+  "coverImageWidth": 800,
+  "coverImageHeight": 600,
+  "keyWords": ["Design System", "React", "Tutorial"]
 }

--- a/documentation-site/pages/blog/getting-started-with-styletron/metadata.json
+++ b/documentation-site/pages/blog/getting-started-with-styletron/metadata.json
@@ -4,5 +4,8 @@
   "title": "Getting Started with Styletron",
   "tagline": "Let's build some buttons!",
   "date": "9 April 2019",
-  "coverImage": "https://images.unsplash.com/photo-1533915828531-55b274d98dc5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60"
+  "coverImage": "https://images.unsplash.com/photo-1533915828531-55b274d98dc5?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=500&q=60",
+  "coverImageWidth": 500,
+  "coverImageHeight": 375,
+  "keyWords": ["Styletron", "CSS", "CSS in JS", "Tutorial"]
 }

--- a/documentation-site/pages/blog/phone-input/metadata.json
+++ b/documentation-site/pages/blog/phone-input/metadata.json
@@ -4,5 +4,8 @@
   "title": "Building an International Phone Input",
   "tagline": "A new component exhibits the flexibility of Base Web",
   "date": "26 June 2019",
-  "coverImage": "https://images.unsplash.com/photo-1535483102974-fa1e64d0ca86?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=400&q=80"
+  "coverImage": "https://i.imgur.com/Q4M6njM.png",
+  "coverImageWidth": 1200,
+  "coverImageHeight": 630,
+  "keyWords": ["Design System", "React", "Phone Input", "Forms"]
 }


### PR DESCRIPTION
#### Description

This PR adds some more meta tags to the head of our blog posts. The main change is that each post's cover image will be used for sharing previews.

<img width="541" alt="Screen Shot 2019-06-28 at 10 44 04 AM" src="https://user-images.githubusercontent.com/1939257/60360914-ac356980-9991-11e9-81d3-16fcf2ed4945.png">

The main goal is to have more control over what scrapers will choose to use for share previews on social networking sites ([Facebook](https://developers.facebook.com/tools/debug/sharing), [Linkedin](https://www.linkedin.com/post-inspector/inspect/), etc). [OGP](http://ogp.me/) meta tags are the main way to control this.

---

While researching this I found [an article](https://iamturns.com/open-graph-image-size/) recommending cover images be `1200w630h` for sharing purposes.

Another best practice is to define the image height and width attributes explicitly as `og:image:width` and `og:image:height` properties. It doesn't seem to affect the result of the scrapers but it was universally recommended to include them so I added them as optional `metadata.json` keys just in case.



#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
