### PR TITLE
fix(phone-input): add disabled property to country select

### DIFF
--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -32,6 +32,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     maxDropdownWidth = DEFAULT_MAX_DROPDOWN_WIDTH,
     maxDropdownHeight = DEFAULT_MAX_DROPDOWN_HEIGHT,
     mapIsoToLabel,
+    disabled = false,
     overrides = {},
   } = props;
   const baseOverrides = {
@@ -105,6 +106,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
       <Select
         size={size}
         value={[country]}
+        disabled={disabled}
         onChange={event => {
           // After choosing a country, shift focus to the text input
           if (inputRef && inputRef.current) {

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -63,6 +63,7 @@ export type CountrySelectPropsT = {
   maxDropdownWidth?: string,
   maxDropdownHeight?: string,
   mapIsoToLabel?: mapIsoToLabelT,
+  disabled?: boolean,
   overrides: {
     DialCode?: OverrideT<*>,
     CountrySelect?: OverrideT<*>,
@@ -100,6 +101,8 @@ export type PropsT = {
   mapIsoToLabel?: mapIsoToLabelT,
   /** Defines the size of the text input. */
   size?: SizeT,
+  /** Renders component in 'disabled' state. */
+  disabled?: boolean,
   /** Defines a maximum dropdown height. The edge of the viewport will shrink the dropdown accordingly. */
   maxDropdownHeight?: string,
   /** Defines a maximum dropdown width. The edge of the viewport will shrink the dropdown accordingly. */


### PR DESCRIPTION
Fixes #1483 

#### Description

This PR makes the Country Select in the Phone Input respect a top level `disabled` prop.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
