### PR TITLE
feat(phone-input): flow & prop enhancements

### DIFF
--- a/src/phone-input/constants.js
+++ b/src/phone-input/constants.js
@@ -5,7 +5,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-// These are not used as of #1490. Leaving here until a future major so as not to break consumer code.
 export const DEFAULT_MAX_DROPDOWN_WIDTH = '400px';
 export const DEFAULT_MAX_DROPDOWN_HEIGHT = '400px';
 

--- a/src/phone-input/constants.js
+++ b/src/phone-input/constants.js
@@ -5,9 +5,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-export const DEFAULT_MAX_DROPDOWN_WIDTH = '400px';
-export const DEFAULT_MAX_DROPDOWN_HEIGHT = '400px';
-
 export const STATE_CHANGE_TYPE = {
   textChange: 'textChange',
   countryChange: 'countryChange',

--- a/src/phone-input/constants.js
+++ b/src/phone-input/constants.js
@@ -5,6 +5,10 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
+// These are not used as of #1490. Leaving here until a future major so as not to break consumer code.
+export const DEFAULT_MAX_DROPDOWN_WIDTH = '400px';
+export const DEFAULT_MAX_DROPDOWN_HEIGHT = '400px';
+
 export const STATE_CHANGE_TYPE = {
   textChange: 'textChange',
   countryChange: 'countryChange',

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 import {List, AutoSizer} from 'react-virtualized';
 
-import {DEFAULT_MAX_DROPDOWN_HEIGHT} from './constants.js';
+import defaultProps from './default-props.js';
 import {
   StyledFlag,
   StyledCountrySelectDropdownContainer as DefaultContainer,
@@ -22,87 +22,97 @@ import {getOverrides} from '../helpers/overrides.js';
 
 import type {CountrySelectDropdownPropsT} from './types.js';
 
-// $FlowFixMe
-const CountrySelectDropdown = React.forwardRef(
-  (props: CountrySelectDropdownPropsT, ref) => {
-    const {
-      children,
-      maxDropdownHeight = DEFAULT_MAX_DROPDOWN_HEIGHT,
-      mapIsoToLabel,
-      country,
-      overrides = {},
-    } = props;
-    const [Container, containerProps] = getOverrides(
-      overrides.CountrySelectDropdown,
-      DefaultContainer,
-    );
-    const [ListItem, listItemProps] = getOverrides(
-      overrides.CountrySelectDropdownListItem,
-      DefaultListItem,
-    );
-    const [FlagColumn, flagColumnProps] = getOverrides(
-      overrides.CountrySelectDropdownFlagColumn,
-      DefaultFlagColumn,
-    );
-    const [NameColumn, nameColumnProps] = getOverrides(
-      overrides.CountrySelectDropdownNameColumn,
-      DefaultNameColumn,
-    );
-    const [Dialcode, dialcodeProps] = getOverrides(
-      overrides.CountrySelectDropdownDialcodeColumn,
-      DefaultDialcodeColumn,
-    );
-    const scrollIndex = Math.min(
-      children.findIndex(opt => opt.props.item.id === country.id) + 5,
-      children.length - 1,
-    );
-    return (
-      <Container ref={ref} $height={maxDropdownHeight} {...containerProps}>
-        <AutoSizer>
-          {({height, width}) => {
-            return (
-              <List
-                role="listbox"
-                height={height}
-                width={width}
-                rowCount={children.length}
-                rowHeight={42}
-                scrollToIndex={scrollIndex}
-                rowRenderer={({index, key, style}) => {
-                  // resetMenu and getItemLabel should not end up on native html elements
-                  const {resetMenu, getItemLabel, ...rest} = children[
-                    index
-                  ].props;
-                  return (
-                    <ListItem
-                      key={key}
-                      style={style}
-                      {...rest}
-                      {...listItemProps}
-                      data-e2e="country-select-list-item"
-                      data-iso={children[index].props.item.id}
-                    >
-                      <FlagColumn {...flagColumnProps}>
-                        <StyledFlag iso={children[index].props.item.id} />
-                      </FlagColumn>
-                      <NameColumn {...nameColumnProps}>
-                        {mapIsoToLabel
-                          ? mapIsoToLabel(props.children[index].props.item.id)
-                          : children[index].props.item.label}
-                      </NameColumn>
-                      <Dialcode {...dialcodeProps}>
-                        {children[index].props.item.dialCode}
-                      </Dialcode>
-                    </ListItem>
-                  );
-                }}
-              />
-            );
-          }}
-        </AutoSizer>
-      </Container>
-    );
-  },
-);
+CountrySelectDropdown.defaultProps = {
+  maxDropdownHeight: defaultProps.maxDropdownHeight,
+  overrides: {},
+};
 
-export default CountrySelectDropdown;
+function CountrySelectDropdown(props: CountrySelectDropdownPropsT) {
+  const {
+    children,
+    containerRef,
+    country,
+    overrides,
+    maxDropdownHeight,
+    mapIsoToLabel,
+  } = props;
+  const [Container, containerProps] = getOverrides(
+    overrides.CountrySelectDropdown,
+    DefaultContainer,
+  );
+  const [ListItem, listItemProps] = getOverrides(
+    overrides.CountrySelectDropdownListItem,
+    DefaultListItem,
+  );
+  const [FlagColumn, flagColumnProps] = getOverrides(
+    overrides.CountrySelectDropdownFlagColumn,
+    DefaultFlagColumn,
+  );
+  const [NameColumn, nameColumnProps] = getOverrides(
+    overrides.CountrySelectDropdownNameColumn,
+    DefaultNameColumn,
+  );
+  const [Dialcode, dialcodeProps] = getOverrides(
+    overrides.CountrySelectDropdownDialcodeColumn,
+    DefaultDialcodeColumn,
+  );
+  const scrollIndex = Math.min(
+    children.findIndex(opt => opt.props.item.id === country.id) + 5,
+    children.length - 1,
+  );
+  return (
+    <Container
+      ref={containerRef}
+      $height={maxDropdownHeight}
+      {...containerProps}
+    >
+      <AutoSizer>
+        {({height, width}) => {
+          return (
+            <List
+              role="listbox"
+              height={height}
+              width={width}
+              rowCount={children.length}
+              rowHeight={42}
+              scrollToIndex={scrollIndex}
+              rowRenderer={({index, key, style}) => {
+                // resetMenu and getItemLabel should not end up on native html elements
+                const {resetMenu, getItemLabel, ...rest} = children[
+                  index
+                ].props;
+                return (
+                  <ListItem
+                    key={key}
+                    style={style}
+                    {...rest}
+                    {...listItemProps}
+                    data-e2e="country-select-list-item"
+                    data-iso={children[index].props.item.id}
+                  >
+                    <FlagColumn {...flagColumnProps}>
+                      <StyledFlag iso={children[index].props.item.id} />
+                    </FlagColumn>
+                    <NameColumn {...nameColumnProps}>
+                      {mapIsoToLabel
+                        ? mapIsoToLabel(props.children[index].props.item.id)
+                        : children[index].props.item.label}
+                    </NameColumn>
+                    <Dialcode {...dialcodeProps}>
+                      {children[index].props.item.dialCode}
+                    </Dialcode>
+                  </ListItem>
+                );
+              }}
+            />
+          );
+        }}
+      </AutoSizer>
+    </Container>
+  );
+}
+
+export default React.forwardRef<
+  CountrySelectDropdownPropsT,
+  typeof CountrySelectDropdown,
+>((props, ref) => <CountrySelectDropdown {...props} containerRef={ref} />);

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -30,7 +30,7 @@ CountrySelectDropdown.defaultProps = {
 function CountrySelectDropdown(props: CountrySelectDropdownPropsT) {
   const {
     children,
-    containerRef,
+    forwardedRef,
     country,
     overrides,
     maxDropdownHeight,
@@ -62,7 +62,7 @@ function CountrySelectDropdown(props: CountrySelectDropdownPropsT) {
   );
   return (
     <Container
-      ref={containerRef}
+      ref={forwardedRef}
       $height={maxDropdownHeight}
       {...containerProps}
     >
@@ -115,4 +115,4 @@ function CountrySelectDropdown(props: CountrySelectDropdownPropsT) {
 export default React.forwardRef<
   CountrySelectDropdownPropsT,
   typeof CountrySelectDropdown,
->((props, ref) => <CountrySelectDropdown {...props} containerRef={ref} />);
+>((props, ref) => <CountrySelectDropdown {...props} forwardedRef={ref} />);

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -6,7 +6,7 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 
-import React from 'react';
+import * as React from 'react';
 import {List, AutoSizer} from 'react-virtualized';
 
 import defaultProps from './default-props.js';
@@ -27,7 +27,9 @@ CountrySelectDropdown.defaultProps = {
   overrides: {},
 };
 
-function CountrySelectDropdown(props: CountrySelectDropdownPropsT) {
+function CountrySelectDropdown(
+  props: CountrySelectDropdownPropsT & {forwardedRef: React.ElementRef<*>},
+) {
   const {
     children,
     forwardedRef,

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -9,31 +9,36 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 
 import {StyledRoot, StyledFlag, StyledDialCode} from './styled-components.js';
-import {
-  SIZE,
-  COUNTRIES,
-  DEFAULT_MAX_DROPDOWN_HEIGHT,
-  DEFAULT_MAX_DROPDOWN_WIDTH,
-} from './constants.js';
+import {COUNTRIES} from './constants.js';
 import CountrySelectDropdown from './country-select-dropdown.js';
 import {Block} from '../block/index.js';
 import {Select as DefaultSelect} from '../select/index.js';
 import {PLACEMENT} from '../popover/index.js';
 import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
+import defaultProps from './default-props.js';
 
 import type {CountryT, CountrySelectPropsT} from './types.js';
+
+CountrySelect.defaultProps = {
+  disabled: defaultProps.disabled,
+  inputRef: null,
+  maxDropdownHeight: defaultProps.maxDropdownHeight,
+  maxDropdownWidth: defaultProps.maxDropdownWidth,
+  overrides: {},
+  size: defaultProps.size,
+};
 
 export default function CountrySelect(props: CountrySelectPropsT) {
   const {
     country,
+    disabled,
     inputRef,
-    onCountryChange = event => {},
-    size = SIZE.default,
-    maxDropdownWidth = DEFAULT_MAX_DROPDOWN_WIDTH,
-    maxDropdownHeight = DEFAULT_MAX_DROPDOWN_HEIGHT,
+    maxDropdownHeight,
+    maxDropdownWidth,
     mapIsoToLabel,
-    disabled = false,
-    overrides = {},
+    onCountryChange,
+    overrides,
+    size,
   } = props;
   const baseOverrides = {
     Root: {
@@ -108,11 +113,11 @@ export default function CountrySelect(props: CountrySelectPropsT) {
         value={[country]}
         disabled={disabled}
         onChange={event => {
+          onCountryChange(event);
           // After choosing a country, shift focus to the text input
           if (inputRef && inputRef.current) {
             inputRef.current.focus();
           }
-          onCountryChange(event);
         }}
         options={Object.values(COUNTRIES)}
         clearable={false}

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -5,7 +5,12 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-import {SIZE, COUNTRIES} from './constants.js';
+import {
+  SIZE,
+  COUNTRIES,
+  DEFAULT_MAX_DROPDOWN_HEIGHT,
+  DEFAULT_MAX_DROPDOWN_WIDTH,
+} from './constants.js';
 
 const defaultProps = {
   'aria-label': 'Please choose a country dial code and enter a phone number.',
@@ -16,8 +21,8 @@ const defaultProps = {
   disabled: false,
   error: false,
   id: null,
-  maxDropdownHeight: '400px',
-  maxDropdownWidth: '400px',
+  maxDropdownHeight: DEFAULT_MAX_DROPDOWN_HEIGHT,
+  maxDropdownWidth: DEFAULT_MAX_DROPDOWN_WIDTH,
   name: null,
   onCountryChange: () => {},
   onTextChange: () => {},

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 import {SIZE, COUNTRIES} from './constants.js';
 
 const defaultProps = {
-  'aria-label': null,
+  'aria-label': 'Please choose a country dial code and enter a phone number.',
   'aria-describedby': null,
   'aria-labelledby': null,
   autoFocus: false,

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -23,6 +23,7 @@ const defaultProps = {
   onTextChange: () => {},
   overrides: {},
   positive: false,
+  required: false,
   size: SIZE.default,
   text: '',
 };

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -15,13 +15,15 @@ const defaultProps = {
   country: COUNTRIES.US,
   disabled: false,
   error: false,
-  positive: false,
-  size: SIZE.default,
+  id: null,
   maxDropdownHeight: '400px',
   maxDropdownWidth: '400px',
+  name: null,
   onCountryChange: () => {},
   onTextChange: () => {},
   overrides: {},
+  positive: false,
+  size: SIZE.default,
   text: '',
 };
 

--- a/src/phone-input/default-props.js
+++ b/src/phone-input/default-props.js
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import {SIZE, COUNTRIES} from './constants.js';
+
+const defaultProps = {
+  'aria-label': null,
+  'aria-describedby': null,
+  'aria-labelledby': null,
+  autoFocus: false,
+  country: COUNTRIES.US,
+  disabled: false,
+  error: false,
+  positive: false,
+  size: SIZE.default,
+  maxDropdownHeight: '400px',
+  maxDropdownWidth: '400px',
+  onCountryChange: () => {},
+  onTextChange: () => {},
+  overrides: {},
+  text: '',
+};
+
+export default defaultProps;

--- a/src/phone-input/phone-input.js
+++ b/src/phone-input/phone-input.js
@@ -5,24 +5,29 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-
 import React, {useRef} from 'react';
-
 import {Input as DefaultInput} from '../input/index.js';
-import {SIZE} from './constants.js';
 import CountrySelect from './country-select.js';
 import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
-
+import defaultProps from './default-props.js';
 import type {PropsT} from './types.js';
+
+PhoneInput.defaultProps = defaultProps;
 
 export default function PhoneInput(props: PropsT) {
   const {
-    text,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
+    country,
+    disabled,
+    error,
     onTextChange,
-    overrides = {},
-    'aria-label': ariaLabel = 'Please choose a country dial code and enter a phone number.',
-    size = SIZE.default,
-    ...restProps
+    onCountryChange,
+    overrides,
+    positive,
+    size,
+    text,
   } = props;
   const inputRef = useRef(null);
   const baseOverrides = {
@@ -32,8 +37,10 @@ export default function PhoneInput(props: PropsT) {
     Before: {
       component: CountrySelect,
       props: {
-        ...props,
+        country,
         inputRef,
+        onCountryChange,
+        size,
       },
     },
   };
@@ -41,16 +48,20 @@ export default function PhoneInput(props: PropsT) {
   const inputOverrides = mergeOverrides(baseOverrides, overrides);
   return (
     <Input
-      type="tel"
-      autoComplete="tel"
-      value={text}
       aria-label={ariaLabel}
-      onChange={onTextChange}
+      aria-labelledby={ariaLabelledBy}
+      aria-describedby={ariaDescribedBy}
+      autoComplete="tel"
       data-baseweb="phone-input"
-      size={size}
+      disabled={disabled}
+      error={error}
       inputRef={inputRef}
+      type="tel"
+      onChange={onTextChange}
       overrides={inputOverrides}
-      {...restProps}
+      positive={positive}
+      size={size}
+      value={text}
       {...inputProps}
     />
   );

--- a/src/phone-input/phone-input.js
+++ b/src/phone-input/phone-input.js
@@ -22,9 +22,12 @@ export default function PhoneInput(props: PropsT) {
     country,
     disabled,
     error,
+    id,
+    name,
     onTextChange,
     onCountryChange,
     overrides,
+    placeholder,
     positive,
     size,
     text,
@@ -38,6 +41,7 @@ export default function PhoneInput(props: PropsT) {
       component: CountrySelect,
       props: {
         country,
+        disabled,
         inputRef,
         onCountryChange,
         size,
@@ -55,12 +59,15 @@ export default function PhoneInput(props: PropsT) {
       data-baseweb="phone-input"
       disabled={disabled}
       error={error}
+      id={id}
       inputRef={inputRef}
-      type="tel"
+      name={name}
       onChange={onTextChange}
       overrides={inputOverrides}
       positive={positive}
+      placeholder={placeholder}
       size={size}
+      type="tel"
       value={text}
       {...inputProps}
     />

--- a/src/phone-input/phone-input.js
+++ b/src/phone-input/phone-input.js
@@ -31,6 +31,7 @@ export default function PhoneInput(props: PropsT) {
     positive,
     size,
     text,
+    ...restProps
   } = props;
   const inputRef = useRef(null);
   const baseOverrides = {
@@ -70,6 +71,7 @@ export default function PhoneInput(props: PropsT) {
       type="tel"
       value={text}
       {...inputProps}
+      {...restProps}
     />
   );
 }

--- a/src/phone-input/stateful-phone-input-container.js
+++ b/src/phone-input/stateful-phone-input-container.js
@@ -7,29 +7,28 @@ LICENSE file in the root directory of this source tree.
 // @flow
 import React from 'react';
 import {COUNTRIES, STATE_CHANGE_TYPE} from './constants.js';
-
 import type {
-  StatefulPhoneInputContainerPropsT,
+  StatefulContainerPropsT,
   StateT,
   StateReducerT,
   StateChangeT,
 } from './types.js';
+import defaultProps from './default-props.js';
 import type {OnChangeParamsT} from '../select/types.js';
 
 const defaultStateReducer: StateReducerT = (type, nextState) => nextState;
 
 export default class StatefulPhoneInputContainer extends React.Component<
-  StatefulPhoneInputContainerPropsT,
+  StatefulContainerPropsT,
   StateT,
 > {
   static defaultProps = {
     initialState: {
-      text: '',
-      country: COUNTRIES.US,
+      text: defaultProps.text,
+      country: defaultProps.country,
     },
-    onTextChange: () => {},
-    onCountryChange: () => {},
-    onClear: () => {},
+    onTextChange: defaultProps.onTextChange,
+    onCountryChange: defaultProps.onTextChange,
     stateReducer: defaultStateReducer,
     overrides: {},
   };
@@ -58,9 +57,10 @@ export default class StatefulPhoneInputContainer extends React.Component<
 
   render() {
     const {children, initialState, stateReducer, ...restProps} = this.props;
+    // $FlowFixMe
     return children({
-      ...this.state,
       ...restProps,
+      ...this.state,
       onTextChange: this.onTextChange,
       onCountryChange: this.onCountryChange,
     });

--- a/src/phone-input/stateful-phone-input-container.js
+++ b/src/phone-input/stateful-phone-input-container.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 import {COUNTRIES, STATE_CHANGE_TYPE} from './constants.js';
 import type {
-  StatefulContainerPropsT,
+  StatefulPhoneInputContainerPropsT,
   StateT,
   StateReducerT,
   StateChangeT,
@@ -19,7 +19,7 @@ import type {OnChangeParamsT} from '../select/types.js';
 const defaultStateReducer: StateReducerT = (type, nextState) => nextState;
 
 export default class StatefulPhoneInputContainer extends React.Component<
-  StatefulContainerPropsT,
+  StatefulPhoneInputContainerPropsT,
   StateT,
 > {
   static defaultProps = {

--- a/src/phone-input/stateful-phone-input-container.js
+++ b/src/phone-input/stateful-phone-input-container.js
@@ -57,8 +57,8 @@ export default class StatefulPhoneInputContainer extends React.Component<
 
   render() {
     const {children, initialState, stateReducer, ...restProps} = this.props;
-    // $FlowFixMe
     return children({
+      ...defaultProps,
       ...restProps,
       ...this.state,
       onTextChange: this.onTextChange,

--- a/src/phone-input/stateful-phone-input.js
+++ b/src/phone-input/stateful-phone-input.js
@@ -5,12 +5,13 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-
 import React from 'react';
 import StatefulPhoneInputContainer from './stateful-phone-input-container.js';
 import PhoneInput from './phone-input.js';
-
+import defaultProps from './default-props.js';
 import type {PropsT, StatefulPhoneInputPropsT} from './types.js';
+
+StatefulPhoneInput.defaultProps = defaultProps;
 
 export default function StatefulPhoneInput(props: StatefulPhoneInputPropsT) {
   return (

--- a/src/phone-input/styled-components.js
+++ b/src/phone-input/styled-components.js
@@ -7,15 +7,18 @@ LICENSE file in the root directory of this source tree.
 // @flow
 
 import Flag from './flag.js';
-import {DEFAULT_MAX_DROPDOWN_HEIGHT, SIZE} from './constants.js';
+import {SIZE} from './constants.js';
 import {styled, withStyle} from '../styles/index.js';
 import {StyledList} from '../menu/index.js';
 import {
   StyledDropdownListItem,
   StyledRoot as SelectStyledRoot,
 } from '../select/index.js';
+import defaultProps from '../select/default-props.js';
 
-type SizeStyleProps = {$size?: $Keys<typeof SIZE>};
+type SizeStyleProps = {
+  $size?: $Keys<typeof SIZE>,
+};
 type HeightStyleProps = {$height: string};
 
 export const StyledFlag = styled<typeof Flag, SizeStyleProps>(
@@ -56,7 +59,7 @@ export const StyledCountrySelectDropdownContainer = withStyle<
   typeof StyledList,
   HeightStyleProps,
 >(StyledList, props => {
-  const {$height = DEFAULT_MAX_DROPDOWN_HEIGHT} = props;
+  const {$height = defaultProps.maxDropdownHeight} = props;
   return {
     height: $height,
     paddingTop: 0,

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -52,7 +52,6 @@ export type CountrySelectDropdownPropsT = {
     CountrySelectDropdownNameColumn?: OverrideT<*>,
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
   },
-  forwardedRef: React.ElementRef<*>,
 };
 
 export type CountrySelectPropsT = {

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -121,7 +121,7 @@ export type PropsT = {
   text: string,
 };
 
-export type StatefulContainerPropsT = {
+export type StatefulPhoneInputContainerPropsT = {
   children: PropsT => React.Node,
   initialState: StateT,
   stateReducer: StateReducerT,

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -52,7 +52,7 @@ export type CountrySelectDropdownPropsT = {
     CountrySelectDropdownNameColumn?: OverrideT<*>,
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
   },
-  containerRef: React.ElementRef<*>,
+  forwardedRef: React.ElementRef<*>,
 };
 
 export type CountrySelectPropsT = {

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -88,12 +88,16 @@ export type PropsT = {
   disabled: boolean,
   /** Renders component in 'error' state. */
   error: boolean,
+  /** Sets the id attribute of the input element. */
+  id: ?string,
   /** Sets the max height of the country select dropdown. */
   maxDropdownHeight: string,
   /** Sets the max width of the country select dropdown. */
   maxDropdownWidth: string,
   /** Function for mapping ISO codes to country names. Useful for localization of the country select dropdown. */
   mapIsoToLabel?: mapIsoToLabelT,
+  /** Sets the name attribute of the input element. */
+  name: ?string,
   /** A handler for the country select's change events. */
   onCountryChange: (event: OnChangeParamsT) => mixed,
   /** A handler for the input element's change events. */

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -115,6 +115,8 @@ export type PropsT = {
   placeholder?: string,
   /** Renders component in 'positive' state. */
   positive: boolean,
+  /** Sets the 'required' attribute of the input element. The country select will always have a value so does has no need for 'require'. */
+  required: boolean,
   /** Sets the size of the component. */
   size: SizeT,
   /** Defines the value of the input element. */

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -5,11 +5,8 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-
 import * as React from 'react';
-
 import {STATE_CHANGE_TYPE, SIZE, COUNTRIES} from './constants.js';
-
 import type {OverrideT} from '../helpers/overrides.js';
 import type {OnChangeParamsT} from '../select/types.js';
 
@@ -18,16 +15,16 @@ export type SizeT = $Keys<typeof SIZE>;
 export type CountryIsoT = $Keys<typeof COUNTRIES>;
 
 export type CountryT = $ReadOnly<{
+  dialCode: string,
   id: CountryIsoT,
   label: string,
-  dialCode: string,
 }>;
 
 export type CountriesT = $ReadOnly<CountryT>;
 
 export type StateT = {
-  text: string,
   country: CountryT,
+  text: string,
 };
 
 export type StateChangeT = $Keys<typeof STATE_CHANGE_TYPE>;
@@ -40,12 +37,14 @@ export type StateReducerT = (
 
 export type mapIsoToLabelT = (iso: string) => string;
 
+// Props
+
 export type CountrySelectDropdownPropsT = {
   // eslint-disable-next-line flowtype/no-weak-types
   children: $ReadOnlyArray<React.Element<any>>,
   country: CountryT,
-  maxDropdownHeight: string,
   mapIsoToLabel?: mapIsoToLabelT,
+  maxDropdownHeight: string,
   overrides: {
     CountrySelectDropdown?: OverrideT<*>,
     CountrySelectDropdownListItem?: OverrideT<*>,
@@ -53,82 +52,83 @@ export type CountrySelectDropdownPropsT = {
     CountrySelectDropdownNameColumn?: OverrideT<*>,
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
   },
+  containerRef: React.ElementRef<*>,
 };
 
 export type CountrySelectPropsT = {
   country: CountryT,
+  disabled: boolean,
   inputRef: {current: HTMLInputElement | null},
-  onCountryChange?: (event: OnChangeParamsT) => mixed,
-  size?: SizeT,
-  maxDropdownWidth?: string,
-  maxDropdownHeight?: string,
+  onCountryChange: (event: OnChangeParamsT) => mixed,
   mapIsoToLabel?: mapIsoToLabelT,
-  disabled?: boolean,
+  maxDropdownHeight: string,
+  maxDropdownWidth: string,
   overrides: {
-    DialCode?: OverrideT<*>,
-    CountrySelect?: OverrideT<*>,
     CountrySelectDropdown?: OverrideT<*>,
     CountrySelectDropdownListItem?: OverrideT<*>,
     CountrySelectDropdownFlagColumn?: OverrideT<*>,
     CountrySelectDropdownNameColumn?: OverrideT<*>,
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
+    DialCode?: OverrideT<*>,
+    CountrySelect?: OverrideT<*>,
   },
-};
-
-export type OverridesT = {
-  Input?: OverrideT<*>,
-  DialCode?: OverrideT<*>,
-  CountrySelect?: OverrideT<*>,
-  CountrySelectDropdown?: OverrideT<*>,
-  CountrySelectDropdownListItem?: OverrideT<*>,
-  CountrySelectDropdownFlagColumn?: OverrideT<*>,
-  CountrySelectDropdownNameColumn?: OverrideT<*>,
-  CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
+  size: SizeT,
 };
 
 export type PropsT = {
-  /** Sets aria-label attribute. */
+  /** Sets aria-label attribute of the input element. */
   'aria-label': ?string,
-  /** Current input text value. Note, this should include the dial code of the selected country. */
-  text: string,
-  /** Current selected country value. Note, this expects an entire CountryT object. */
+  /** Sets aria-labelledby attribute of the input element. */
+  'aria-labelledby': ?string,
+  /** Sets aria-describedby attribute of the input element. */
+  'aria-describedby': ?string,
+  /** Defines the value of the country select. */
   country: CountryT,
-  /** Change handler of the text input to be called when a value is changed. */
-  onTextChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
-  /** Change handler of the country select to be called when a value is changed. */
-  onCountryChange: (event: OnChangeParamsT) => mixed,
-  /** A function that can be used to map iso codes to localized country names */
+  /** Defines if the component is disabled. */
+  disabled: boolean,
+  /** Renders component in 'error' state. */
+  error: boolean,
+  /** Sets the max height of the country select dropdown. */
+  maxDropdownHeight: string,
+  /** Sets the max width of the country select dropdown. */
+  maxDropdownWidth: string,
+  /** Function for mapping ISO codes to country names. Useful for localization of the country select dropdown. */
   mapIsoToLabel?: mapIsoToLabelT,
-  /** Defines the size of the text input. */
-  size?: SizeT,
-  /** Renders component in 'disabled' state. */
-  disabled?: boolean,
-  /** Defines a maximum dropdown height. The edge of the viewport will shrink the dropdown accordingly. */
-  maxDropdownHeight?: string,
-  /** Defines a maximum dropdown width. The edge of the viewport will shrink the dropdown accordingly. */
-  maxDropdownWidth?: string,
-  overrides?: OverridesT,
+  /** A handler for the country select's change events. */
+  onCountryChange: (event: OnChangeParamsT) => mixed,
+  /** A handler for the input element's change events. */
+  onTextChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
+  overrides: {
+    Input?: OverrideT<*>,
+    CountrySelectDropdown?: OverrideT<*>,
+    CountrySelectDropdownListItem?: OverrideT<*>,
+    CountrySelectDropdownFlagColumn?: OverrideT<*>,
+    CountrySelectDropdownNameColumn?: OverrideT<*>,
+    CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
+    DialCode?: OverrideT<*>,
+    CountrySelect?: OverrideT<*>,
+  },
+  /** Sets the placeholder text for the input element.  */
+  placeholder?: string,
+  /** Renders component in 'positive' state. */
+  positive: boolean,
+  /** Sets the size of the component. */
+  size: SizeT,
+  /** Defines the value of the input element. */
+  text: string,
 };
 
-export type StatefulPhoneInputContainerPropsT = {
-  /** Sets aria-label attribute. */
-  'aria-label': ?string,
+export type StatefulContainerPropsT = {
   children: PropsT => React.Node,
   initialState: StateT,
   stateReducer: StateReducerT,
   onTextChange: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
   onCountryChange: (event: OnChangeParamsT) => mixed,
-  mapIsoToLabel?: mapIsoToLabelT,
-  overrides: OverridesT,
 };
 
-export type StatefulPhoneInputPropsT = {
-  /** Sets aria-label attribute. */
-  'aria-label'?: string,
+export type StatefulPhoneInputPropsT = PropsT & {
   initialState?: StateT,
   stateReducer?: StateReducerT,
   onTextChange?: (event: SyntheticInputEvent<HTMLInputElement>) => mixed,
   onCountryChange?: (event: OnChangeParamsT) => mixed,
-  mapIsoToLabel?: mapIsoToLabelT,
-  overrides?: OverridesT,
 };


### PR DESCRIPTION
#### Description

This PR reorganizes the flow types for the phone input a bit.

It _shouldn't_ be breaking even though I've made some properties required. I added defaults in defaultProps to make up for those but there may be some other issues I've overlooked.

After hooking up the disabled property in #1487, I noticed that the types were a bit messy and inconsistent with some patterns elsewhere. I also wanted to make the types a bit more explicit about which props were actually accepted and used.

Previously I was just spreading everything the phone input didn't use over the inner input element- but it feels better to be intentional about what is passed through and makes for better documentation. I don't think the phone input should just proxy every prop input accepts - that is what overrides are for.


#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
