### PR TITLE
fix(docs): update example for the resizable textarea with restrictions

### DIFF
--- a/documentation-site/static/examples/textarea/resizable.js
+++ b/documentation-site/static/examples/textarea/resizable.js
@@ -3,13 +3,21 @@ import {StatefulTextarea as Textarea} from 'baseui/textarea';
 
 export default () => (
   <Textarea
-    placeholder="Resizable > 100px & < 300px"
+    placeholder="Resizable: 100px<height<300px 300px<width<100%"
     overrides={{
       Input: {
         style: {
           maxHeight: '300px',
           minHeight: '100px',
+          minWidth: '300px',
+          width: '100vw', //fill all available space up to parent max-width
           resize: 'both',
+        },
+      },
+      InputContainer: {
+        style: {
+          maxWidth: '100%',
+          width: 'min-content',
         },
       },
     }}


### PR DESCRIPTION
Fixes #1466 <!-- remove the (`) quotes to link the issues -->

#### Description
The outer container aligns in both dimensions `height` and `width` with resizable textaera.
<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
