### PR TITLE
fix(button-group): handles one button in group

### DIFF
--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -68,6 +68,13 @@ export function ButtonGroupRoot(props: {|...PropsT, ...LocaleT|}) {
           overrides: {
             BaseButton: {
               style: () => {
+                // Even though baseui's buttons have square corners, some applications override to
+                // rounded. Maintaining corner radius in this circumstance is ideal to avoid further
+                // customization.
+                if (props.children.length === 1) {
+                  return {};
+                }
+
                 // left most button
                 if (index === 0) {
                   return {


### PR DESCRIPTION
#### Description

does not apply corner styles if only one button is in group

#### Scope

- [x] Patch: Bug Fix
