### PR TITLE
fix(docs-site): update example to include base provider

### DIFF
--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -26,6 +26,7 @@ const index = `
 import React from "react";
 import ReactDOM from "react-dom";
 
+import {BaseProvider, LightTheme} from 'baseui';
 import { Provider as StyletronProvider } from "styletron-react";
 import { Client as Styletron } from "styletron-engine-atomic";
 
@@ -40,7 +41,9 @@ function App() {
 const rootElement = document.getElementById("root");
 ReactDOM.render(
   <StyletronProvider value={engine}>
-    <App />
+    <BaseProvider theme={LightTheme}>
+      <App />
+    </BaseProvider>
   </StyletronProvider>,
   rootElement
 );


### PR DESCRIPTION
### Description

Portal divs were not being cleaned up in codesandbox because the app was not wrapped in the new `BaseProvider` component. This issue only came up in codesandbox because we neglected to update that part of the code when the new context provider was created. Was interesting to track the issue down because we configured the scenarios and doc site correctly 

#### Scope

- [x] Patch: Bug Fix