### PR TITLE
fix(codemod): update codemod to handle styled calls with existing generics

### DIFF
--- a/src/codemods/__testfixtures__/styled-flowfixme-existing-generics.input.js
+++ b/src/codemods/__testfixtures__/styled-flowfixme-existing-generics.input.js
@@ -1,0 +1,3 @@
+// @flow
+import {styled} from 'baseui';
+const Component = styled<{}>('div', {color: 'red'});

--- a/src/codemods/__testfixtures__/styled-flowfixme-existing-generics.output.js
+++ b/src/codemods/__testfixtures__/styled-flowfixme-existing-generics.output.js
@@ -1,0 +1,3 @@
+// @flow
+import {styled} from 'baseui';
+const Component = styled<{}>('div', {color: 'red'});

--- a/src/codemods/__tests__/styled-flowfixme-test.js
+++ b/src/codemods/__tests__/styled-flowfixme-test.js
@@ -19,6 +19,13 @@ describe('styled-flowfixme', () => {
     'styled-flowfixme-baseui-import',
   );
 
+  defineTest(
+    __dirname,
+    'styled-flowfixme',
+    null,
+    'styled-flowfixme-existing-generics',
+  );
+
   defineTest(__dirname, 'styled-flowfixme', null, 'styled-flowfixme-flow');
   defineTest(__dirname, 'styled-flowfixme', null, 'styled-flowfixme-no-flow');
   defineTest(__dirname, 'styled-flowfixme', null, 'styled-flowfixme-renamed');

--- a/src/codemods/styled-flowfixme.js
+++ b/src/codemods/styled-flowfixme.js
@@ -35,9 +35,10 @@ module.exports = function(file, api, options) {
     if (styledImportName) {
       const comment = j.commentLine(' $FlowFixMe', true, false);
       const styledComponents = root.find(j.VariableDeclaration).filter(path => {
-        const calls = j(path).find(j.CallExpression, {
-          callee: {name: styledImportName},
-        });
+        const calls = j(path)
+          .find(j.CallExpression, {callee: {name: styledImportName}})
+          // ignore styled calls that already include call expression generics
+          .filter(call => !call.node.typeArguments);
         return Boolean(calls.length);
       });
 


### PR DESCRIPTION
#### Description

v7 codemod now handles the case where `styled` call already has type annotations

#### Scope

- [x] Patch: Bug Fix
