### PR TITLE
fix(build): esm mapping

### DIFF
--- a/scripts/build-package-json.js
+++ b/scripts/build-package-json.js
@@ -21,12 +21,21 @@ const packageJson = require('../package.json');
 
 async function run() {
   const files = await asyncRecursive(path.resolve(__dirname, '../dist/esm'));
-  const projectRelativePaths = files.map(file => file.split('dist/esm')[1]);
+  const indexFiles = files.filter(file => file.includes('index.js'));
+  const projectRelativePaths = indexFiles
+    .map(file => file.split('dist/esm')[1])
+    .map(file => file.slice(1))
+    .filter(file => file.split('/').length === 2);
 
-  const modules = projectRelativePaths.reduce((acc, current) => {
-    acc[current] = `/esm${current}`;
-    return acc;
-  }, {});
+  const modules = projectRelativePaths.reduce(
+    (acc, current) => {
+      acc[`baseui/${current.replace('/index.js', '')}`] = `esm/${current}`;
+      return acc;
+    },
+    {
+      baseui: 'esm/index.js',
+    },
+  );
 
   packageJson.module = modules;
   fs.writeFileSync(


### PR DESCRIPTION
Currently, our mapping use absolute paths instead of relative, and the keys do not match the import statements:

<img width="808" alt="Screen Shot 2019-07-02 at 1 01 01 PM" src="https://user-images.githubusercontent.com/2174968/60542760-8f6aa000-9cc9-11e9-837b-ac974269f392.png">

This PR changes it to be like this:

<img width="344" alt="Screen Shot 2019-07-02 at 12 57 21 PM" src="https://user-images.githubusercontent.com/2174968/60542792-9d202580-9cc9-11e9-8f3b-ebeab2772769.png">
