### PR TITLE
fix(select): always highlight the first item initially

### DIFF
--- a/src/select/__tests__/select.e2e.js
+++ b/src/select/__tests__/select.e2e.js
@@ -167,4 +167,19 @@ describe('select', () => {
     const canBeParisCreated = (await page.$(optionAtPosition(1))) !== null;
     expect(canBeParisCreated).toBeFalsy();
   });
+
+  it('selects second option without mouse or arrow keys', async () => {
+    await mount(page, 'select-search-multi');
+    await page.waitFor(selectors.selectInput);
+    await page.click(selectors.selectInput);
+    await page.type(selectors.selectInput, 'dark');
+    await page.keyboard.press('Enter');
+    await page.type(selectors.selectInput, 'az');
+    await page.keyboard.press('Enter');
+    const selectedValue = await page.$eval(
+      selectors.selectedList,
+      select => select.textContent,
+    );
+    expect(selectedValue).toBe('DarkBlueAzure');
+  });
 });

--- a/src/select/dropdown.js
+++ b/src/select/dropdown.js
@@ -89,7 +89,6 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
       onItemSelect,
       options = [],
       overrides = {},
-      value,
       size,
     } = this.props;
     const [DropdownContainer, dropdownContainerProps] = getOverrides(
@@ -118,10 +117,7 @@ export default class SelectDropdown extends React.Component<DropdownPropsT> {
           size={size}
           initialState={{
             isFocused: true,
-            highlightedIndex:
-              Array.isArray(value) && value.length === 1
-                ? options.findIndex(opt => opt.id === value[0].id)
-                : 0,
+            highlightedIndex: 0,
           }}
           overrides={mergeOverrides(
             {


### PR DESCRIPTION
When the select menu is open and mounted, always highlight the first item initially. There is no reason to do filtering based on the input value because the options are naturally filtered so the first item should be highlighted.

This was causing a bug with multi select when on the second input, the menu was unfocused.