### PR TITLE
fix(phone-input): fix country-select overrides and nested overrides

### DIFF
--- a/src/phone-input/__tests__/phone-input-overrides.scenario.js
+++ b/src/phone-input/__tests__/phone-input-overrides.scenario.js
@@ -1,0 +1,42 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {StatefulPhoneInput} from '../index.js';
+
+export const name = 'phone-input-overrides';
+
+export const component = () => (
+  <StatefulPhoneInput
+    overrides={{
+      Input: {
+        props: {
+          overrides: {
+            InputContainer: {
+              style: {
+                backgroundColor: 'orange',
+              },
+            },
+          },
+        },
+      },
+      CountrySelect: {
+        props: {
+          overrides: {
+            ControlContainer: {
+              style: {
+                backgroundColor: 'pink',
+              },
+            },
+          },
+        },
+      },
+    }}
+  />
+);

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -101,7 +101,8 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     overrides.CountrySelect,
     DefaultSelect,
   );
-  const selectOverrides = mergeOverrides(baseOverrides, overrides);
+  // $FlowFixMe
+  selectProps.overrides = mergeOverrides(baseOverrides, selectProps.overrides);
   const [DialCode, dialCodeProps] = getOverrides(
     overrides.DialCode,
     StyledDialCode,
@@ -125,7 +126,6 @@ export default function CountrySelect(props: CountrySelectPropsT) {
         getValueLabel={(value: {option: CountryT}) => {
           return <StyledFlag iso={value.option.id} $size={size} />;
         }}
-        overrides={selectOverrides}
         {...selectProps}
       />
       <DialCode data-e2e="phone-input-dialcode" {...dialCodeProps}>

--- a/src/phone-input/phone-input.js
+++ b/src/phone-input/phone-input.js
@@ -46,11 +46,13 @@ export default function PhoneInput(props: PropsT) {
         inputRef,
         onCountryChange,
         size,
+        overrides,
       },
     },
   };
   const [Input, inputProps] = getOverrides(overrides.Input, DefaultInput);
-  const inputOverrides = mergeOverrides(baseOverrides, overrides);
+  // $FlowFixMe
+  inputProps.overrides = mergeOverrides(baseOverrides, inputProps.overrides);
   return (
     <Input
       aria-label={ariaLabel}
@@ -64,14 +66,13 @@ export default function PhoneInput(props: PropsT) {
       inputRef={inputRef}
       name={name}
       onChange={onTextChange}
-      overrides={inputOverrides}
       positive={positive}
       placeholder={placeholder}
       size={size}
       type="tel"
       value={text}
-      {...inputProps}
       {...restProps}
+      {...inputProps}
     />
   );
 }


### PR DESCRIPTION
#### Description

This PR fixes a regression introduced in #1490. The issue was that some of the country select related overrides in the phone input were no longer working properly. This was because `overrides` was not being passed through to through to the `CountrySelect`. This is a one-line fix.

While playing around with overrides though, I noticed that nested overrides were not working correctly either. If you tried to pass nested overrides through `props` to `Input` and `CountrySelect`, they would overwrite (rather than deep merge with) all the built in overrides from the original source. I corrected the merging logic in this PR, but I had to add a couple `$FlowFixMe`s until we solve the underlying Flow issue with `mergeOverrides`.

In the interest of getting this patch out I think we should push that Flow update until later.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
