### PR TITLE
fix(types): fix styled() type so it can take a single string arg

### DIFF
--- a/src/styles/__tests__/styled.test.js
+++ b/src/styles/__tests__/styled.test.js
@@ -42,6 +42,13 @@ test('styled', () => {
   wrapper.unmount();
 });
 
+test('styled can be called with single string argument', () => {
+  const ADiv = styled('div');
+  expect(ADiv).toBeTruthy();
+  const wrapper = mount(<ADiv />);
+  wrapper.unmount();
+});
+
 test('styled override prop', () => {
   const StyledMockButton = styled('button', {
     color: 'red',

--- a/src/styles/styled.js
+++ b/src/styles/styled.js
@@ -32,6 +32,8 @@ type StyletronComponent<Props> = React.StatelessFunctionalComponent<Props> & {
 };
 
 type StyleFn<Theme> = {
+  (string): StyletronComponent<{||}>,
+
   (string, StyleObject): StyletronComponent<{}>,
 
   <Props>(


### PR DESCRIPTION
Fixes #1535

#### Description

Changed the type of `styled()`

#### Scope

- [x] Patch: Bug Fix
