### PR TITLE
Update slider flow types to mark optional params optional

### DIFF
--- a/src/slider/types.js
+++ b/src/slider/types.js
@@ -28,16 +28,16 @@ export type PropsT = {
   /** Position of the thumbs. It can be a single point (one thumb) or 2 points array (range thumbs). */
   value: Array<number>,
   /** The minimum allowed value of the slider. Should not be bigger than max. */
-  min: number,
+  min?: number,
   /** The maximum allowed value of the slider. Should not be smaller than min. */
-  max: number,
+  max?: number,
   /** The granularity the slider can step through value. Default step is 1. */
-  step: number,
+  step?: number,
   overrides?: OverridesT,
   /** Disable control from being changed. */
-  disabled: boolean,
+  disabled?: boolean,
   /** Handler for events on trigger element, each time thumbs change selection, which is passed in `value`. */
-  onChange: ({
+  onChange?: ({
     ...ParamsT,
   }) => mixed,
 };


### PR DESCRIPTION
Fixes #1548

#### Description

Changes Flow type for Slider props to match TypeScript types and documentation.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
