### PR TITLE
fix(ts): fix overrides, theme and locale exports

### DIFF
--- a/scripts/ts-copy.js
+++ b/scripts/ts-copy.js
@@ -15,7 +15,7 @@ const globby = require('globby');
 const path = require('path');
 
 (async () => {
-  const files = await globby(['src/**/*.d.ts']);
+  const files = await globby(['src/**/*.ts']);
   files.forEach(async file => {
     try {
       const from = path.join(__dirname, '../', file);

--- a/src/datepicker/index.d.ts
+++ b/src/datepicker/index.d.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {StyletronComponent} from 'styletron-react';
 import {Option} from '../select';
 import {Override} from '../overrides';
+import {Locale} from '../locale';
 import {any} from 'prop-types';
 
 export interface STATE_CHANGE_TYPE {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import {StyleObject, StyletronComponent} from 'styletron-react';
 import {Overrides} from './overrides';
+import {Locale} from './locale';
+import {Theme, ThemePrimitives} from './theme';
 
 export function createTheme(
   primitives: ThemePrimitives,

--- a/src/locale.ts
+++ b/src/locale.ts
@@ -45,7 +45,7 @@ interface ToastLocale {
   close: string;
 }
 
-interface Locale {
+export interface Locale {
   accordion: AccordionLocale;
   breadcrumbs: BreadcrumbLocale;
   datepicker: DatepickerLocale;

--- a/src/overrides.ts
+++ b/src/overrides.ts
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import {StyleObject} from 'styletron-react';
+import {Theme} from './theme';
 
 type StyleOverride<T> =
   | StyleObject

--- a/src/pagination/index.d.ts
+++ b/src/pagination/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {StyletronComponent} from 'styletron-react';
 import {Override} from '../overrides';
+import {Locale} from '../locale';
 
 export interface STATE_CHANGE_TYPE {
   change: 'change';

--- a/src/rating/index.d.ts
+++ b/src/rating/index.d.ts
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {StyletronComponent} from 'styletron-react';
 import {Override} from '../overrides';
+import {Theme} from '../theme';
 
 export interface RatingState {
   previewIndex?: number;

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -3,6 +3,7 @@ import {StyletronComponent} from 'styletron-react';
 import {SIZE} from '../input';
 import {OnItemSelect} from '../menu';
 import {Override} from '../overrides';
+import {Locale} from '../locale';
 
 export interface TYPE {
   select: 'select';

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -472,7 +472,7 @@ interface ZIndex {
   modal?: number;
 }
 
-interface Theme {
+export interface Theme {
   name?: string;
   breakpoints?: Breakpoints;
   colors?: Colors;
@@ -488,7 +488,7 @@ interface Theme {
   };
 }
 
-interface ThemePrimitives {
+export interface ThemePrimitives {
   // Primary Palette
   primary50: string;
   primary100: string;


### PR DESCRIPTION
- replace all triple-slash directives `/// <reference path="...">` with ES modules, seems to be the preferred/modern way of composing typedefs, also it makes type dependencies explicit
- copy and publish these new `.ts` files (not only `.d.ts`) so it actually works
- tested with a 3rd party app
