### PR TITLE
fix(multiselect): set the same gap between the Tags (vertical axis)

### DIFF
--- a/src/select/multi-value.js
+++ b/src/select/multi-value.js
@@ -19,10 +19,10 @@ export default function MultiValue(props: any) {
       overrides={{
         Root: {
           style: ({$theme: {sizing}}) => ({
+            marginTop: sizing.scale0,
             marginRight: sizing.scale0,
-            marginBottom: 0,
+            marginBottom: sizing.scale0,
             marginLeft: sizing.scale0,
-            marginTop: 0,
           }),
         },
       }}


### PR DESCRIPTION
Fixes #1550 <!-- remove the (`) quotes to link the issues -->

#### Description
Make the same gap between Tags components along the vertical axis. Now gaps along vertical and horizontal axes are the same.

<img width="406" alt="1" src="https://user-images.githubusercontent.com/13419634/61188426-82658d80-a687-11e9-9d3e-14d75bafa447.png">


<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
