### PR TITLE
feat(select): add startOpen property

### DIFF
--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -12,6 +12,7 @@ import Layout from '../../components/layout';
 import SelectBasic from 'examples/select/basic.js';
 import SelectSizes from 'examples/select/sizes.js';
 import SelectControlled from 'examples/select/controlled.js';
+import SelectOpen from 'examples/select/open.js';
 import SelectOverridden from 'examples/select/overridden.js';
 import SelectLabel from 'examples/select/label.js';
 import SelectInModal from 'examples/select/in-modal.js';
@@ -54,6 +55,15 @@ Things to note in the `Select Controlled` example:
 
 - the `value` is always an `Array` to provide a consistent interface - no matter if you use multi or single selects,
 - you have to call `setState` with the entire object, not just the `id` value.
+
+<Example title="Select with open dropdown" path="">
+  <SelectOpen />
+</Example>
+
+Use `startOpen` to mount the Select with an open dropdown.
+Combine this with `autoFocus` if you want the input to be focused as well.
+Note, the dropdown will close once an item is selected or if the `escape` key is pressed while the Select has focus.
+If you want the dropdown to stay open you might be better off using [`Menu`](/components/menu) directly.
 
 <Example
   title="Select with overridden menu"
@@ -102,7 +112,10 @@ Things to note in the `Select Controlled` example:
 The creatable select enables users to create new options along with choosing
 existing options.
 
-<Example title="Select dropdown overrides" path="examples/select/overridden-dropdown.js">
+<Example
+  title="Select dropdown overrides"
+  path="examples/select/overridden-dropdown.js"
+>
   <SelectOverriddenDropdown />
 </Example>
 

--- a/documentation-site/static/examples/select/open.js
+++ b/documentation-site/static/examples/select/open.js
@@ -1,0 +1,18 @@
+import * as React from 'react';
+import {StatefulSelect} from 'baseui/select';
+
+export default () => (
+  <StatefulSelect
+    options={[
+      {id: 'AliceBlue', color: '#F0F8FF'},
+      {id: 'AntiqueWhite', color: '#FAEBD7'},
+      {id: 'Aqua', color: '#00FFFF'},
+      {id: 'Aquamarine', color: '#7FFFD4'},
+      {id: 'Azure', color: '#F0FFFF'},
+      {id: 'Beige', color: '#F5F5DC'},
+    ]}
+    labelKey="id"
+    valueKey="color"
+    startOpen
+  />
+);

--- a/src/select/__tests__/__snapshots__/select.test.js.snap
+++ b/src/select/__tests__/__snapshots__/select.test.js.snap
@@ -54,6 +54,7 @@ exports[`Select component renders component in search mode and false for multipl
   required={false}
   searchable={true}
   size="default"
+  startOpen={false}
   type="search"
   value={Array []}
   valueKey="id"
@@ -838,6 +839,7 @@ exports[`Select component renders component in search mode and true for multiple
   required={false}
   searchable={true}
   size="default"
+  startOpen={false}
   type="search"
   value={Array []}
   valueKey="id"
@@ -1622,6 +1624,7 @@ exports[`Select component renders component in select mode and false for multipl
   required={false}
   searchable={true}
   size="default"
+  startOpen={false}
   type="select"
   value={Array []}
   valueKey="id"
@@ -2418,6 +2421,7 @@ exports[`Select component renders component in select mode and true for multiple
   required={false}
   searchable={true}
   size="default"
+  startOpen={false}
   type="select"
   value={Array []}
   valueKey="id"

--- a/src/select/__tests__/select-open.scenario.js
+++ b/src/select/__tests__/select-open.scenario.js
@@ -1,0 +1,24 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+
+import {StatefulSelect} from '../index.js';
+
+export const name = 'select-open';
+
+export const component = () => (
+  <StatefulSelect
+    startOpen
+    options={[
+      {id: 'a', label: 'hey!'},
+      {id: 'b', label: 'are you listening?'},
+      {id: 'c', label: 'look at me!'},
+    ]}
+  />
+);

--- a/src/select/default-props.js
+++ b/src/select/default-props.js
@@ -40,6 +40,7 @@ const defaultProps = {
   onOpen: null,
   onClose: null,
   openOnClick: true,
+  startOpen: false,
   options: [],
   overrides: {},
   required: false,

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -99,15 +99,12 @@ class Select extends React.Component<PropsT, SelectStateT> {
   // closeOnSelect is false. This flag helps to detect that selection was just made.
   justSelected: boolean;
 
-  constructor(props: PropsT) {
-    super(props);
-    this.state = {
-      inputValue: '',
-      isFocused: false,
-      isOpen: props.startOpen,
-      isPseudoFocused: false,
-    };
-  }
+  state = {
+    inputValue: '',
+    isFocused: false,
+    isOpen: this.props.startOpen,
+    isPseudoFocused: false,
+  };
 
   componentDidMount() {
     if (this.props.autoFocus) {

--- a/src/select/select.js
+++ b/src/select/select.js
@@ -99,12 +99,15 @@ class Select extends React.Component<PropsT, SelectStateT> {
   // closeOnSelect is false. This flag helps to detect that selection was just made.
   justSelected: boolean;
 
-  state = {
-    inputValue: '',
-    isFocused: false,
-    isOpen: false,
-    isPseudoFocused: false,
-  };
+  constructor(props: PropsT) {
+    super(props);
+    this.state = {
+      inputValue: '',
+      isFocused: false,
+      isOpen: props.startOpen,
+      isPseudoFocused: false,
+    };
+  }
 
   componentDidMount() {
     if (this.props.autoFocus) {

--- a/src/select/types.js
+++ b/src/select/types.js
@@ -139,6 +139,8 @@ export type PropsT = {
   onClose: ?() => mixed,
   /** Defines if the dropdown opens on a click event on the select. */
   openOnClick: boolean,
+  /** If true, opens the dropdown when the select mounts. */
+  startOpen: boolean,
   /** Options to be displayed in the dropdown. If an option has a
    * disabled prop value set to true it will be rendered as a disabled option in the dropdown. */
   options: ?ValueT,


### PR DESCRIPTION
Fixes #744 

#### Description

This PR adds an `openOnMount` prop to the `Select` component. If true, the dropdown will open upon mounting. By default the prop is `false`.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
