### PR TITLE
fix(side-nav): removes memo fn from being passed to styled nav-item

### DIFF
--- a/src/side-navigation/nav-item.js
+++ b/src/side-navigation/nav-item.js
@@ -34,7 +34,13 @@ class NavItem extends React.Component<NavItemPropsT> {
   };
 
   render() {
-    const {item, overrides, ...sharedProps} = this.props;
+    const {
+      item,
+      overrides,
+      itemMemoizationComparator,
+      ...sharedProps
+    } = this.props;
+
     const [NavItem, itemProps] = getOverrides(overrides.NavItem, StyledNavItem);
     const [NavLink, linkProps] = getOverrides(overrides.NavLink, StyledNavLink);
     return (


### PR DESCRIPTION
#### Description

```
<Navigation
      items={nav}
      activeItemId={location}
      onChange={({ item }) => setLocation(item.itemId)}
      overrides={{
        NavItem: props => {
          return <StyledNavItem {...props} />;
        }
      }}
    />
```

code above gives the error below

```
Warning: React does not recognize the `itemMemoizationComparator` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `itemmemoizationcomparator` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by Context.Consumer)
    in DevConsumer (created by ForwardRef)
    in ForwardRef (created by Context.Consumer)
    in StyledNavItem (created by NavItem)
    in NavItem (created by NavItem)
    in a (created by Context.Consumer)
    in DevConsumer (created by ForwardRef)
    in ForwardRef (created by Context.Consumer)
    in StyledNavLink (created by NavItem)
    in NavItem
    in NavItem (created by SideNav)
    in li (created by Context.Consumer)
    in DevConsumer (created by ForwardRef)
    in ForwardRef (created by Context.Consumer)
    in StyledNavItemContainer (created by SideNav)
    in ul (created by Context.Consumer)
    in DevConsumer (created by ForwardRef)
    in ForwardRef (created by Context.Consumer)
    in StyledRoot (created by SideNav)
    in SideNav (created by _default)
    in _default (created by App)
    in App
    in ThemeProvider (created by BaseProvider)
    in div (created by Context.Consumer)
    in LayersManager (created by BaseProvider)
    in BaseProvider
    in DevProvider
```

#### Scope

- [x] Patch: Bug Fix
