### PR TITLE
fix(docs): add path to select open example

### DIFF
--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -56,7 +56,7 @@ Things to note in the `Select Controlled` example:
 - the `value` is always an `Array` to provide a consistent interface - no matter if you use multi or single selects,
 - you have to call `setState` with the entire object, not just the `id` value.
 
-<Example title="Select with open dropdown" path="">
+<Example title="Select with open dropdown" path="examples/select/open.js">
   <SelectOpen />
 </Example>
 


### PR DESCRIPTION
#### Description

Problem: <img width="622" alt="Screen Shot 2019-07-16 at 10 38 29 AM" src="https://user-images.githubusercontent.com/1939257/61316470-e4bcac00-a7b5-11e9-835b-5aaa119a17e3.png">

This PR fixes this by adding the path to the example in `select.mdx`.

#### Scope

- [ ] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
