### PR TITLE
fix(phone-input): correct flow type for inputRef

### DIFF
--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -21,7 +21,7 @@ import type {CountryT, CountrySelectPropsT} from './types.js';
 
 CountrySelect.defaultProps = {
   disabled: defaultProps.disabled,
-  inputRef: null,
+  inputRef: {current: null},
   maxDropdownHeight: defaultProps.maxDropdownHeight,
   maxDropdownWidth: defaultProps.maxDropdownWidth,
   overrides: {},


### PR DESCRIPTION
#### Description

Fix a flow type error where `inputRef` cannot be `null`.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
