### PR TITLE
fix(breakpoints): stable breakpoint keys

### DIFF
--- a/src/helpers/__tests__/responsive-helpers.test.js
+++ b/src/helpers/__tests__/responsive-helpers.test.js
@@ -37,4 +37,18 @@ describe('Helpers - ResponsiveHelpers', () => {
       '@media screen and (min-width: 1280px)',
     ]);
   });
+
+  test('getMediaQueries stable breakpoint order', () => {
+    expect(
+      getMediaQueries({
+        large: 1280,
+        small: 320,
+        medium: 600,
+      }),
+    ).toMatchObject([
+      '@media screen and (min-width: 320px)',
+      '@media screen and (min-width: 600px)',
+      '@media screen and (min-width: 1280px)',
+    ]);
+  });
 });

--- a/src/helpers/responsive-helpers.js
+++ b/src/helpers/responsive-helpers.js
@@ -29,6 +29,6 @@ export const getMediaQuery = (
 };
 
 export const getMediaQueries = (breakpoints: BreakpointsT): string[] =>
-  Object.keys(breakpoints).map(size =>
-    getMediaQuery({'min-width': `${breakpoints[size]}px`}),
-  );
+  Object.keys(breakpoints)
+    .sort((a, b) => breakpoints[a] - breakpoints[b])
+    .map(size => getMediaQuery({'min-width': `${breakpoints[size]}px`}));


### PR DESCRIPTION
#### Description

Javascript objects do not guarantee stable property order.  When generating media queries, the breakpoints could be referenced in the wrong order and the resulting media queries would apply to the wrong style values.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
