### PR TITLE
fix(input): clearable icon sizing

### DIFF
--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -205,7 +205,7 @@ class BaseInput<T: EventTarget> extends React.Component<
   }
 
   renderClear() {
-    const {clearable, value, disabled, overrides = {}, size} = this.props;
+    const {clearable, value, disabled, overrides = {}} = this.props;
     if (!clearable || !value || !value.length || disabled) {
       return null;
     }
@@ -218,18 +218,20 @@ class BaseInput<T: EventTarget> extends React.Component<
       StyledClearIcon,
     );
     const ariaLabel = 'Clear value';
+    const sharedProps = getSharedProps(this.props, this.state);
     return (
       <ClearIconContainer
-        $size={size}
         $alignTop={this.props.type === CUSTOM_INPUT_TYPE.textarea}
+        {...sharedProps}
         {...clearIconContainerProps}
       >
         <ClearIcon
-          size={size === SIZE.large ? 'scale700' : 'scale600'}
+          size={16}
           title={ariaLabel}
           aria-label={ariaLabel}
           onClick={this.onClearIconClick}
           role="button"
+          {...sharedProps}
           {...clearIconProps}
         />
       </ClearIconContainer>

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -13,21 +13,13 @@ import {DeleteAlt} from '../icon/index.js';
 
 export const StyledClearIconContainer = styled<{
   $alignTop: boolean,
-  $size: SizeT,
   $theme: ThemeT,
-}>('div', ({$size = SIZE.default, $alignTop = false, $theme}) => {
-  const sidePadding =
-    $size === SIZE.compact
-      ? $theme.sizing.scale100
-      : $size === SIZE.large
-        ? $theme.sizing.scale300
-        : $theme.sizing.scale200;
+}>('div', ({$alignTop = false, $theme}) => {
   return {
     display: 'flex',
     alignItems: $alignTop ? 'flex-start' : 'center',
-    paddingLeft: sidePadding,
-    paddingRight: sidePadding,
-    paddingTop: $alignTop ? sidePadding : '0px',
+    paddingRight: $theme.sizing.scale500,
+    paddingTop: $alignTop ? $theme.sizing.scale500 : '0px',
     color: $theme.colors.foregroundAlt,
   };
 });


### PR DESCRIPTION
#### Description

- Fix a bug where theme values are being applied to SVG rather than actual pixel values. This is a problem if someone brings their own SVG.
- Normalize clearable icon across select and input by removing alternate sizing, passing sharedProps

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
