### PR TITLE
fix(button-group): apply overrides to children correctly

### DIFF
--- a/src/button-group/__tests__/button-group-overrides.scenario.js
+++ b/src/button-group/__tests__/button-group-overrides.scenario.js
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {Button} from '../../button/index.js';
+import {StatefulButtonGroup, MODE} from '../index.js';
+
+export const name = 'button-group-overrides';
+
+const buttonOverrides = {
+  BaseButton: {
+    style: ({$isSelected}) => {
+      if ($isSelected)
+        return {
+          backgroundColor: 'seagreen',
+        };
+    },
+  },
+};
+
+export const component = () => (
+  <StatefulButtonGroup mode={MODE.checkbox} initialState={{selected: [0, 1]}}>
+    <Button overrides={buttonOverrides}>Label</Button>
+    <Button overrides={buttonOverrides}>Label</Button>
+    <Button overrides={buttonOverrides}>Label</Button>
+  </StatefulButtonGroup>
+);

--- a/src/button-group/button-group.js
+++ b/src/button-group/button-group.js
@@ -97,8 +97,8 @@ export function ButtonGroupRoot(props: {|...PropsT, ...LocaleT|}) {
                   borderBottomLeftRadius: 0,
                 };
               },
-              ...child.props.overrides,
             },
+            ...child.props.overrides,
           },
         });
       })}


### PR DESCRIPTION
The overrides for ButtonGroup children were being spread in the BaseButton override rather than the top level override object. This PR adds a one line fix in addition to a visual regression test.