### PR TITLE
docs: update nested overrides copy and example

### DIFF
--- a/documentation-site/components/example.js
+++ b/documentation-site/components/example.js
@@ -59,7 +59,7 @@ type PropsT = {
   additionalPackages: {[string]: string},
   children: React.Node,
   path: string, // required to fetch the uncompiled source code
-  title: string,
+  title: ?string,
 };
 
 type StateT = {
@@ -70,7 +70,7 @@ type StateT = {
 };
 
 class Example extends React.Component<PropsT, StateT> {
-  static defaultProps = {additionalPackages: {}};
+  static defaultProps = {additionalPackages: {}, title: null};
   state = {
     sourceSelected: -1,
     source: null,
@@ -154,7 +154,7 @@ class Example extends React.Component<PropsT, StateT> {
           },
         }}
       >
-        <H2>{this.props.title}</H2>
+        {this.props.title && <H2>{this.props.title}</H2>}
         {this.props.children}
 
         <Block paddingTop="scale400">

--- a/documentation-site/examples/datepicker/nested-override.js
+++ b/documentation-site/examples/datepicker/nested-override.js
@@ -1,0 +1,28 @@
+// @flow
+import * as React from 'react';
+import {StatefulCalendar} from 'baseui/datepicker';
+
+export default () => (
+  <StatefulCalendar
+    overrides={{
+      // MonthYearSelectStatefulMenu is a Menu component
+      // We can use any overrides available to Menu
+      MonthYearSelectStatefulMenu: {
+        props: {
+          overrides: {
+            ListItem: {
+              style: ({$isHighlighted}) => {
+                if ($isHighlighted) {
+                  return {
+                    color: 'white',
+                    backgroundColor: 'salmon',
+                  };
+                }
+              },
+            },
+          },
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/examples/datepicker/nested-override.tsx
+++ b/documentation-site/examples/datepicker/nested-override.tsx
@@ -1,0 +1,31 @@
+import * as React from 'react';
+import {StatefulCalendar} from 'baseui/datepicker';
+
+export default () => (
+  <StatefulCalendar
+    overrides={{
+      // MonthYearSelectStatefulMenu is a Menu component
+      // We can use any overrides available to Menu
+      MonthYearSelectStatefulMenu: {
+        props: {
+          overrides: {
+            ListItem: {
+              style: ({
+                $isHighlighted,
+              }: {
+                $isHighlighted: boolean;
+              }) => {
+                return $isHighlighted
+                  ? {
+                      color: 'white',
+                      backgroundColor: 'salmon',
+                    }
+                  : null;
+              },
+            },
+          },
+        },
+      },
+    }}
+  />
+);

--- a/documentation-site/examples/select/overriden-tag.js
+++ b/documentation-site/examples/select/overriden-tag.js
@@ -1,35 +1,57 @@
 // @flow
 import * as React from 'react';
-import {StatefulSelect, TYPE} from 'baseui/select';
+import {StatefulSelect} from 'baseui/select';
 
 export default class Container extends React.Component<{}, {}> {
   render() {
     return (
       <StatefulSelect
-        options={[
-          {id: 'AliceBlue', color: '#F0F8FF'},
-          {id: 'AntiqueWhite', color: '#FAEBD7'},
-        ]}
         overrides={{
           MultiValue: {
             props: {
-              color: '#4327F1',
-              kind: 'custom',
               overrides: {
                 Root: {
                   style: {
-                    borderLeft: '1px solid black',
+                    borderRadius: '0px',
+                    backgroundColor: 'slateblue',
+                  },
+                },
+                Action: {
+                  style: {
+                    borderRadius: '0px',
+                    ':hover': {
+                      backgroundColor: 'mediumpurple',
+                    },
+                    ':focus': {
+                      backgroundColor: 'mediumpurple',
+                    },
+                  },
+                },
+                Text: {
+                  style: {
+                    color: 'lavender',
+                  },
+                },
+                ActionIcon: {
+                  props: {
+                    color: 'lavender',
                   },
                 },
               },
             },
           },
         }}
-        labelKey="id"
-        valueKey="color"
-        type={TYPE.search}
         multi
-        onChange={event => console.log(event)}
+        type="search"
+        options={[
+          {label: 'Atlanta', id: 'ATL'},
+          {label: 'Baltimore', id: 'BWI'},
+          {label: 'Chicago', id: 'ORD'},
+          {label: 'Denver', id: 'DEN'},
+        ]}
+        initialState={{
+          value: [{label: 'Atlanta', id: 'ATL'}],
+        }}
       />
     );
   }

--- a/documentation-site/examples/select/overriden-tag.tsx
+++ b/documentation-site/examples/select/overriden-tag.tsx
@@ -1,34 +1,56 @@
 import * as React from 'react';
-import {StatefulSelect, TYPE} from 'baseui/select';
+import {StatefulSelect} from 'baseui/select';
 
 export default class Container extends React.Component<{}, {}> {
   render() {
     return (
       <StatefulSelect
-        options={[
-          {id: 'AliceBlue', color: '#F0F8FF'},
-          {id: 'AntiqueWhite', color: '#FAEBD7'},
-        ]}
         overrides={{
           MultiValue: {
             props: {
-              color: '#4327F1',
-              kind: 'custom',
               overrides: {
                 Root: {
                   style: {
-                    borderLeft: '1px solid black',
+                    borderRadius: '0px',
+                    backgroundColor: 'pink',
+                  },
+                },
+                Action: {
+                  style: {
+                    borderRadius: '0px',
+                    ':hover': {
+                      backgroundColor: 'salmon',
+                    },
+                    ':focus': {
+                      backgroundColor: 'salmon',
+                    },
+                  },
+                },
+                Text: {
+                  style: {
+                    color: '#fff',
+                  },
+                },
+                ActionIcon: {
+                  props: {
+                    color: '#fff',
                   },
                 },
               },
             },
           },
         }}
-        labelKey="id"
-        valueKey="color"
-        type={TYPE.search}
         multi
-        onChange={event => console.log(event)}
+        type="search"
+        options={[
+          {label: 'Atlanta', id: 'ATL'},
+          {label: 'Baltimore', id: 'BWI'},
+          {label: 'Chicago', id: 'ORD'},
+          {label: 'Denver', id: 'DEN'},
+        ]}
+        initialState={{
+          value: [{label: 'Atlanta', id: 'ATL'}],
+        }}
       />
     );
   }

--- a/documentation-site/pages/components/datepicker.mdx
+++ b/documentation-site/pages/components/datepicker.mdx
@@ -22,6 +22,7 @@ import ComposedRangePickers from 'examples/datepicker/composed-range-pickers.js'
 import ComposedSinglePickers from 'examples/datepicker/composed-single-pickers.js';
 import DatePickersColorStates from 'examples/datepicker/datepickers-color-states.js';
 import DatePickerTimezone from 'examples/datepicker/datepicker-with-timezone.js';
+import NestedOverride from 'examples/datepicker/nested-override.js';
 
 import Overrides from '../../components/overrides';
 import {StatefulCalendar} from 'baseui/datepicker';
@@ -45,10 +46,7 @@ A simple and reusable component to work with or select a date or a range of date
   <DatepickerBasic />
 </Example>
 
-<Example
-  title="Datepicker in a popover"
-  path="datepicker/in-popover.js"
->
+<Example title="Datepicker in a popover" path="datepicker/in-popover.js">
   <DatepickerInPopover />
 </Example>
 
@@ -59,17 +57,11 @@ A simple and reusable component to work with or select a date or a range of date
   <DatepickerQuickSelect />
 </Example>
 
-<Example
-  title="Datepicker with localization"
-  path="datepicker/i18n.js"
->
+<Example title="Datepicker with localization" path="datepicker/i18n.js">
   <DatepickerI18n />
 </Example>
 
-<Example
-  title="Datepicker with overrides"
-  path="datepicker/with-overrides.js"
->
+<Example title="Datepicker with overrides" path="datepicker/with-overrides.js">
   <DatepickerWithOverrides />
 </Example>
 
@@ -120,9 +112,9 @@ A simple and reusable component to work with or select a date or a range of date
   title="Datepicker with timezone selection"
   path="datepicker/datepicker-with-timezone.js"
 >
-  This example works for most use-cases, however certian edge-cases
-  are not handled here. If this data is mission critical for your systems,
-  consider using Moment.js, and pass the date object from Moment.js to the datepicker.
+  This example works for most use-cases, however certian edge-cases are not
+  handled here. If this data is mission critical for your systems, consider
+  using Moment.js, and pass the date object from Moment.js to the datepicker.
   <DatePickerTimezone />
 </Example>
 
@@ -142,6 +134,12 @@ A simple and reusable component to work with or select a date or a range of date
     />
   )}
 />
+
+<Example title="Nested Override" path="datepicker/nested-override.js">
+  <NestedOverride />
+</Example>
+
+In this example we use a [nested override](/theming/understanding-overrides#override-nested-components) to customize the `ListItem` within the month/year dropdown (`MonthYearSelectStatefulMenu`).
 
 <API
   heading="Calendar API"

--- a/documentation-site/pages/components/datepicker.mdx
+++ b/documentation-site/pages/components/datepicker.mdx
@@ -135,7 +135,10 @@ A simple and reusable component to work with or select a date or a range of date
   )}
 />
 
-<Example title="Nested Override" path="datepicker/nested-override.js">
+<Example
+  title="Overriding a nested component"
+  path="datepicker/nested-override.js"
+>
   <NestedOverride />
 </Example>
 

--- a/documentation-site/pages/components/select.mdx
+++ b/documentation-site/pages/components/select.mdx
@@ -107,8 +107,7 @@ existing options.
   <SelectOverriddenDropdown />
 </Example>
 
-To override the `Popover` that's being used by the Dropdown subcomponent, you have to follow
-the approach outlined [here](/theming/understanding-overrides#override-nested-components).
+To override the `Popover` that's being used by the Dropdown subcomponent, you have to use a [nested override](/theming/understanding-overrides#override-nested-components).
 
 <Example title="Select creatable multi-pick" path="select/creatable-multi.js">
   <SelectCreatableMulti />

--- a/documentation-site/pages/theming/understanding-overrides.mdx
+++ b/documentation-site/pages/theming/understanding-overrides.mdx
@@ -9,6 +9,7 @@ import Layout from '../../components/layout';
 
 import Example from '../../components/example';
 import Overrides from '../../components/overrides';
+import {StatefulSelect, TYPE} from 'baseui/select';
 import {StatefulList} from 'baseui/dnd-list';
 import * as ListExports from 'baseui/dnd-list';
 
@@ -155,19 +156,97 @@ Almost every Base Web component has multiple overrides. **How can you learn what
 
 If you are interested in **which state props your style functions can use**, you'll find the list of them at the bottom of every component page. Scroll down to the API section and click on the `Expand Prop Shape` button for the `overrides` property.
 
-## Override Nested Components
+## Nested Overrides
 
-Some Base Web components use other Base Web components internally. Examples include the `Select` component, which uses the `Tag` component
-for the multi-select mode, or the `FileUploader` which uses the `Button` component.
+Every Base Web component exposes the `override` prop. When one Base Web component uses another Base Web component internally we have access to a new, powerful pattern: **Nested Overrides**.
 
-In these cases, you are not directly modifying styled components, but nested components. To make that happen, you have to pass in your overrides
-through the `props` override functionality.
+The idea is to use a component's `overrides` prop to access a nested component and pass this nested component an `overrides` prop of its own. You end up with a _nested_ structure like so:
 
-To better understand it, let's take a look at the example of the `Select` component:
+```jsx
+<Foo
+  overrides={{
+    Boo: {
+      props: {
+        overrides: {
+          // pass "nested" overrides to the inner "Boo" component
+        },
+      },
+    },
+  }}
+/>
+```
 
-<Example title="Nested overrides" path="select/overriden-tag.js">
+This is a very reliable method for customizing deeply nested components. It is possible because everywhere a Base Web component uses another Base Web component, that ‟parent” component will expose an `overrides` property for the ‟child” component. In theory, you could nest overrides as many levels deep as necessary to customize something.
+
+```jsx
+<Foo
+  overrides={{
+    Boo: {
+      props: {
+        overrides: {
+          Moo: {
+            props: {
+              overrides: {
+                Zoo: {
+                  props: {
+                    overrides: {
+                      Goo: () => 'hey mom!',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  }}
+/>
+```
+
+In this example, we use four nested overrides to replace the `Goo` component. We do this without affecting the four components above `Goo`. We've avoided having to re-implement layers and layers of logic, and, because the interface is consistent, you can focus on _where_ you want to drop in, rather than _how_ to do it.
+
+If you find the exact syntax of this technique a little difficult to recall, try instead to remember that every Base Web component exposes an `overrides` prop and that every nested Base Web component is made accessible as an `overrides` property in the top-level component.
+
+The path always follows this pattern:
+
+> ComponentA > overrides > ComponentB > props > overrides
+
+### A more practical example
+
+Here is the default multi-select option for Base Web:
+
+<StatefulSelect
+  multi
+  type="search"
+  options={[
+    {label: 'Atlanta', id: 'ATL'},
+    {label: 'Baltimore', id: 'BWI'},
+    {label: 'Chicago', id: 'ORD'},
+    {label: 'Denver', id: 'DEN'},
+  ]}
+  initialState={{
+    value: [{label: 'Atlanta', id: 'ATL'}],
+  }}
+/>
+
+Let's change the way the selected values appear.
+
+The first step is to identify _what_ we want to override. In this case, we want to change the selected values for a multi-select. Let's check out the [`overrides` inspector for Select](/components/select/#overrides). Looking through the list of possible overrides, we see there is a promising `MultiValue` property.
+
+You might notice that the `MultiValue` component is just an instance of the `Tag` component. We can [reference the documentation for Tag](/components/tag/#overrides) to see what overrides are available.
+
+We have identified a nested Base Web component that is accessible via overrides. Now we can apply some nested overrides to customize things:
+
+<Example path="select/overriden-tag.js">
   <SelectTagExample />
 </Example>
+
+Notice the nested override pattern here:
+
+> StatefulSelect > overrides > MultiValue > props > overrides
+
+Once we have access to the nested `Tag`, we can override the styles for the `Root`, `Text`, `Action` & `ActionIcon`, changing the colors to a few lovely shades purple.
 
 ## Override The Entire Subcomponent
 

--- a/documentation-site/pages/theming/understanding-overrides.mdx
+++ b/documentation-site/pages/theming/understanding-overrides.mdx
@@ -156,7 +156,7 @@ Almost every Base Web component has multiple overrides. **How can you learn what
 
 If you are interested in **which state props your style functions can use**, you'll find the list of them at the bottom of every component page. Scroll down to the API section and click on the `Expand Prop Shape` button for the `overrides` property.
 
-## Nested Overrides
+## Override Nested Components
 
 Every Base Web component exposes the `override` prop. When one Base Web component uses another Base Web component internally we have access to a new, powerful pattern: **Nested Overrides**.
 

--- a/documentation-site/pages/theming/understanding-overrides.mdx
+++ b/documentation-site/pages/theming/understanding-overrides.mdx
@@ -246,7 +246,7 @@ Notice the nested override pattern here:
 
 > StatefulSelect > overrides > MultiValue > props > overrides
 
-Once we have access to the nested `Tag`, we can override the styles for the `Root`, `Text`, `Action` & `ActionIcon`, changing the colors to a few lovely shades purple.
+Once we have access to the nested `Tag`, we can override the styles for the `Root`, `Text`, `Action` & `ActionIcon`, changing the colors to a few lovely shades of purple.
 
 ## Override The Entire Subcomponent
 


### PR DESCRIPTION
Updates the doc site to have a more robust explanation of nested overrides.