### PR TITLE
fix: match input height cross browser

### DIFF
--- a/src/input/__tests__/__snapshots__/base-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/base-input.test.js.snap
@@ -63,6 +63,7 @@ Object {
     "fontSize": "$theme.typography.font400.fontSize",
     "fontWeight": "$theme.typography.font400.fontWeight",
     "lineHeight": "$theme.typography.font400.lineHeight",
+    "margin": "0",
     "maxWidth": "100%",
     "outline": "none",
     "paddingBottom": "$theme.sizing.scale400",

--- a/src/input/__tests__/__snapshots__/input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/input.test.js.snap
@@ -39,6 +39,7 @@ Object {
     "fontSize": "$theme.typography.font400.fontSize",
     "fontWeight": "$theme.typography.font400.fontWeight",
     "lineHeight": "$theme.typography.font400.lineHeight",
+    "margin": "0",
     "maxWidth": "100%",
     "outline": "none",
     "paddingBottom": "$theme.sizing.scale400",

--- a/src/input/__tests__/__snapshots__/masked-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/masked-input.test.js.snap
@@ -94,6 +94,7 @@ Object {
     "fontSize": "$theme.typography.font400.fontSize",
     "fontWeight": "$theme.typography.font400.fontWeight",
     "lineHeight": "$theme.typography.font400.lineHeight",
+    "margin": "0",
     "maxWidth": "100%",
     "outline": "none",
     "paddingBottom": "$theme.sizing.scale400",

--- a/src/input/styled-components.js
+++ b/src/input/styled-components.js
@@ -331,6 +331,7 @@ export const getInputStyles = (props: SharedPropsT & {$theme: ThemeT}) => {
     width: '100%',
     maxWidth: '100%',
     cursor: $disabled ? 'not-allowed' : 'text',
+    margin: '0',
     paddingTop: '0',
     paddingBottom: '0',
     paddingLeft: '0',

--- a/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
+++ b/src/textarea/__tests__/__snapshots__/textarea.test.js.snap
@@ -39,6 +39,7 @@ Object {
     "fontSize": "$theme.typography.font400.fontSize",
     "fontWeight": "$theme.typography.font400.fontWeight",
     "lineHeight": "$theme.typography.font400.lineHeight",
+    "margin": "0",
     "maxWidth": "100%",
     "outline": "none",
     "paddingBottom": "$theme.sizing.scale400",


### PR DESCRIPTION
#### Description
- Resolves #1576 
- Ensures `input` has no `margin` (was only being applied in Safari)

<!-- Describe your changes below in as much detail as possible -->

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
