### PR TITLE
fix(button): password mask button should not fire form submit

### DIFF
--- a/src/input/base-input.js
+++ b/src/input/base-input.js
@@ -183,6 +183,7 @@ class BaseInput<T: EventTarget> extends React.Component<
         kind={KIND.minimal}
         onClick={() => this.setState({isMasked: !this.state.isMasked})}
         title={label}
+        type="button"
         {...maskToggleButtonProps}
       >
         {this.state.isMasked ? (


### PR DESCRIPTION
Fixes #1662 

#### Description

Adds `type="button"` to the password mask toggle button so that it does not erroneously fire inside of a `form` element.

#### Scope

- [x] Patch: Bug Fix
