### PR TITLE
fix(yard): recover from bad URL source code

### DIFF
--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -145,30 +145,37 @@ export default withRouter(
     React.useEffect(() => {
       if (!urlCodeHydrated && router.query.code) {
         setUrlCodeHydrated(true);
-        const propValues: {[key: string]: any} = {};
-        const parsedProps = parseProps(router.query.code as string, 'Button');
-        Object.keys(state.props).forEach(name => {
-          //@ts-ignore
-          propValues[name] = COMPONENTS[componentName][name].value;
-          if (name === 'overrides') {
-            // overrides need a special treatment since the value needs to
-            // be further analyzed and parsed
-            propValues[name] = parseOverrides(
-              parsedProps[name],
-              COMPONENTS[componentName].overrides.meta.names,
-            );
-          } else {
-            propValues[name] = parsedProps[name];
-          }
-        });
+        try {
+          const propValues: {[key: string]: any} = {};
+          const parsedProps = parseProps(router.query.code as string, 'Button');
+          Object.keys(state.props).forEach(name => {
+            //@ts-ignore
+            propValues[name] = COMPONENTS[componentName][name].value;
+            if (name === 'overrides') {
+              // overrides need a special treatment since the value needs to
+              // be further analyzed and parsed
+              propValues[name] = parseOverrides(
+                parsedProps[name],
+                COMPONENTS[componentName].overrides.meta.names,
+              );
+            } else {
+              propValues[name] = parsedProps[name];
+            }
+          });
 
-        dispatch({
-          type: Action.UpdatePropsAndCode,
-          payload: {
-            code: formatCode(router.query.code as string),
-            updatedPropValues: propValues,
-          },
-        });
+          dispatch({
+            type: Action.UpdatePropsAndCode,
+            payload: {
+              code: formatCode(router.query.code as string),
+              updatedPropValues: propValues,
+            },
+          });
+        } catch (e) {
+          dispatch({
+            type: Action.UpdateCode,
+            payload: router.query.code,
+          });
+        }
       }
     }, [router.query.code]);
     return (


### PR DESCRIPTION
When hydrating the source code from the URL, it was not wrapped by try/catch so these steps killed the page:

- click in the onClick input
- select all
- type `}` (kills the page)
- try to refresh (the page is still dead)

Fix: set the source code but ignore AST parsing errors - let react-live deal with it and display the error.