### PR TITLE
fix(docs): ensure user logos are visible in dark mode

### DIFF
--- a/documentation-site/pages/index.js
+++ b/documentation-site/pages/index.js
@@ -149,6 +149,8 @@ const Index = (props: {
         display="grid"
         gridTemplateColumns="repeat(3, 1fr)"
         alignItems="center"
+        justifyItems="center"
+        backgroundColor="mono100"
       >
         <Block width="125px" $as="img" src="/static/images/uber-logo.png" />
         <Block width="125px" $as="img" src="/static/images/broadcom-logo.svg" />


### PR DESCRIPTION
User logos are not visible on the documentation site when in dark mode:

![dark-mode](https://user-images.githubusercontent.com/155164/62659071-a1bea600-b927-11e9-8d13-3d4cea81fdff.png)

#### Description

Sets the `background-color` of the surrounding `<Block>` to `mono100` (white in light mode, gray in dark mode) and ensures proper padding around logos by setting `justify-items` to `center`.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
