### PR TITLE
fix(datepicker): let stateful container to take care of the initial state value in stateful datepicker

### DIFF
--- a/src/datepicker/__tests__/stateful-range-datepicker.scenario.js
+++ b/src/datepicker/__tests__/stateful-range-datepicker.scenario.js
@@ -12,6 +12,4 @@ import {StatefulDatepicker} from '../index.js';
 
 export const name = 'stateful-range-datepicker';
 
-export const component = () => (
-  <StatefulDatepicker range initialState={{value: []}} />
-);
+export const component = () => <StatefulDatepicker range />;

--- a/src/datepicker/stateful-datepicker.js
+++ b/src/datepicker/stateful-datepicker.js
@@ -19,7 +19,7 @@ function StatefulComponent(props: StatefulDatepickerPropsT<DatepickerPropsT>) {
 }
 
 StatefulComponent.defaultProps = {
-  initialState: {value: null},
+  initialState: {},
   stateReducer: (type, nextState) => nextState,
   onChange: () => {},
 };


### PR DESCRIPTION
Fixes #1651

#### Description

We handle setting the initial state value in the StatefulContainer component. It sets the value to an empty array in case of a range picker. This PR removes the default value override in the StatefulDatepicker and lets the stateful container take care of it.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
