### PR TITLE
fix(docs): removes storybook build

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
   publish = "public/"
-  command = "yarn install --production=false && yarn documentation:build && yarn build-storybook"
+  command = "yarn install --production=false && yarn documentation:build"
 
 [build.environment]
   NODE_ENV = "production"


### PR DESCRIPTION
netlify builds are timing out.. this will hopefully allow us to publish the site while we figure out a more sustainable fix