### PR TITLE
fix(bundle-size): update build script

### DIFF
--- a/component-sizes.json
+++ b/component-sizes.json
@@ -1,49 +1,41 @@
 {
   "accordion": {
-    "size": 78925,
+    "size": 60636,
     "dependencySizes": [
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
         "name": "react-is",
         "approximateSize": 1467
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
       }
     ],
-    "gzip": 29739,
-    "minified": 78163
+    "gzip": 25069,
+    "minified": 60011
   },
   "aspect-ratio-box": {
-    "size": 67833,
+    "size": 65866,
     "dependencySizes": [
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
       {
         "name": "styletron-react",
         "approximateSize": 6869
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "styletron-standard",
@@ -52,83 +44,83 @@
       {
         "name": "object-assign",
         "approximateSize": 1085
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       }
     ],
-    "gzip": 27008,
-    "minified": 67175
+    "gzip": 26510,
+    "minified": 65223
   },
   "avatar": {
-    "size": 58549,
+    "size": 57763,
     "dependencySizes": [
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 23377,
-    "minified": 57895
+    "gzip": 23213,
+    "minified": 57121
   },
   "block": {
-    "size": 64283,
+    "size": 63818,
     "dependencySizes": [
       {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "object-assign",
+        "approximateSize": 1085
       },
       {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "react",
         "approximateSize": 5008
       }
     ],
-    "gzip": 25832,
-    "minified": 63643
+    "gzip": 25779,
+    "minified": 63190
   },
   "breadcrumbs": {
-    "size": 64510,
+    "size": 63835,
     "dependencySizes": [
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "styletron-react",
@@ -137,13 +129,17 @@
       {
         "name": "just-extend",
         "approximateSize": 645
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       }
     ],
-    "gzip": 25521,
-    "minified": 63775
+    "gzip": 25609,
+    "minified": 63112
   },
   "button": {
-    "size": 66325,
+    "size": 64935,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -154,23 +150,23 @@
         "approximateSize": 6869
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 26443,
-    "minified": 65668
+    "gzip": 26045,
+    "minified": 64278
   },
   "button-group": {
-    "size": 79587,
+    "size": 72832,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -181,97 +177,105 @@
         "approximateSize": 1085
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
         "name": "react",
         "approximateSize": 5008
       },
       {
         "name": "styletron-react",
         "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "just-extend",
         "approximateSize": 645
       }
     ],
-    "gzip": 30404,
-    "minified": 78814
+    "gzip": 28605,
+    "minified": 72072
   },
   "card": {
-    "size": 59230,
+    "size": 57557,
     "dependencySizes": [
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 23601,
-    "minified": 58606
+    "gzip": 23304,
+    "minified": 56945
   },
   "checkbox": {
-    "size": 70222,
+    "size": 64161,
     "dependencySizes": [
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "react",
+        "approximateSize": 5008
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 28637,
-    "minified": 69590
+    "gzip": 27013,
+    "minified": 63542
   },
   "datepicker": {
-    "size": 567837,
+    "size": 522622,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
         "name": "date-fns",
         "approximateSize": 36093
       },
       {
-        "name": "timezone-support",
-        "approximateSize": 19566
-      },
-      {
         "name": "react-is",
         "approximateSize": 1467
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "react-input-mask",
+        "approximateSize": 8501
       },
       {
         "name": "styletron-react",
@@ -282,28 +286,8 @@
         "approximateSize": 955
       },
       {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "just-extend",
         "approximateSize": 645
-      },
-      {
-        "name": "polished",
-        "approximateSize": 28614
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
       },
       {
         "name": "popper.js",
@@ -312,89 +296,61 @@
       {
         "name": "webpack",
         "approximateSize": 243
+      },
+      {
+        "name": "smoothscroll-polyfill",
+        "approximateSize": 2903
+      },
+      {
+        "name": "polished",
+        "approximateSize": 28614
       }
     ],
-    "gzip": 238467,
-    "minified": 564207
+    "gzip": 217320,
+    "minified": 519031
   },
   "dnd-list": {
-    "size": 195721,
+    "size": 189499,
     "dependencySizes": [
-      {
-        "name": "webpack",
-        "approximateSize": 243
-      },
       {
         "name": "react-dom",
         "approximateSize": 64818
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
       },
       {
         "name": "react-movable",
         "approximateSize": 9147
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
         "name": "react-is",
         "approximateSize": 1467
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       }
     ],
-    "gzip": 97796,
-    "minified": 194431
+    "gzip": 96073,
+    "minified": 188222
   },
   "file-uploader": {
-    "size": 123188,
+    "size": 122073,
     "dependencySizes": [
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "file-selector",
-        "approximateSize": 2662
-      },
-      {
-        "name": "prop-types",
-        "approximateSize": 1518
-      },
-      {
-        "name": "attr-accept",
-        "approximateSize": 4537
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "react-dropzone",
         "approximateSize": 7185
@@ -402,25 +358,57 @@
       {
         "name": "tslib",
         "approximateSize": 3700
+      },
+      {
+        "name": "attr-accept",
+        "approximateSize": 4537
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "just-extend",
+        "approximateSize": 645
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "prop-types",
+        "approximateSize": 1518
+      },
+      {
+        "name": "file-selector",
+        "approximateSize": 2662
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       }
     ],
-    "gzip": 49247,
-    "minified": 122330
+    "gzip": 49055,
+    "minified": 121227
   },
   "flex-grid": {
-    "size": 72302,
+    "size": 67449,
     "dependencySizes": [
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "styletron-react",
         "approximateSize": 6869
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
       },
       {
         "name": "react-is",
@@ -429,40 +417,44 @@
       {
         "name": "object-assign",
         "approximateSize": 1085
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       }
     ],
-    "gzip": 28432,
-    "minified": 71625
+    "gzip": 26665,
+    "minified": 66798
   },
   "form-control": {
-    "size": 58557,
+    "size": 57437,
     "dependencySizes": [
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 23362,
-    "minified": 57935
+    "gzip": 23091,
+    "minified": 56815
   },
   "header-navigation": {
-    "size": 58537,
+    "size": 57593,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -473,27 +465,31 @@
         "approximateSize": 6869
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 23220,
-    "minified": 57897
+    "gzip": 22929,
+    "minified": 56965
   },
   "heading": {
-    "size": 67016,
+    "size": 66135,
     "dependencySizes": [
       {
         "name": "react-is",
         "approximateSize": 1467
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
@@ -504,24 +500,16 @@
         "approximateSize": 6869
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
         "name": "object-assign",
         "approximateSize": 1085
       }
     ],
-    "gzip": 26526,
-    "minified": 66377
+    "gzip": 26600,
+    "minified": 65496
   },
   "icon": {
-    "size": 95061,
+    "size": 55126,
     "dependencySizes": [
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
@@ -535,63 +523,47 @@
         "approximateSize": 955
       },
       {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
         "name": "object-assign",
         "approximateSize": 1085
       }
     ],
-    "gzip": 30388,
-    "minified": 94438
+    "gzip": 22174,
+    "minified": 54503
   },
   "input": {
-    "size": 223214,
+    "size": 90643,
     "dependencySizes": [
-      {
-        "name": "webpack",
-        "approximateSize": 243
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
         "name": "react",
         "approximateSize": 5008
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "react-dom",
-        "approximateSize": 64818
-      },
-      {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
       }
     ],
-    "gzip": 106450,
-    "minified": 221826
+    "gzip": 34651,
+    "minified": 89914
   },
   "layer": {
-    "size": 193429,
+    "size": 165977,
     "dependencySizes": [
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "styletron-react",
         "approximateSize": 6869
@@ -601,20 +573,24 @@
         "approximateSize": 64818
       },
       {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
-        "name": "popper.js",
-        "approximateSize": 16380
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "webpack",
         "approximateSize": 243
       }
     ],
-    "gzip": 99054,
-    "minified": 191076
+    "gzip": 85249,
+    "minified": 164960
   },
   "link": {
     "size": 50369,
@@ -659,35 +635,35 @@
     "minified": 11068
   },
   "menu": {
-    "size": 259824,
+    "size": 236338,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "just-extend",
+        "approximateSize": 645
       },
       {
         "name": "styletron-standard",
         "approximateSize": 955
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "popper.js",
@@ -696,37 +672,21 @@
       {
         "name": "webpack",
         "approximateSize": 243
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
       }
     ],
-    "gzip": 121256,
-    "minified": 257018
+    "gzip": 115360,
+    "minified": 233577
   },
   "modal": {
-    "size": 245342,
+    "size": 226606,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
         "name": "react-focus-lock",
         "approximateSize": 8924
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
       },
       {
         "name": "@babel/runtime",
@@ -737,39 +697,51 @@
         "approximateSize": 8223
       },
       {
-        "name": "react-clientside-effect",
-        "approximateSize": 1058
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "prop-types",
-        "approximateSize": 1518
+        "name": "just-extend",
+        "approximateSize": 645
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
+        "name": "prop-types",
+        "approximateSize": 1518
       },
       {
         "name": "popper.js",
         "approximateSize": 16380
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "webpack",
         "approximateSize": 243
+      },
+      {
+        "name": "react-clientside-effect",
+        "approximateSize": 1058
       }
     ],
-    "gzip": 117809,
-    "minified": 242395
+    "gzip": 114208,
+    "minified": 223728
   },
   "notification": {
-    "size": 192117,
+    "size": 191800,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -788,35 +760,31 @@
         "approximateSize": 6869
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "just-extend",
         "approximateSize": 645
       },
       {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
         "name": "webpack",
         "approximateSize": 243
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 93990,
-    "minified": 190714
+    "gzip": 93795,
+    "minified": 190397
   },
   "pagination": {
-    "size": 442790,
+    "size": 436898,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
       },
       {
         "name": "memoize-one",
@@ -827,75 +795,79 @@
         "approximateSize": 1467
       },
       {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
-      {
-        "name": "polished",
-        "approximateSize": 28614
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
         "name": "object-assign",
         "approximateSize": 1085
-      },
-      {
-        "name": "webpack",
-        "approximateSize": 243
-      },
-      {
-        "name": "popper.js",
-        "approximateSize": 16380
-      }
-    ],
-    "gzip": 190042,
-    "minified": 439546
-  },
-  "payment-card": {
-    "size": 266593,
-    "dependencySizes": [
-      {
-        "name": "card-validator",
-        "approximateSize": 5516
-      },
-      {
-        "name": "webpack",
-        "approximateSize": 243
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
       },
       {
         "name": "react-input-mask",
         "approximateSize": 8501
       },
       {
+        "name": "just-extend",
+        "approximateSize": 645
+      },
+      {
+        "name": "polished",
+        "approximateSize": 28614
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
+        "name": "smoothscroll-polyfill",
+        "approximateSize": 2903
+      },
+      {
+        "name": "popper.js",
+        "approximateSize": 16380
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
+      }
+    ],
+    "gzip": 188823,
+    "minified": 433667
+  },
+  "payment-card": {
+    "size": 264966,
+    "dependencySizes": [
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "card-validator",
+        "approximateSize": 5516
+      },
+      {
         "name": "credit-card-type",
         "approximateSize": 5114
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
+        "name": "react-input-mask",
+        "approximateSize": 8501
       },
       {
         "name": "styletron-standard",
@@ -910,15 +882,27 @@
         "approximateSize": 64818
       }
     ],
-    "gzip": 128586,
-    "minified": 265072
+    "gzip": 128464,
+    "minified": 263457
   },
   "phone-input": {
-    "size": 993734,
+    "size": 988251,
     "dependencySizes": [
       {
         "name": "core-js",
-        "approximateSize": 35491
+        "approximateSize": 36279
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       },
       {
         "name": "react-virtualized",
@@ -933,44 +917,32 @@
         "approximateSize": 955
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
         "name": "react-input-mask",
         "approximateSize": 8501
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "prop-types",
-        "approximateSize": 1518
-      },
-      {
-        "name": "babel-runtime",
-        "approximateSize": 7356
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
       },
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
-        "name": "dom-helpers",
-        "approximateSize": 884
+        "name": "babel-runtime",
+        "approximateSize": 7356
+      },
+      {
+        "name": "prop-types",
+        "approximateSize": 1518
       },
       {
         "name": "smoothscroll-polyfill",
         "approximateSize": 2903
+      },
+      {
+        "name": "popper.js",
+        "approximateSize": 16380
+      },
+      {
+        "name": "dom-helpers",
+        "approximateSize": 884
       },
       {
         "name": "polished",
@@ -981,59 +953,59 @@
         "approximateSize": 391
       },
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "webpack",
+        "approximateSize": 243
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "@babel/runtime",
         "approximateSize": 174
       },
       {
-        "name": "webpack",
-        "approximateSize": 243
-      },
-      {
-        "name": "popper.js",
-        "approximateSize": 16380
-      },
-      {
         "name": "linear-layout-vector",
         "approximateSize": 4474
+      },
+      {
+        "name": "just-extend",
+        "approximateSize": 645
       }
     ],
-    "gzip": 514024,
-    "minified": 988063
+    "gzip": 515627,
+    "minified": 982593
   },
   "pin-code": {
-    "size": 233587,
+    "size": 229850,
     "dependencySizes": [
-      {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
       {
         "name": "webpack",
         "approximateSize": 243
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
       },
       {
         "name": "react-multi-ref",
         "approximateSize": 654
       },
       {
+        "name": "react-input-mask",
+        "approximateSize": 8501
+      },
+      {
         "name": "@babel/runtime",
         "approximateSize": 1134
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "styletron-react",
         "approximateSize": 6869
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
+        "name": "react",
+        "approximateSize": 5008
       },
       {
         "name": "react-is",
@@ -1048,89 +1020,81 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 109533,
-    "minified": 232178
+    "gzip": 108929,
+    "minified": 228454
   },
   "popover": {
-    "size": 221066,
+    "size": 213300,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
       },
       {
         "name": "popper.js",
         "approximateSize": 16380
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "webpack",
         "approximateSize": 243
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
       }
     ],
-    "gzip": 109856,
-    "minified": 218422
+    "gzip": 107146,
+    "minified": 210669
   },
   "progress-bar": {
-    "size": 59027,
+    "size": 57836,
     "dependencySizes": [
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 23583,
-    "minified": 58405
+    "gzip": 23223,
+    "minified": 57214
   },
   "progress-steps": {
-    "size": 67921,
+    "size": 59397,
     "dependencySizes": [
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
       {
         "name": "react-is",
         "approximateSize": 1467
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
       },
       {
         "name": "styletron-react",
@@ -1139,37 +1103,45 @@
       {
         "name": "styletron-standard",
         "approximateSize": 955
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 26811,
-    "minified": 67285
+    "gzip": 23693,
+    "minified": 58787
   },
   "radio": {
-    "size": 72545,
+    "size": 62315,
     "dependencySizes": [
       {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "styletron-react",
         "approximateSize": 6869
       },
       {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 28521,
-    "minified": 71894
+    "gzip": 25385,
+    "minified": 61696
   },
   "rating": {
     "size": 68893,
@@ -1199,27 +1171,23 @@
     "minified": 68253
   },
   "select": {
-    "size": 425976,
+    "size": 418247,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "polished",
-        "approximateSize": 28614
+        "name": "just-extend",
+        "approximateSize": 645
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "styletron-standard",
@@ -1230,31 +1198,35 @@
         "approximateSize": 8501
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "polished",
+        "approximateSize": 28614
       },
       {
-        "name": "just-extend",
-        "approximateSize": 645
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       },
       {
         "name": "smoothscroll-polyfill",
         "approximateSize": 2903
       },
       {
-        "name": "webpack",
-        "approximateSize": 243
-      },
-      {
         "name": "popper.js",
         "approximateSize": 16380
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
       }
     ],
-    "gzip": 187871,
-    "minified": 422754
+    "gzip": 185331,
+    "minified": 415038
   },
   "side-navigation": {
-    "size": 64559,
+    "size": 63293,
     "dependencySizes": [
       {
         "name": "object-assign",
@@ -1265,39 +1237,39 @@
         "approximateSize": 955
       },
       {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
         "name": "styletron-react",
         "approximateSize": 6869
       },
       {
         "name": "react-is",
         "approximateSize": 1467
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
       }
     ],
-    "gzip": 25111,
-    "minified": 63926
+    "gzip": 24975,
+    "minified": 62660
   },
   "slider": {
-    "size": 78910,
+    "size": 73398,
     "dependencySizes": [
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
       {
         "name": "react-range",
         "approximateSize": 9465
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "styletron-react",
@@ -1308,11 +1280,11 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 33308,
-    "minified": 78275
+    "gzip": 31844,
+    "minified": 72776
   },
   "spinner": {
-    "size": 60851,
+    "size": 60038,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -1327,75 +1299,39 @@
         "approximateSize": 6869
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 24571,
-    "minified": 60203
+    "gzip": 24527,
+    "minified": 59402
   },
   "table": {
-    "size": 269174,
+    "size": 56945,
     "dependencySizes": [
       {
-        "name": "react-dom",
-        "approximateSize": 64818
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "@babel/runtime",
-        "approximateSize": 1145
-      },
-      {
-        "name": "react-focus-lock",
-        "approximateSize": 8924
-      },
-      {
         "name": "styletron-react",
         "approximateSize": 6869
       },
       {
-        "name": "focus-lock",
-        "approximateSize": 8223
-      },
-      {
-        "name": "react-clientside-effect",
-        "approximateSize": 1058
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "prop-types",
-        "approximateSize": 1518
-      },
-      {
         "name": "object-assign",
         "approximateSize": 1085
-      },
-      {
-        "name": "popper.js",
-        "approximateSize": 16380
-      },
-      {
-        "name": "webpack",
-        "approximateSize": 243
       }
     ],
-    "gzip": 127709,
-    "minified": 266268
+    "gzip": 23010,
+    "minified": 56573
   },
   "table-grid": {
     "size": 270300,
@@ -1457,70 +1393,66 @@
     "minified": 267394
   },
   "tabs": {
-    "size": 67615,
+    "size": 59117,
     "dependencySizes": [
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
+      },
       {
         "name": "styletron-react",
         "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      }
+    ],
+    "gzip": 24032,
+    "minified": 58495
+  },
+  "tag": {
+    "size": 103608,
+    "dependencySizes": [
+      {
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
         "name": "react",
         "approximateSize": 5008
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      }
-    ],
-    "gzip": 26718,
-    "minified": 66967
-  },
-  "tag": {
-    "size": 104852,
-    "dependencySizes": [
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
       },
       {
         "name": "polished",
         "approximateSize": 28614
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "styletron-react",
         "approximateSize": 6869
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
       }
     ],
-    "gzip": 46361,
-    "minified": 104139
+    "gzip": 45785,
+    "minified": 102895
   },
   "textarea": {
-    "size": 229254,
+    "size": 226725,
     "dependencySizes": [
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
       {
         "name": "webpack",
         "approximateSize": 243
@@ -1542,20 +1474,32 @@
         "approximateSize": 5008
       },
       {
-        "name": "react-dom",
-        "approximateSize": 64818
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "object-assign",
         "approximateSize": 1085
+      },
+      {
+        "name": "react-dom",
+        "approximateSize": 64818
       }
     ],
-    "gzip": 107782,
-    "minified": 227853
+    "gzip": 107177,
+    "minified": 225324
   },
   "toast": {
-    "size": 189597,
+    "size": 69877,
     "dependencySizes": [
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
+      },
+      {
+        "name": "just-extend",
+        "approximateSize": 645
+      },
       {
         "name": "react-is",
         "approximateSize": 1467
@@ -1565,55 +1509,27 @@
         "approximateSize": 955
       },
       {
-        "name": "react-dom",
-        "approximateSize": 64818
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "webpack",
-        "approximateSize": 243
+        "name": "styletron-react",
+        "approximateSize": 6869
       }
     ],
-    "gzip": 93649,
-    "minified": 188207
+    "gzip": 28568,
+    "minified": 69144
   },
   "tooltip": {
-    "size": 230847,
+    "size": 225960,
     "dependencySizes": [
       {
         "name": "react-dom",
         "approximateSize": 64818
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
         "name": "styletron-react",
         "approximateSize": 6869
-      },
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
       },
       {
         "name": "styletron-standard",
@@ -1624,12 +1540,24 @@
         "approximateSize": 16380
       },
       {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
         "name": "webpack",
         "approximateSize": 243
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 111129,
-    "minified": 228162
+    "gzip": 110342,
+    "minified": 223303
   },
   "typography": {
     "size": 66573,

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "terser": "^4.1.4",
     "typescript": "^3.5.3",
     "webpack": "^4.17.1",
+    "webpack-bundle-analyzer": "^3.4.1",
     "webpack-cli": "^3.1.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2835,6 +2835,11 @@ acorn-jsx@^5.0.0:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.0.1.tgz#32a064fd925429216a09b141102bfdd185fae40e"
   integrity sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==
 
+acorn-walk@^6.1.1:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-6.2.0.tgz#123cb8f3b84c2171f1f7fb252615b1c78a6b1a8c"
+  integrity sha512-7evsyfH1cLOCdAzZAd43Cic04yKydNx0cF+7tiA19p1XnLLPU4dpCQOqpjqwokFe//vS0QqfqqjCS2JkiIs0cA==
+
 acorn@^5.0.0, acorn@^5.5.3:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-5.7.1.tgz#f095829297706a7c9776958c0afc8930a9b9d9d8"
@@ -4581,6 +4586,16 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bfj@^6.1.1:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/bfj/-/bfj-6.1.2.tgz#325c861a822bcb358a41c78a33b8e6e2086dde7f"
+  integrity sha512-BmBJa4Lip6BPRINSZ0BPEIfB1wUY/9rwbwvIHQA1KjX9om29B6id0wnWXq7m3bn5JrUVjeOTnVuhPT1FiHwPGw==
+  dependencies:
+    bluebird "^3.5.5"
+    check-types "^8.0.3"
+    hoopy "^0.1.4"
+    tryer "^1.0.1"
+
 bhttp@^1.2.1:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/bhttp/-/bhttp-1.2.4.tgz#fed0c24f765b35afc4940b08ab3214813e38f38f"
@@ -4643,6 +4658,11 @@ bluebird@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
   integrity sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==
+
+bluebird@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.5.tgz#a8d0afd73251effbbd5fe384a77d73003c17a71f"
+  integrity sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==
 
 bluebird@~3.4.6:
   version "3.4.7"
@@ -5203,6 +5223,11 @@ chardet@^0.7.0:
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
   integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
+check-types@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/check-types/-/check-types-8.0.3.tgz#3356cca19c889544f2d7a95ed49ce508a0ecf552"
+  integrity sha512-YpeKZngUmG65rLudJ4taU7VLkOCTMhNl/u4ctNC56LQS/zJTyNH0Lrtwm1tfTsbLlwvlfsA2d1c8vCf/Kh2KwQ==
+
 cheerio@^1.0.0-rc.2:
   version "1.0.0-rc.2"
   resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-1.0.0-rc.2.tgz#4b9f53a81b27e4d5dac31c0ffd0cfa03cc6830db"
@@ -5479,7 +5504,7 @@ commander@2.17.x, commander@^2.11.0, commander@^2.9.0, commander@~2.17.1:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
   integrity sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==
 
-commander@2.20.0, commander@^2.20.0:
+commander@2.20.0, commander@^2.18.0, commander@^2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -7614,7 +7639,7 @@ fileset@^2.0.3:
     glob "^7.0.3"
     minimatch "^3.0.3"
 
-filesize@3.6.1:
+filesize@3.6.1, filesize@^3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/filesize/-/filesize-3.6.1.tgz#090bb3ee01b6f801a8a8be99d31710b3422bb317"
   integrity sha512-7KjR1vv6qnicaPMi1iiTcI85CyYwRO/PSFCu6SvqL8jN2Wjt/NIYQTFtFs7fSDCYOstUkEWIQGFUg5YZQfjlcg==
@@ -8282,6 +8307,14 @@ gzip-size@5.0.0:
     duplexer "^0.1.1"
     pify "^3.0.0"
 
+gzip-size@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/gzip-size/-/gzip-size-5.1.1.tgz#cb9bee692f87c0612b232840a873904e4c135274"
+  integrity sha512-FNHi6mmoHvs1mxZAds4PpdCS6QG8B4C1krxJsMutgxl5t3+GlRTzzI3NEkifXx2pVsOvJdOGSmIgDhQ55FwdPA==
+  dependencies:
+    duplexer "^0.1.1"
+    pify "^4.0.1"
+
 handlebars@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.0.tgz#0d6a6f34ff1f63cecec8423aa4169827bf787c3a"
@@ -8448,6 +8481,11 @@ homedir-polyfill@^1.0.0, homedir-polyfill@^1.0.1:
   integrity sha1-TCu8inWJmP7r9e1oWA921GdotLw=
   dependencies:
     parse-passwd "^1.0.0"
+
+hoopy@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/hoopy/-/hoopy-0.1.4.tgz#609207d661100033a9a9402ad3dea677381c1b1d"
+  integrity sha512-HRcs+2mr52W0K+x8RzcLzuPPmVIKMSv97RGHy0Ea9y/mpcaK+xTrjICA04KAHi4GRzxliNqNJEFYWHghy3rSfQ==
 
 hosted-git-info@^2.1.4:
   version "2.7.1"
@@ -11706,6 +11744,11 @@ opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
   integrity sha512-pVOEP16TrAO2/fjej1IdOyupJY8KDUM1CvsaScRbw6oddvpQoOfGk4ywha0HKKVAD6RkW4x6Q+tNBwhf3Bgpuw==
+
+opener@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/opener/-/opener-1.5.1.tgz#6d2f0e77f1a0af0032aca716c2c1fbb8e7e8abed"
+  integrity sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA==
 
 opn@5.4.0, opn@^5.2.0, opn@^5.4.0:
   version "5.4.0"
@@ -15304,6 +15347,11 @@ trough@^1.0.0:
   resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
   integrity sha512-fwkLWH+DimvA4YCy+/nvJd61nWQQ2liO/nF/RjkTpiOGi+zxZzVkhb1mvbHIIW4b/8nDsYI8uTmAlc0nNkRMOw==
 
+tryer@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/tryer/-/tryer-1.0.1.tgz#f2c85406800b9b0f74c9f7465b81eaad241252f8"
+  integrity sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -15892,6 +15940,25 @@ webidl-conversions@^4.0.2:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-4.0.2.tgz#a855980b1f0b6b359ba1d5d9fb39ae941faa63ad"
   integrity sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==
 
+webpack-bundle-analyzer@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/webpack-bundle-analyzer/-/webpack-bundle-analyzer-3.4.1.tgz#430544c7ba1631baccf673475ca8300cb74a3c47"
+  integrity sha512-Bs8D/1zF+17lhqj2OYmzi7HEVYqEVxu7lCO9Ff8BwajenOU0vAwEoV8e4ICCPNZAcqR1PCR/7o2SkW+cnCmF0A==
+  dependencies:
+    acorn "^6.0.7"
+    acorn-walk "^6.1.1"
+    bfj "^6.1.1"
+    chalk "^2.4.1"
+    commander "^2.18.0"
+    ejs "^2.6.1"
+    express "^4.16.3"
+    filesize "^3.6.1"
+    gzip-size "^5.0.0"
+    lodash "^4.17.15"
+    mkdirp "^0.5.1"
+    opener "^1.5.1"
+    ws "^6.0.0"
+
 webpack-cli@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-3.1.0.tgz#d71a83687dcfeb758fdceeb0fe042f96bcf62994"
@@ -16221,6 +16288,13 @@ ws@^5.2.0:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
   integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.0.0:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.2.1.tgz#442fdf0a47ed64f59b6a5d8ff130f4748ed524fb"
+  integrity sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==
   dependencies:
     async-limiter "~1.0.0"
 


### PR DESCRIPTION
* adds an option to trigger the bundle analyzer
* build the main component file, instead of the index, so webpack can treeshake it properly