### PR TITLE
fix(docs): avoid page layout jumping when ToC changes

### DIFF
--- a/documentation-site/components/table-of-contents.js
+++ b/documentation-site/components/table-of-contents.js
@@ -74,6 +74,8 @@ const TableOfContents = props => {
         // to make sure we align vertically with the edit on github button
         marginTop: '-10px',
         marginBottom: 0,
+        // set predictable width to avoid page relayout when table of content changes
+        width: 160
       })}
     >
       {TOC.map(header => (

--- a/documentation-site/components/table-of-contents.js
+++ b/documentation-site/components/table-of-contents.js
@@ -75,7 +75,7 @@ const TableOfContents = props => {
         marginTop: '-10px',
         marginBottom: 0,
         // set predictable width to avoid page relayout when table of content changes
-        width: 160
+        width: 160,
       })}
     >
       {TOC.map(header => (


### PR DESCRIPTION
`Fixes #1, Fixes #2` <!-- remove the (`) quotes to link the issues -->

#### Description

In Base Web demo today, I noticed the whole page jumps when navigate between pages on the documentation site, for example: https://baseweb.design/getting-started/usage/ and https://baseweb.design/getting-started/learn/
This happened because the Table of Content component has unset width which grows and shrinks based on its children link. Setting the width to a fixed width would fix it. 160px was chosen because it's a reasonable width and it's based on the 8px grid used in designs. - Vietanh

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
