### PR TITLE
feat(phone-input): replace flag svg with emoji

### DIFF
--- a/component-sizes.json
+++ b/component-sizes.json
@@ -27,7 +27,7 @@
     "minified": 60011
   },
   "aspect-ratio-box": {
-    "size": 65866,
+    "size": 65906,
     "dependencySizes": [
       {
         "name": "styletron-react",
@@ -50,8 +50,8 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 26510,
-    "minified": 65223
+    "gzip": 26505,
+    "minified": 65263
   },
   "avatar": {
     "size": 57763,
@@ -81,7 +81,7 @@
     "minified": 57121
   },
   "block": {
-    "size": 63818,
+    "size": 63858,
     "dependencySizes": [
       {
         "name": "object-assign",
@@ -104,8 +104,8 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 25779,
-    "minified": 63190
+    "gzip": 26015,
+    "minified": 63230
   },
   "breadcrumbs": {
     "size": 63835,
@@ -251,7 +251,7 @@
     "minified": 63542
   },
   "datepicker": {
-    "size": 522622,
+    "size": 522644,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -278,20 +278,16 @@
         "approximateSize": 8501
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
       },
       {
-        "name": "just-extend",
-        "approximateSize": 645
-      },
-      {
         "name": "popper.js",
         "approximateSize": 16380
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
       },
       {
         "name": "webpack",
@@ -304,10 +300,14 @@
       {
         "name": "polished",
         "approximateSize": 28614
+      },
+      {
+        "name": "just-extend",
+        "approximateSize": 645
       }
     ],
-    "gzip": 217320,
-    "minified": 519031
+    "gzip": 216971,
+    "minified": 519053
   },
   "dnd-list": {
     "size": 189499,
@@ -349,7 +349,7 @@
     "minified": 188222
   },
   "file-uploader": {
-    "size": 122073,
+    "size": 122113,
     "dependencySizes": [
       {
         "name": "react-dropzone",
@@ -396,11 +396,11 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 49055,
-    "minified": 121227
+    "gzip": 49099,
+    "minified": 121267
   },
   "flex-grid": {
-    "size": 67449,
+    "size": 67489,
     "dependencySizes": [
       {
         "name": "styletron-standard",
@@ -423,8 +423,8 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 26665,
-    "minified": 66798
+    "gzip": 26848,
+    "minified": 66838
   },
   "form-control": {
     "size": 57437,
@@ -481,7 +481,7 @@
     "minified": 56965
   },
   "heading": {
-    "size": 66135,
+    "size": 66175,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -504,8 +504,8 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 26600,
-    "minified": 65496
+    "gzip": 26596,
+    "minified": 65536
   },
   "icon": {
     "size": 55126,
@@ -542,10 +542,6 @@
         "approximateSize": 1467
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
       },
@@ -554,11 +550,15 @@
         "approximateSize": 1085
       },
       {
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
         "name": "react",
         "approximateSize": 5008
       }
     ],
-    "gzip": 34651,
+    "gzip": 34054,
     "minified": 89914
   },
   "layer": {
@@ -780,7 +780,7 @@
     "minified": 190397
   },
   "pagination": {
-    "size": 436898,
+    "size": 436897,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -803,10 +803,6 @@
         "approximateSize": 955
       },
       {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
         "name": "react-input-mask",
         "approximateSize": 8501
       },
@@ -817,6 +813,10 @@
       {
         "name": "polished",
         "approximateSize": 28614
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       },
       {
         "name": "react",
@@ -835,33 +835,25 @@
         "approximateSize": 243
       }
     ],
-    "gzip": 188823,
-    "minified": 433667
+    "gzip": 190056,
+    "minified": 433666
   },
   "payment-card": {
-    "size": 264966,
+    "size": 264965,
     "dependencySizes": [
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
       {
         "name": "webpack",
         "approximateSize": 243
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
-      },
-      {
-        "name": "card-validator",
-        "approximateSize": 5516
       },
       {
         "name": "credit-card-type",
         "approximateSize": 5114
       },
       {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
         "name": "react",
         "approximateSize": 5008
       },
@@ -870,122 +862,130 @@
         "approximateSize": 8501
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
-        "name": "styletron-react",
-        "approximateSize": 6869
-      },
-      {
-        "name": "react-dom",
-        "approximateSize": 64818
-      }
-    ],
-    "gzip": 128464,
-    "minified": 263457
-  },
-  "phone-input": {
-    "size": 988251,
-    "dependencySizes": [
-      {
-        "name": "core-js",
-        "approximateSize": 36279
-      },
-      {
-        "name": "react",
-        "approximateSize": 5008
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
+        "name": "card-validator",
+        "approximateSize": 5516
       },
       {
         "name": "object-assign",
         "approximateSize": 1085
       },
       {
-        "name": "react-virtualized",
-        "approximateSize": 96118
-      },
-      {
-        "name": "react-lifecycles-compat",
-        "approximateSize": 1683
-      },
-      {
         "name": "styletron-standard",
         "approximateSize": 955
-      },
-      {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
-      {
-        "name": "react-dom",
-        "approximateSize": 64818
-      },
-      {
-        "name": "babel-runtime",
-        "approximateSize": 7356
-      },
-      {
-        "name": "prop-types",
-        "approximateSize": 1518
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
-        "name": "popper.js",
-        "approximateSize": 16380
-      },
-      {
-        "name": "dom-helpers",
-        "approximateSize": 884
-      },
-      {
-        "name": "polished",
-        "approximateSize": 28614
-      },
-      {
-        "name": "clsx",
-        "approximateSize": 391
-      },
-      {
-        "name": "webpack",
-        "approximateSize": 243
       },
       {
         "name": "styletron-react",
         "approximateSize": 6869
       },
       {
+        "name": "react-dom",
+        "approximateSize": 64818
+      }
+    ],
+    "gzip": 128235,
+    "minified": 263456
+  },
+  "phone-input": {
+    "size": 607886,
+    "dependencySizes": [
+      {
+        "name": "core-js",
+        "approximateSize": 41963
+      },
+      {
+        "name": "babel-runtime",
+        "approximateSize": 7356
+      },
+      {
+        "name": "react-virtualized",
+        "approximateSize": 96118
+      },
+      {
+        "name": "react",
+        "approximateSize": 5008
+      },
+      {
+        "name": "prop-types",
+        "approximateSize": 1518
+      },
+      {
+        "name": "dom-helpers",
+        "approximateSize": 884
+      },
+      {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
+        "name": "polished",
+        "approximateSize": 28614
+      },
+      {
+        "name": "react-dom",
+        "approximateSize": 64818
+      },
+      {
+        "name": "popper.js",
+        "approximateSize": 16380
+      },
+      {
+        "name": "smoothscroll-polyfill",
+        "approximateSize": 2903
+      },
+      {
+        "name": "react-lifecycles-compat",
+        "approximateSize": 1683
+      },
+      {
         "name": "@babel/runtime",
         "approximateSize": 174
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
+      },
+      {
+        "name": "react-input-mask",
+        "approximateSize": 8501
       },
       {
         "name": "linear-layout-vector",
         "approximateSize": 4474
       },
       {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
+      },
+      {
+        "name": "clsx",
+        "approximateSize": 391
+      },
+      {
         "name": "just-extend",
         "approximateSize": 645
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       }
     ],
-    "gzip": 515627,
-    "minified": 982593
+    "gzip": 275604,
+    "minified": 603680
   },
   "pin-code": {
-    "size": 229850,
+    "size": 229849,
     "dependencySizes": [
       {
         "name": "webpack",
         "approximateSize": 243
       },
       {
-        "name": "react-multi-ref",
-        "approximateSize": 654
+        "name": "react-is",
+        "approximateSize": 1467
       },
       {
         "name": "react-input-mask",
@@ -1004,12 +1004,12 @@
         "approximateSize": 6869
       },
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "react-multi-ref",
+        "approximateSize": 654
       },
       {
-        "name": "react-is",
-        "approximateSize": 1467
+        "name": "react",
+        "approximateSize": 5008
       },
       {
         "name": "react-dom",
@@ -1020,8 +1020,8 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 108929,
-    "minified": 228454
+    "gzip": 108583,
+    "minified": 228453
   },
   "popover": {
     "size": 213300,
@@ -1171,7 +1171,7 @@
     "minified": 68253
   },
   "select": {
-    "size": 418247,
+    "size": 418246,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -1190,6 +1190,10 @@
         "approximateSize": 6869
       },
       {
+        "name": "react-is",
+        "approximateSize": 1467
+      },
+      {
         "name": "styletron-standard",
         "approximateSize": 955
       },
@@ -1200,10 +1204,6 @@
       {
         "name": "polished",
         "approximateSize": 28614
-      },
-      {
-        "name": "react-is",
-        "approximateSize": 1467
       },
       {
         "name": "object-assign",
@@ -1222,8 +1222,8 @@
         "approximateSize": 243
       }
     ],
-    "gzip": 185331,
-    "minified": 415038
+    "gzip": 185025,
+    "minified": 415037
   },
   "side-navigation": {
     "size": 63293,
@@ -1253,16 +1253,8 @@
     "minified": 62660
   },
   "slider": {
-    "size": 73398,
+    "size": 73782,
     "dependencySizes": [
-      {
-        "name": "object-assign",
-        "approximateSize": 1085
-      },
-      {
-        "name": "react-range",
-        "approximateSize": 9465
-      },
       {
         "name": "styletron-standard",
         "approximateSize": 955
@@ -1272,16 +1264,24 @@
         "approximateSize": 1467
       },
       {
-        "name": "styletron-react",
-        "approximateSize": 6869
+        "name": "react-range",
+        "approximateSize": 9562
+      },
+      {
+        "name": "object-assign",
+        "approximateSize": 1085
       },
       {
         "name": "react",
         "approximateSize": 5008
+      },
+      {
+        "name": "styletron-react",
+        "approximateSize": 6869
       }
     ],
-    "gzip": 31844,
-    "minified": 72776
+    "gzip": 32359,
+    "minified": 73160
   },
   "spinner": {
     "size": 60038,
@@ -1451,7 +1451,7 @@
     "minified": 102895
   },
   "textarea": {
-    "size": 226725,
+    "size": 226724,
     "dependencySizes": [
       {
         "name": "webpack",
@@ -1462,16 +1462,16 @@
         "approximateSize": 6869
       },
       {
-        "name": "styletron-standard",
-        "approximateSize": 955
+        "name": "react",
+        "approximateSize": 5008
       },
       {
         "name": "react-input-mask",
         "approximateSize": 8501
       },
       {
-        "name": "react",
-        "approximateSize": 5008
+        "name": "styletron-standard",
+        "approximateSize": 955
       },
       {
         "name": "react-is",
@@ -1486,8 +1486,8 @@
         "approximateSize": 64818
       }
     ],
-    "gzip": 107177,
-    "minified": 225324
+    "gzip": 107522,
+    "minified": 225323
   },
   "toast": {
     "size": 69877,
@@ -1560,7 +1560,7 @@
     "minified": 223303
   },
   "typography": {
-    "size": 66573,
+    "size": 66613,
     "dependencySizes": [
       {
         "name": "styletron-standard",
@@ -1583,7 +1583,7 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 26653,
-    "minified": 65945
+    "gzip": 26642,
+    "minified": 65985
   }
 }

--- a/component-sizes.json
+++ b/component-sizes.json
@@ -139,7 +139,7 @@
     "minified": 63112
   },
   "button": {
-    "size": 64935,
+    "size": 64954,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -162,11 +162,11 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 26045,
-    "minified": 64278
+    "gzip": 25978,
+    "minified": 64297
   },
   "button-group": {
-    "size": 72832,
+    "size": 72851,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -193,8 +193,8 @@
         "approximateSize": 645
       }
     ],
-    "gzip": 28605,
-    "minified": 72072
+    "gzip": 28755,
+    "minified": 72091
   },
   "card": {
     "size": 57557,
@@ -251,7 +251,7 @@
     "minified": 63542
   },
   "datepicker": {
-    "size": 522644,
+    "size": 522663,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -306,8 +306,8 @@
         "approximateSize": 645
       }
     ],
-    "gzip": 216971,
-    "minified": 519053
+    "gzip": 216572,
+    "minified": 519072
   },
   "dnd-list": {
     "size": 189499,
@@ -349,7 +349,7 @@
     "minified": 188222
   },
   "file-uploader": {
-    "size": 122113,
+    "size": 122132,
     "dependencySizes": [
       {
         "name": "react-dropzone",
@@ -396,8 +396,8 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 49099,
-    "minified": 121267
+    "gzip": 49106,
+    "minified": 121286
   },
   "flex-grid": {
     "size": 67489,
@@ -535,7 +535,7 @@
     "minified": 54503
   },
   "input": {
-    "size": 90643,
+    "size": 90662,
     "dependencySizes": [
       {
         "name": "react-is",
@@ -558,8 +558,8 @@
         "approximateSize": 5008
       }
     ],
-    "gzip": 34054,
-    "minified": 89914
+    "gzip": 34210,
+    "minified": 89933
   },
   "layer": {
     "size": 165977,
@@ -780,7 +780,7 @@
     "minified": 190397
   },
   "pagination": {
-    "size": 436897,
+    "size": 436916,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -835,11 +835,11 @@
         "approximateSize": 243
       }
     ],
-    "gzip": 190056,
-    "minified": 433666
+    "gzip": 189395,
+    "minified": 433685
   },
   "payment-card": {
-    "size": 264965,
+    "size": 264984,
     "dependencySizes": [
       {
         "name": "webpack",
@@ -882,87 +882,27 @@
         "approximateSize": 64818
       }
     ],
-    "gzip": 128235,
-    "minified": 263456
+    "gzip": 128172,
+    "minified": 263475
   },
   "phone-input": {
-    "size": 607886,
+    "size": 461331,
     "dependencySizes": [
       {
-        "name": "core-js",
-        "approximateSize": 41963
-      },
-      {
-        "name": "babel-runtime",
-        "approximateSize": 7356
-      },
-      {
-        "name": "react-virtualized",
-        "approximateSize": 96118
+        "name": "react-dom",
+        "approximateSize": 64818
       },
       {
         "name": "react",
         "approximateSize": 5008
       },
       {
-        "name": "prop-types",
-        "approximateSize": 1518
-      },
-      {
-        "name": "dom-helpers",
-        "approximateSize": 884
-      },
-      {
         "name": "react-is",
         "approximateSize": 1467
       },
       {
-        "name": "polished",
-        "approximateSize": 28614
-      },
-      {
-        "name": "react-dom",
-        "approximateSize": 64818
-      },
-      {
-        "name": "popper.js",
-        "approximateSize": 16380
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
-        "name": "react-lifecycles-compat",
-        "approximateSize": 1683
-      },
-      {
-        "name": "@babel/runtime",
-        "approximateSize": 174
-      },
-      {
-        "name": "webpack",
-        "approximateSize": 243
-      },
-      {
-        "name": "react-input-mask",
-        "approximateSize": 8501
-      },
-      {
-        "name": "linear-layout-vector",
-        "approximateSize": 4474
-      },
-      {
-        "name": "styletron-standard",
-        "approximateSize": 955
-      },
-      {
         "name": "styletron-react",
         "approximateSize": 6869
-      },
-      {
-        "name": "clsx",
-        "approximateSize": 391
       },
       {
         "name": "just-extend",
@@ -971,13 +911,37 @@
       {
         "name": "object-assign",
         "approximateSize": 1085
+      },
+      {
+        "name": "styletron-standard",
+        "approximateSize": 955
+      },
+      {
+        "name": "react-input-mask",
+        "approximateSize": 8501
+      },
+      {
+        "name": "polished",
+        "approximateSize": 28614
+      },
+      {
+        "name": "smoothscroll-polyfill",
+        "approximateSize": 2903
+      },
+      {
+        "name": "popper.js",
+        "approximateSize": 16380
+      },
+      {
+        "name": "webpack",
+        "approximateSize": 243
       }
     ],
-    "gzip": 275604,
-    "minified": 603680
+    "gzip": 204596,
+    "minified": 458716
   },
   "pin-code": {
-    "size": 229849,
+    "size": 229868,
     "dependencySizes": [
       {
         "name": "webpack",
@@ -1020,8 +984,8 @@
         "approximateSize": 1085
       }
     ],
-    "gzip": 108583,
-    "minified": 228453
+    "gzip": 108950,
+    "minified": 228472
   },
   "popover": {
     "size": 213300,
@@ -1171,7 +1135,7 @@
     "minified": 68253
   },
   "select": {
-    "size": 418246,
+    "size": 418265,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -1222,8 +1186,8 @@
         "approximateSize": 243
       }
     ],
-    "gzip": 185025,
-    "minified": 415037
+    "gzip": 184682,
+    "minified": 415056
   },
   "side-navigation": {
     "size": 63293,
@@ -1334,7 +1298,7 @@
     "minified": 56573
   },
   "table-grid": {
-    "size": 270300,
+    "size": 270319,
     "dependencySizes": [
       {
         "name": "react-dom",
@@ -1389,8 +1353,8 @@
         "approximateSize": 955
       }
     ],
-    "gzip": 128096,
-    "minified": 267394
+    "gzip": 128097,
+    "minified": 267413
   },
   "tabs": {
     "size": 59117,
@@ -1451,7 +1415,7 @@
     "minified": 102895
   },
   "textarea": {
-    "size": 226724,
+    "size": 226743,
     "dependencySizes": [
       {
         "name": "webpack",
@@ -1486,8 +1450,8 @@
         "approximateSize": 64818
       }
     ],
-    "gzip": 107522,
-    "minified": 225323
+    "gzip": 107519,
+    "minified": 225342
   },
   "toast": {
     "size": 69877,

--- a/documentation-site/examples/phone-input/flag-overrides.js
+++ b/documentation-site/examples/phone-input/flag-overrides.js
@@ -1,0 +1,34 @@
+// @flow
+import React, {useState} from 'react';
+import {
+  PhoneInput,
+  COUNTRIES,
+  StyledFlag,
+} from 'baseui/phone-input';
+
+function CustomFlag(props) {
+  const {children, ...rest} = props;
+  return <StyledFlag iso={props.$iso} {...rest} />;
+}
+
+export default () => {
+  const [text, setText] = useState('');
+  const [country, setCountry] = useState(COUNTRIES.US);
+  return (
+    <PhoneInput
+      text={text}
+      country={country}
+      onTextChange={event => {
+        setText(event.currentTarget.value);
+      }}
+      onCountryChange={(event: any) => {
+        setCountry(event.option);
+      }}
+      overrides={{
+        FlagContainer: {
+          component: CustomFlag,
+        },
+      }}
+    />
+  );
+};

--- a/documentation-site/examples/phone-input/flag-overrides.tsx
+++ b/documentation-site/examples/phone-input/flag-overrides.tsx
@@ -1,4 +1,3 @@
-// @flow
 import * as React from 'react';
 import {
   PhoneInput,
@@ -6,12 +5,8 @@ import {
   CountrySelectDropdown,
   StyledFlag,
 } from 'baseui/phone-input';
-import type {CountryIsoT} from 'baseui/phone-input';
 
-function CustomFlag(props: {
-  children: React.Node,
-  $iso: CountryIsoT,
-}) {
+function CustomFlag(props: any) {
   const {children, ...rest} = props;
   return <StyledFlag iso={props.$iso} {...rest} />;
 }

--- a/documentation-site/examples/phone-input/localized.js
+++ b/documentation-site/examples/phone-input/localized.js
@@ -4,7 +4,7 @@ import {PhoneInput, COUNTRIES} from 'baseui/phone-input';
 
 const iso2FlagEmoji = (iso: any) =>
   String.fromCodePoint(
-    ...[...iso.toUpperCase()].map(
+    ...Array.from(iso.toUpperCase()).map(
       char => char.charCodeAt(0) + 127397,
     ),
   );

--- a/documentation-site/examples/phone-input/localized.tsx
+++ b/documentation-site/examples/phone-input/localized.tsx
@@ -3,8 +3,8 @@ import {PhoneInput, COUNTRIES} from 'baseui/phone-input';
 
 const iso2FlagEmoji = (iso: any) =>
   String.fromCodePoint(
-    ...[...iso.toUpperCase()].map(
-      char => char.charCodeAt(0) + 127397,
+    ...Array.from(iso.toUpperCase()).map(
+      (char: any) => char.charCodeAt(0) + 127397,
     ),
   );
 

--- a/documentation-site/pages/components/phone-input.mdx
+++ b/documentation-site/pages/components/phone-input.mdx
@@ -20,6 +20,7 @@ import {Block} from 'baseui/block/index.js';
 import PhoneInputBasic from 'examples/phone-input/basic.js';
 import PhoneInputUncontrolled from 'examples/phone-input/uncontrolled.js';
 import PhoneInputLocalized from 'examples/phone-input/localized.js';
+import FlagOverrides from 'examples/phone-input/flag-overrides.js';
 import WithNestedOverrides from 'examples/phone-input/nested-overrides.js';
 
 export default Layout;
@@ -37,6 +38,10 @@ It contains a dropdown which allows the user to choose from a list of countries 
 
 <Example title="Localized country names" path="phone-input/localized.js">
   <PhoneInputLocalized />
+</Example>
+
+<Example title="With flag overrides" path="phone-input/flag-overrides.js">
+  <FlagOverrides />
 </Example>
 
 <Example title="With nested overrides" path="phone-input/nested-overrides.js">

--- a/documentation-site/pages/components/phone-input.mdx
+++ b/documentation-site/pages/components/phone-input.mdx
@@ -40,7 +40,10 @@ It contains a dropdown which allows the user to choose from a list of countries 
   <PhoneInputLocalized />
 </Example>
 
-<Example title="With flag overrides" path="phone-input/flag-overrides.js">
+<Example
+  title="With flag overrides and virtualized dropdown list"
+  path="phone-input/flag-overrides.js"
+>
   <FlagOverrides />
 </Example>
 

--- a/src/phone-input/__tests__/country-select-dropdown.scenario.js
+++ b/src/phone-input/__tests__/country-select-dropdown.scenario.js
@@ -9,7 +9,7 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 // eslint-disable-next-line import/extensions
 import Screener, {Steps} from 'screener-storybook/src/screener';
-import {StatefulPhoneInput} from '../index.js';
+import {StatefulPhoneInput, SIZE} from '../index.js';
 
 export const name = 'phone-input-dropdown';
 
@@ -23,7 +23,11 @@ export const component = () => {
         .snapshot('Phone input country selector dropdown')
         .end()}
     >
+      <StatefulPhoneInput size={SIZE.compact} />
+      <br />
       <StatefulPhoneInput />
+      <br />
+      <StatefulPhoneInput size={SIZE.large} />
     </Screener>
   );
 };

--- a/src/phone-input/__tests__/phone-input.e2e.js
+++ b/src/phone-input/__tests__/phone-input.e2e.js
@@ -22,7 +22,7 @@ const selectors = {
 };
 
 const countryListItemForIso = iso =>
-  `${selectors.phoneInputSelectListItem}[data-iso="${iso}"]`;
+  `${selectors.phoneInputSelectListItem} [data-iso="${iso}"]`;
 
 const unitedStates = {iso: 'US', dialCode: '+1'};
 const unitedKingdom = {iso: 'GB', dialCode: '+44'};

--- a/src/phone-input/__tests__/phone-input.scenario.js
+++ b/src/phone-input/__tests__/phone-input.scenario.js
@@ -12,4 +12,18 @@ import {StatefulPhoneInput} from '../index.js';
 
 export const name = 'phone-input';
 
-export const component = () => <StatefulPhoneInput />;
+export const component = () => (
+  <StatefulPhoneInput
+    overrides={{
+      CountrySelectDropdownListItem: {
+        props: {'data-e2e': 'country-select-list-item'},
+      },
+      FlagContainer: {
+        props: {'data-e2e': 'country-flag'},
+      },
+      DialCode: {
+        props: {'data-e2e': 'phone-input-dialcode'},
+      },
+    }}
+  />
+);

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -90,26 +90,27 @@ function CountrySelectDropdown(
                 const {resetMenu, getItemLabel, ...rest} = children[
                   index
                 ].props;
+                const iso = children[index].props.item.id;
                 return (
                   <ListItem
                     key={key}
                     style={style}
                     {...rest}
                     {...listItemProps}
-                    data-e2e="country-select-list-item"
-                    data-iso={children[index].props.item.id}
+                    data-iso={iso}
                   >
                     <FlagColumn {...flagColumnProps}>
                       <FlagContainer
-                        $iso={children[index].props.item.id}
+                        $iso={iso}
+                        data-iso={iso}
                         {...flagContainerProps}
                       >
-                        {iso2FlagEmoji(children[index].props.item.id)}
+                        {iso2FlagEmoji(iso)}
                       </FlagContainer>
                     </FlagColumn>
                     <NameColumn {...nameColumnProps}>
                       {mapIsoToLabel
-                        ? mapIsoToLabel(children[index].props.item.id)
+                        ? mapIsoToLabel(iso)
                         : children[index].props.item.label}
                     </NameColumn>
                     <Dialcode {...dialcodeProps}>

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -11,7 +11,7 @@ import {List, AutoSizer} from 'react-virtualized';
 
 import defaultProps from './default-props.js';
 import {
-  StyledFlag,
+  StyledFlagContainer,
   StyledCountrySelectDropdownContainer as DefaultContainer,
   StyledCountrySelectDropdownListItem as DefaultListItem,
   StyledCountrySelectDropdownFlagColumn as DefaultFlagColumn,
@@ -19,6 +19,7 @@ import {
   StyledCountrySelectDropdownDialcodeColumn as DefaultDialcodeColumn,
 } from './styled-components.js';
 import {getOverrides} from '../helpers/overrides.js';
+import {iso2FlagEmoji} from './utils.js';
 
 import type {CountrySelectDropdownPropsT} from './types.js';
 
@@ -31,11 +32,11 @@ function CountrySelectDropdown(
   props: CountrySelectDropdownPropsT & {forwardedRef: React.ElementRef<*>},
 ) {
   const {
-    forwardedRef,
     country,
-    overrides,
+    forwardedRef,
     maxDropdownHeight,
     mapIsoToLabel,
+    overrides,
   } = props;
 
   const children = React.Children.toArray(props.children);
@@ -51,6 +52,10 @@ function CountrySelectDropdown(
   const [FlagColumn, flagColumnProps] = getOverrides(
     overrides.CountrySelectDropdownFlagColumn,
     DefaultFlagColumn,
+  );
+  const [FlagContainer, flagContainerProps] = getOverrides(
+    overrides.FlagContainer,
+    StyledFlagContainer,
   );
   const [NameColumn, nameColumnProps] = getOverrides(
     overrides.CountrySelectDropdownNameColumn,
@@ -95,11 +100,16 @@ function CountrySelectDropdown(
                     data-iso={children[index].props.item.id}
                   >
                     <FlagColumn {...flagColumnProps}>
-                      <StyledFlag iso={children[index].props.item.id} />
+                      <FlagContainer
+                        $iso={children[index].props.item.id}
+                        {...flagContainerProps}
+                      >
+                        {iso2FlagEmoji(children[index].props.item.id)}
+                      </FlagContainer>
                     </FlagColumn>
                     <NameColumn {...nameColumnProps}>
                       {mapIsoToLabel
-                        ? mapIsoToLabel(props.children[index].props.item.id)
+                        ? mapIsoToLabel(children[index].props.item.id)
                         : children[index].props.item.label}
                     </NameColumn>
                     <Dialcode {...dialcodeProps}>

--- a/src/phone-input/country-select-dropdown.js
+++ b/src/phone-input/country-select-dropdown.js
@@ -8,7 +8,6 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 import {List, AutoSizer} from 'react-virtualized';
-
 import defaultProps from './default-props.js';
 import {
   StyledFlagContainer,
@@ -29,14 +28,14 @@ CountrySelectDropdown.defaultProps = {
 };
 
 function CountrySelectDropdown(
-  props: CountrySelectDropdownPropsT & {forwardedRef: React.ElementRef<*>},
+  props: CountrySelectDropdownPropsT & {$forwardedRef: React.ElementRef<*>},
 ) {
   const {
-    country,
-    forwardedRef,
-    maxDropdownHeight,
-    mapIsoToLabel,
-    overrides,
+    $country: country,
+    $forwardedRef: forwardedRef,
+    $maxDropdownHeight: maxDropdownHeight,
+    $mapIsoToLabel: mapIsoToLabel,
+    $overrides: overrides,
   } = props;
 
   const children = React.Children.toArray(props.children);
@@ -105,7 +104,7 @@ function CountrySelectDropdown(
                         data-iso={iso}
                         {...flagContainerProps}
                       >
-                        {iso2FlagEmoji(iso)}
+                        ABC {iso2FlagEmoji(iso)}
                       </FlagContainer>
                     </FlagColumn>
                     <NameColumn {...nameColumnProps}>
@@ -130,4 +129,4 @@ function CountrySelectDropdown(
 export default React.forwardRef<
   CountrySelectDropdownPropsT,
   typeof CountrySelectDropdown,
->((props, ref) => <CountrySelectDropdown {...props} forwardedRef={ref} />);
+>((props, ref) => <CountrySelectDropdown {...props} $forwardedRef={ref} />);

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -8,7 +8,11 @@ LICENSE file in the root directory of this source tree.
 
 import React from 'react';
 
-import {StyledRoot, StyledFlag, StyledDialCode} from './styled-components.js';
+import {
+  StyledRoot,
+  StyledFlagContainer,
+  StyledDialCode,
+} from './styled-components.js';
 import {COUNTRIES} from './constants.js';
 import CountrySelectDropdown from './country-select-dropdown.js';
 import {Block} from '../block/index.js';
@@ -16,6 +20,7 @@ import {Select as DefaultSelect} from '../select/index.js';
 import {PLACEMENT} from '../popover/index.js';
 import {getOverrides, mergeOverrides} from '../helpers/overrides.js';
 import defaultProps from './default-props.js';
+import {iso2FlagEmoji} from './utils.js';
 
 import type {CountryT, CountrySelectPropsT} from './types.js';
 
@@ -32,18 +37,27 @@ export default function CountrySelect(props: CountrySelectPropsT) {
   const {
     country,
     disabled,
+    error,
     inputRef,
     maxDropdownHeight,
     maxDropdownWidth,
     mapIsoToLabel,
     onCountryChange,
     overrides,
+    positive,
+    required,
     size,
   } = props;
+  const sharedProps = {
+    $disabled: disabled,
+    $error: error,
+    $positive: positive,
+    $required: required,
+    $size: size,
+  };
   const baseOverrides = {
     Root: {
       component: StyledRoot,
-      props: {$size: size},
     },
     ControlContainer: {
       style: props => {
@@ -75,9 +89,9 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     Dropdown: {
       component: CountrySelectDropdown,
       props: {
-        country: country,
-        maxDropdownHeight: maxDropdownHeight,
-        mapIsoToLabel: mapIsoToLabel,
+        country,
+        maxDropdownHeight,
+        mapIsoToLabel,
         overrides: {
           CountrySelectDropdown: overrides.CountrySelectDropdown,
           CountrySelectDropdownListItem:
@@ -88,6 +102,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
             overrides.CountrySelectDropdownNameColumn,
           CountrySelectDropdownDialcodeColumn:
             overrides.CountrySelectDropdownDialcodeColumn,
+          FlagContainer: overrides.FlagContainer,
         },
       },
     },
@@ -101,6 +116,12 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     overrides.CountrySelect,
     DefaultSelect,
   );
+
+  const [FlagContainer, flagContainerProps] = getOverrides(
+    overrides.FlagContainer,
+    StyledFlagContainer,
+  );
+
   // $FlowFixMe
   selectProps.overrides = mergeOverrides(baseOverrides, selectProps.overrides);
   const [DialCode, dialCodeProps] = getOverrides(
@@ -110,9 +131,20 @@ export default function CountrySelect(props: CountrySelectPropsT) {
   return (
     <Block display="flex" alignItems="center">
       <Select
-        size={size}
-        value={[country]}
+        clearable={false}
         disabled={disabled}
+        getValueLabel={(value: {option: CountryT}) => {
+          return (
+            <FlagContainer
+              $iso={value.option.id}
+              {...sharedProps}
+              {...flagContainerProps}
+            >
+              {iso2FlagEmoji(value.option.id)}
+            </FlagContainer>
+          );
+        }}
+        error={error}
         onChange={event => {
           onCountryChange(event);
           // After choosing a country, shift focus to the text input
@@ -121,14 +153,18 @@ export default function CountrySelect(props: CountrySelectPropsT) {
           }
         }}
         options={Object.values(COUNTRIES)}
-        clearable={false}
+        positive={positive}
+        required={required}
         searchable={false}
-        getValueLabel={(value: {option: CountryT}) => {
-          return <StyledFlag iso={value.option.id} $size={size} />;
-        }}
+        size={size}
+        value={[country]}
         {...selectProps}
       />
-      <DialCode data-e2e="phone-input-dialcode" {...dialCodeProps}>
+      <DialCode
+        data-e2e="phone-input-dialcode"
+        {...sharedProps}
+        {...dialCodeProps}
+      >
         {country.dialCode}
       </DialCode>
     </Block>

--- a/src/phone-input/country-select.js
+++ b/src/phone-input/country-select.js
@@ -128,19 +128,22 @@ export default function CountrySelect(props: CountrySelectPropsT) {
     overrides.DialCode,
     StyledDialCode,
   );
+
   return (
     <Block display="flex" alignItems="center">
       <Select
         clearable={false}
         disabled={disabled}
         getValueLabel={(value: {option: CountryT}) => {
+          const iso = value.option.id;
           return (
             <FlagContainer
-              $iso={value.option.id}
+              $iso={iso}
+              data-iso={iso}
               {...sharedProps}
               {...flagContainerProps}
             >
-              {iso2FlagEmoji(value.option.id)}
+              {iso2FlagEmoji(iso)}
             </FlagContainer>
           );
         }}
@@ -160,11 +163,7 @@ export default function CountrySelect(props: CountrySelectPropsT) {
         value={[country]}
         {...selectProps}
       />
-      <DialCode
-        data-e2e="phone-input-dialcode"
-        {...sharedProps}
-        {...dialCodeProps}
-      >
+      <DialCode {...sharedProps} {...dialCodeProps}>
         {country.dialCode}
       </DialCode>
     </Block>

--- a/src/phone-input/flag.js
+++ b/src/phone-input/flag.js
@@ -26,14 +26,7 @@ export default function Flag(props: {
   const {$iso, iso: oldIsoProp, width = '16px', ...restProps} = props;
   const iso: CountryIsoT = oldIsoProp || $iso;
   const FlagComponent = flags[`Flag${iso.toUpperCase()}`];
-  return (
-    <FlagComponent
-      width={width}
-      data-e2e="country-flag"
-      data-iso={iso}
-      {...restProps}
-    />
-  );
+  return <FlagComponent width={width} data-iso={iso} {...restProps} />;
 }
 
 export const StyledFlag = styled<typeof Flag, SizeStyleProps>(

--- a/src/phone-input/flag.js
+++ b/src/phone-input/flag.js
@@ -9,11 +9,23 @@ LICENSE file in the root directory of this source tree.
 import React from 'react';
 
 import * as flags from './flags/index.js';
-import type {CountryIsoT} from './types.js';
+import {styled} from '../styles/index.js';
+import {SIZE} from './constants.js';
+import type {CountryIsoT, SizeT} from './types.js';
 
-export default function Flag(props: {iso: CountryIsoT, width?: string}) {
-  const {iso, width = '16px', ...restProps} = props;
-  const FlagComponent = flags[`Flag${props.iso.toUpperCase()}`];
+type SizeStyleProps = {
+  $size?: SizeT,
+};
+
+export default function Flag(props: {
+  $iso: CountryIsoT,
+  // remove `iso` prop in the next major version
+  iso?: CountryIsoT,
+  width?: string,
+}) {
+  const {$iso, iso: oldIsoProp, width = '16px', ...restProps} = props;
+  const iso: CountryIsoT = oldIsoProp || $iso;
+  const FlagComponent = flags[`Flag${iso.toUpperCase()}`];
   return (
     <FlagComponent
       width={width}
@@ -23,3 +35,17 @@ export default function Flag(props: {iso: CountryIsoT, width?: string}) {
     />
   );
 }
+
+export const StyledFlag = styled<typeof Flag, SizeStyleProps>(
+  Flag,
+  ({$size = SIZE.default, $theme: {sizing}}) => {
+    const sizeToWidth = {
+      [SIZE.compact]: sizing.scale800,
+      [SIZE.default]: sizing.scale900,
+      [SIZE.large]: sizing.scale1000,
+    };
+    return {
+      width: sizeToWidth[$size],
+    };
+  },
+);

--- a/src/phone-input/index.d.ts
+++ b/src/phone-input/index.d.ts
@@ -320,6 +320,7 @@ export interface PhoneInputOverrides {
   CountrySelectDropdownFlagColumn?: Override<any>;
   CountrySelectDropdownNameColumn?: Override<any>;
   CountrySelectDropdownDialcodeColumn?: Override<any>;
+  FlagContainer?: Override<any>;
 }
 export interface PhoneInputProps {
   'aria-label'?: string;
@@ -396,6 +397,7 @@ export interface CountrySelectProps {
     CountrySelectDropdownFlagColumn?: Override<any>;
     CountrySelectDropdownNameColumn?: Override<any>;
     CountrySelectDropdownDialcodeColumn?: Override<any>;
+    FlagContainer?: Override<any>;
   };
 }
 export const CountrySelect: React.FC<CountrySelectProps>;
@@ -411,6 +413,7 @@ export interface CountrySelectDropdownProps {
     CountrySelectDropdownFlagColumn?: Override<any>;
     CountrySelectDropdownNameColumn?: Override<any>;
     CountrySelectDropdownDialcodeColumn?: Override<any>;
+    FlagContainer?: Override<any>;
   };
 }
 export const CountrySelectDropdown: React.RefForwardingComponent<

--- a/src/phone-input/index.js
+++ b/src/phone-input/index.js
@@ -13,7 +13,7 @@ export {
 } from './stateful-phone-input-container.js';
 export {default as CountrySelect} from './country-select.js';
 export {default as CountrySelectDropdown} from './country-select-dropdown.js';
-export {default as Flag} from './flag.js';
+export {default as Flag, StyledFlag} from './flag.js';
 export * from './constants.js';
 export * from './types.js';
 export * from './styled-components.js';

--- a/src/phone-input/phone-input.js
+++ b/src/phone-input/phone-input.js
@@ -30,6 +30,7 @@ export default function PhoneInput(props: PropsT) {
     overrides,
     placeholder,
     positive,
+    required,
     size,
     text,
     ...restProps
@@ -44,10 +45,13 @@ export default function PhoneInput(props: PropsT) {
       props: {
         country,
         disabled,
+        error,
         inputRef,
         mapIsoToLabel,
         onCountryChange,
         overrides,
+        positive,
+        required,
         size,
       },
     },

--- a/src/phone-input/styled-components.js
+++ b/src/phone-input/styled-components.js
@@ -5,8 +5,6 @@ This source code is licensed under the MIT license found in the
 LICENSE file in the root directory of this source tree.
 */
 // @flow
-
-import Flag from './flag.js';
 import {SIZE} from './constants.js';
 import {styled, withStyle} from '../styles/index.js';
 import {StyledList} from '../menu/index.js';
@@ -15,22 +13,23 @@ import {
   StyledRoot as SelectStyledRoot,
 } from '../select/index.js';
 import defaultProps from '../select/default-props.js';
+import type {SizeT} from './types.js';
 
 type SizeStyleProps = {
-  $size?: $Keys<typeof SIZE>,
+  $size?: SizeT,
 };
 type HeightStyleProps = {$height: string};
 
-export const StyledFlag = styled<typeof Flag, SizeStyleProps>(
-  Flag,
+export const StyledFlagContainer = styled<SizeStyleProps>(
+  'span',
   ({$size = SIZE.default, $theme: {sizing}}) => {
-    const sizeToWidth = {
+    const sizeToFont = {
       [SIZE.compact]: sizing.scale800,
       [SIZE.default]: sizing.scale900,
       [SIZE.large]: sizing.scale1000,
     };
     return {
-      width: sizeToWidth[$size],
+      fontSize: sizeToFont[$size],
     };
   },
 );

--- a/src/phone-input/styled-components.js
+++ b/src/phone-input/styled-components.js
@@ -75,6 +75,7 @@ export const StyledCountrySelectDropdownListItem = withStyle<
   paddingRight: 0,
   display: 'flex',
   alignItems: 'center',
+  height: '42px',
 });
 
 export const StyledCountrySelectDropdownFlagColumn = styled<{}>(

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -51,12 +51,14 @@ export type CountrySelectDropdownPropsT = {
     CountrySelectDropdownFlagColumn?: OverrideT<*>,
     CountrySelectDropdownNameColumn?: OverrideT<*>,
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
+    FlagContainer?: OverrideT<*>,
   },
 };
 
 export type CountrySelectPropsT = {
   country: CountryT,
   disabled: boolean,
+  error: boolean,
   inputRef: {current: HTMLInputElement | null},
   onCountryChange: (event: OnChangeParamsT) => mixed,
   mapIsoToLabel?: mapIsoToLabelT,
@@ -70,7 +72,10 @@ export type CountrySelectPropsT = {
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
     DialCode?: OverrideT<*>,
     CountrySelect?: OverrideT<*>,
+    FlagContainer?: OverrideT<*>,
   },
+  positive: boolean,
+  required: boolean,
   size: SizeT,
 };
 
@@ -110,6 +115,7 @@ export type PropsT = {
     CountrySelectDropdownDialcodeColumn?: OverrideT<*>,
     DialCode?: OverrideT<*>,
     CountrySelect?: OverrideT<*>,
+    FlagContainer?: OverrideT<*>,
   },
   /** Sets the placeholder text for the input element.  */
   placeholder?: string,

--- a/src/phone-input/types.js
+++ b/src/phone-input/types.js
@@ -42,10 +42,10 @@ export type mapIsoToLabelT = (iso: string) => string;
 export type CountrySelectDropdownPropsT = {
   // eslint-disable-next-line flowtype/no-weak-types
   children: $ReadOnlyArray<React.Element<any>>,
-  country: CountryT,
-  mapIsoToLabel?: mapIsoToLabelT,
-  maxDropdownHeight: string,
-  overrides: {
+  $country: CountryT,
+  $mapIsoToLabel?: mapIsoToLabelT,
+  $maxDropdownHeight: string,
+  $overrides: {
     CountrySelectDropdown?: OverrideT<*>,
     CountrySelectDropdownListItem?: OverrideT<*>,
     CountrySelectDropdownFlagColumn?: OverrideT<*>,

--- a/src/phone-input/utils.js
+++ b/src/phone-input/utils.js
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+// country code regex
+const ISO_REGEX = /^[a-z]{2}$/i;
+// offset between uppercase ascii and regional indicator symbols
+const OFFSET = 127397;
+// convert country code to corresponding emoji flag
+export function iso2FlagEmoji(iso: string) {
+  if (__DEV__) {
+    if (!ISO_REGEX.test(iso)) {
+      const type = typeof iso;
+      throw new TypeError(
+        `iso argument must be an ISO 3166-1 alpha-2 string, but got '${
+          type === 'string' ? iso : type
+        }' instead.`,
+      );
+    }
+  }
+  return String.fromCodePoint(
+    ...[...iso.toUpperCase()].map(char => char.charCodeAt(0) + OFFSET),
+  );
+}

--- a/src/phone-input/utils.js
+++ b/src/phone-input/utils.js
@@ -12,17 +12,15 @@ const ISO_REGEX = /^[a-z]{2}$/i;
 const OFFSET = 127397;
 // convert country code to corresponding emoji flag
 export function iso2FlagEmoji(iso: string) {
-  if (__DEV__) {
-    if (!ISO_REGEX.test(iso)) {
-      const type = typeof iso;
-      throw new TypeError(
-        `iso argument must be an ISO 3166-1 alpha-2 string, but got '${
-          type === 'string' ? iso : type
-        }' instead.`,
-      );
-    }
+  if (!ISO_REGEX.test(iso)) {
+    const type = typeof iso;
+    console.warn(
+      `iso argument must be an ISO 3166-1 alpha-2 string, but got '${
+        type === 'string' ? iso : type
+      }' instead.`,
+    );
+    return;
   }
-  return String.fromCodePoint(
-    ...[...iso.toUpperCase()].map(char => char.charCodeAt(0) + OFFSET),
-  );
+  const chars = [...iso.toUpperCase()].map(char => char.charCodeAt(0) + OFFSET);
+  return String.fromCodePoint(...chars);
 }

--- a/src/phone-input/utils.js
+++ b/src/phone-input/utils.js
@@ -21,6 +21,8 @@ export function iso2FlagEmoji(iso: string) {
     );
     return;
   }
-  const chars = [...iso.toUpperCase()].map(char => char.charCodeAt(0) + OFFSET);
+  const chars = Array.from(iso.toUpperCase()).map(
+    char => char.charCodeAt(0) + OFFSET,
+  );
   return String.fromCodePoint(...chars);
 }


### PR DESCRIPTION
#### Description

Replaces default flag svgs usage with emojis. It results in the phone-input size reduction from 136.17 KB to 10.79 KB.

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
