### PR TITLE
fix(build): remove prepublish

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "e2e:serve": "static-server e2e/dist --port 8080",
     "e2e:test": "jest --runInBand -c jest.e2e.config.js",
     "e2e:test:ci": "jest -c jest.e2e.config.js",
-    "prepublish": "npm run build",
     "icon:generate": "node ./src/icon/build-icons.js",
     "predocumentation:dev": "node ./scripts/build-documentation-site-files.js",
     "predocumentation:dev:watch": "node ./scripts/build-documentation-site-files.js",


### PR DESCRIPTION
```
prepublish: Run BEFORE the package is packed and published, as well as on local npm install without any arguments. (See below)
```

we do not this anymore, because install is handled by our buildkite job - previously it was in a separate buildkite job, that's why we had it

this will speed up builds because we won't do the babel builds twice