### PR TITLE
fix(tag component): removing role and aria-label attrib if disabled

### DIFF
--- a/src/tag/__tests__/tag.test.js
+++ b/src/tag/__tests__/tag.test.js
@@ -37,6 +37,26 @@ describe('Stateless tag', function() {
     expect(wrapper).toMatchSnapshot('Component has correct render');
   });
 
+  describe('On disabled', function() {
+    beforeEach(function() {
+      allProps.onActionClick = jest.fn();
+      wrapper = mount(
+        <Tag {...allProps} disabled>
+          {children}
+        </Tag>,
+      );
+    });
+
+    test('should not render a11y attributes', function() {
+      const tag = wrapper.getDOMNode();
+      const closeBtn = tag.children[1];
+      expect(tag.getAttribute('aria-label')).toBeNull();
+      expect(tag.getAttribute('role')).toBeNull();
+      expect(closeBtn.getAttribute('aria-label')).toBeNull();
+      expect(closeBtn.getAttribute('role')).toBeNull();
+    });
+  });
+
   describe('On action', function() {
     beforeEach(function() {
       allProps.onActionClick = jest.fn();

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -103,8 +103,8 @@ class Tag extends React.Component<PropsT, {}> {
     return (
       <Root
         data-baseweb="tag"
-        aria-label="button"
-        role="button"
+        aria-label={disabled ? null : 'button'}
+        role={disabled ? null : 'button'}
         tabIndex={clickable ? 0 : null}
         {...rootHandlers}
         {...sharedProps}
@@ -113,8 +113,8 @@ class Tag extends React.Component<PropsT, {}> {
         <Text {...textProps}>{children}</Text>
         {closeable ? (
           <Action
-            aria-label="close button"
-            role="button"
+            aria-label={disabled ? null : 'close button'}
+            role={disabled ? null : 'button'}
             tabIndex={0}
             {...actionHandlers}
             {...sharedProps}


### PR DESCRIPTION
Fixes https://github.com/uber-web/baseui/issues/1788 
Added unit test for the change
Ran e2e tests in local mentioned in TESTING.md

#### Description
If a Tag component is disabled, removing aria-label and role from it. If disabled Tag has close button then it should not have these attributes as well.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
