### PR TITLE
fix: add type annotation for scale750 in theme.sizing

### DIFF
--- a/src/styles/types.js
+++ b/src/styles/types.js
@@ -438,6 +438,7 @@ export type SizingT = {
   scale600: string,
   scale650: string,
   scale700: string,
+  scale750: string,
   scale800: string,
   scale900: string,
   scale1000: string,

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -426,6 +426,7 @@ interface Sizing {
   scale550: string;
   scale600: string;
   scale700: string;
+  scale750: string;
   scale800: string;
   scale900: string;
   scale1000: string;


### PR DESCRIPTION
Adds `scale750` to existing types, to reflect already existing theme variable.