### PR TITLE
fix(modal): add contrasting color for close button in modal

### DIFF
--- a/src/modal/styled-components.js
+++ b/src/modal/styled-components.js
@@ -130,17 +130,17 @@ export const Close = styled<SharedStylePropsArgT>('button', props => {
     paddingBottom: 0,
 
     // colors
-    color: $theme.colors.mono700,
+    color: $theme.colors.modalCloseColor,
     transitionProperty: 'color, border-color',
     transitionDuration: $theme.animation.timing100,
     borderWidth: '1px',
     borderStyle: 'solid',
     borderColor: 'transparent',
     ':hover': {
-      color: $theme.colors.mono800,
+      color: $theme.colors.modalCloseColorHover,
     },
     ':focus': {
-      color: $theme.colors.mono800,
+      color: $theme.colors.modalCloseColorFocus,
       borderColor: $theme.colors.primary,
     },
 

--- a/src/styles/types.js
+++ b/src/styles/types.js
@@ -228,6 +228,11 @@ export type ColorsT = {
   menuFontHighlighted: string,
   menuFontSelected: string,
 
+  // Modal
+  modalCloseColor: string,
+  modalCloseColorHover: string,
+  modalCloseColorFocus: string,
+
   // Pagination
   paginationTriangleDown: string,
 

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -209,6 +209,11 @@ interface Colors {
   menuFontHighlighted: string;
   menuFontSelected: string;
 
+  // Modal
+  modalCloseColor: string;
+  modalCloseColorHover: string;
+  modalCloseColorFocus: string;
+
   // Pagination
   paginationTriangleDown: string;
 

--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -238,6 +238,11 @@ export default function createTheme(
       menuFontHighlighted: primitives.mono1000,
       menuFontSelected: primitives.mono1000,
 
+      // Modal
+      modalCloseColor: primitives.mono700,
+      modalCloseColorHover: primitives.mono800,
+      modalCloseColorFocus: primitives.mono800,
+
       // Pagination
       paginationTriangleDown: primitives.mono800,
 

--- a/src/themes/dark-theme-colors.js
+++ b/src/themes/dark-theme-colors.js
@@ -91,6 +91,11 @@ export default {
     // ProgressSteps
     progressStepsIconActiveFill: primitives.mono100,
 
+    // Modal
+    modalCloseColor: primitives.mono300,
+    modalCloseColorHover: primitives.mono400,
+    modalCloseColorFocus: primitives.mono400,
+
     // Notification
     notificationPrimaryBackground: primitives.primary700,
     notificationPrimaryText: primitives.primary200,


### PR DESCRIPTION
Fixes #1809 

#### Description
- add contrasting color for close button in modal
- handle case of light and dark theme

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
