### PR TITLE
fix(datepicker): make the calendar arrows larger

### DIFF
--- a/src/datepicker/calendar-header.js
+++ b/src/datepicker/calendar-header.js
@@ -177,6 +177,7 @@ export default class CalendarHeader extends React.Component<
       >
         {isHidden ? null : (
           <PrevButtonIcon
+            size={'24px'}
             overrides={{Svg: {style: navBtnStyle}}}
             {...prevButtonIconProps}
           />
@@ -240,6 +241,7 @@ export default class CalendarHeader extends React.Component<
       >
         {isHidden ? null : (
           <NextButtonIcon
+            size={'24px'}
             overrides={{Svg: {style: navBtnStyle}}}
             {...nextButtonIconProps}
           />

--- a/src/datepicker/styled-components.js
+++ b/src/datepicker/styled-components.js
@@ -111,17 +111,18 @@ export const StyledMonthYearSelectIconContainer = styled<{}>('span', props => {
 function getArrowBtnStyle({$theme, $disabled}) {
   return {
     boxSizing: 'border-box',
-    height: '22px',
     color: $disabled
       ? $theme.colors.datepickerDayFontDisabled
       : $theme.colors.white,
     cursor: $disabled ? 'default' : 'pointer',
     backgroundColor: 'transparent',
     borderWidth: 0,
-    paddingTop: '3px',
-    paddingBottom: '3px',
-    paddingLeft: '3px',
-    paddingRight: '3px',
+    paddingTop: '0',
+    paddingBottom: '0',
+    paddingLeft: '0',
+    paddingRight: '0',
+    marginLeft: '6px',
+    marginRight: '6px',
     outline: 'none',
     ':focus': $disabled
       ? {}


### PR DESCRIPTION
Before: 
<img width="328" alt="Screen Shot 2019-08-29 at 3 44 20 PM" src="https://user-images.githubusercontent.com/1920399/63981434-f0b5b200-ca73-11e9-9fa6-2a446df79563.png">

After:
<img width="335" alt="Screen Shot 2019-08-29 at 3 43 54 PM" src="https://user-images.githubusercontent.com/1920399/63981438-f4e1cf80-ca73-11e9-940b-3b3af30c9ec1.png">
