### PR TITLE
fix(build): add doc site generation for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "predocumentation:dev:watch": "node ./scripts/build-documentation-site-files.js",
     "predocumentation:build": "node ./scripts/build-documentation-site-files.js",
     "predocumentation:serve": "node ./scripts/build-documentation-site-files.js",
+    "pretest": "node ./scripts/build-documentation-site-files.js",
     "documentation:dev": "run-p build:es2015 next:dev",
     "documentation:dev:watch": "yarn build:es2015 --watch & next documentation-site",
     "documentation:build": "run-s build:es2015 next:build next:export",


### PR DESCRIPTION
Clean build tests are failing locally because we don't build the doc site there

![Image Pasted at 2019-8-30 11-56](https://user-images.githubusercontent.com/2174968/64053066-ba406b80-cb35-11e9-8139-172501445ee4.png)
