### PR TITLE
feat(tag): add title attribute when children is a string

### DIFF
--- a/src/tag/__tests__/__snapshots__/tag.test.js.snap
+++ b/src/tag/__tests__/__snapshots__/tag.test.js.snap
@@ -88,9 +88,12 @@ exports[`Stateless tag should render component: Component has correct render 1`]
           }
         }
       >
-        <ForwardRef>
+        <ForwardRef
+          title="Some tag"
+        >
           <MockStyledComponent
             forwardedRef={null}
+            title="Some tag"
           >
             <span
               styled-component="true"
@@ -102,6 +105,7 @@ exports[`Stateless tag should render component: Component has correct render 1`]
                   "whiteSpace": "nowrap",
                 }
               }
+              title="Some tag"
             >
               Some tag
             </span>

--- a/src/tag/__tests__/utils.test.js
+++ b/src/tag/__tests__/utils.test.js
@@ -1,0 +1,34 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+import * as React from 'react';
+import * as Utils from '../utils.js';
+
+describe('Tag Utils - getTextFromChildren', () => {
+  it('handles no children', () => {
+    expect(Utils.getTextFromChildren()).toBe(null);
+    expect(Utils.getTextFromChildren(null)).toBe(null);
+    expect(Utils.getTextFromChildren(undefined)).toBe(null);
+  });
+
+  it('handles one child', () => {
+    expect(Utils.getTextFromChildren('')).toBe('');
+    expect(Utils.getTextFromChildren('foo')).toBe('foo');
+    expect(Utils.getTextFromChildren(0)).toBe('0');
+    expect(Utils.getTextFromChildren(123)).toBe('123');
+  });
+
+  it('handles multiple children', () => {
+    expect(Utils.getTextFromChildren(['foo', 123])).toBe('foo123');
+    expect(Utils.getTextFromChildren(['foo', null, 123])).toBe('foo123');
+  });
+
+  it('ignores non-joinable children', () => {
+    expect(Utils.getTextFromChildren(<div />)).toBe(null);
+    expect(Utils.getTextFromChildren(['foo', <div key={1} />, 123])).toBe(null);
+  });
+});

--- a/src/tag/tag.js
+++ b/src/tag/tag.js
@@ -14,6 +14,7 @@ import {
   Text as StyledText,
 } from './styled-components.js';
 import {KIND, VARIANT} from './constants.js';
+import {getTextFromChildren} from './utils.js';
 import type {PropsT, SharedPropsArgT} from './types.js';
 
 class Tag extends React.Component<PropsT, {}> {
@@ -65,6 +66,7 @@ class Tag extends React.Component<PropsT, {}> {
       isFocused,
       isHovered,
       kind,
+      title,
       onActionClick,
       onClick,
       overrides = {},
@@ -100,6 +102,7 @@ class Tag extends React.Component<PropsT, {}> {
       $kind: kind,
       $variant: variant,
     };
+    const titleText = title || getTextFromChildren(children);
     return (
       <Root
         data-baseweb="tag"
@@ -110,7 +113,9 @@ class Tag extends React.Component<PropsT, {}> {
         {...sharedProps}
         {...rootProps}
       >
-        <Text {...textProps}>{children}</Text>
+        <Text title={titleText} {...textProps}>
+          {children}
+        </Text>
         {closeable ? (
           <Action
             aria-label={disabled ? null : 'close button'}

--- a/src/tag/types.js
+++ b/src/tag/types.js
@@ -38,6 +38,8 @@ export type PropsT = {
   children?: React$Node,
   /** The color theme to be applied to a Tag. Default is `KIND.primary`. */
   color?: string,
+  /** Text to display in native OS tooltip on long hover. */
+  title?: string,
   /** onClick handler for the action button element. */
   onActionClick: (e: Event, children?: React$Node) => mixed,
   /** keydown handler for the action button element. */

--- a/src/tag/utils.js
+++ b/src/tag/utils.js
@@ -1,0 +1,35 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+/* eslint-disable import/prefer-default-export */
+import * as React from 'react';
+
+const JOINABLE_TYPES = new Set(['string', 'number']);
+
+// Checks the children of a React component to ensure every value is a number
+// or a string. If they are, they are joined and returned. Useful for collecting
+// text from the child of a node to use as an attribute.
+export function getTextFromChildren(children: ?React$Node) {
+  const childList = React.Children.toArray(children).filter(
+    child => child !== null && child !== undefined,
+  );
+
+  if (!childList.length) {
+    return null;
+  }
+
+  const isJoinable = childList.every(child => JOINABLE_TYPES.has(typeof child));
+
+  if (!isJoinable) {
+    return null;
+  }
+
+  // Join on an empty string to preserve React's whitespace handling:
+  // <Tag>foo{'bar'}baz</Tag> => 'foobar'
+  // <Tag>foo {'bar'} baz</Tag> => 'foo bar baz'
+  return childList.join('');
+}


### PR DESCRIPTION
When `<Tag>` content is truncated, there's no means of seeing the complete text of the tag.

![image](https://user-images.githubusercontent.com/155164/64054431-2f1aa200-cb44-11e9-9224-82a37702b7ac.png)

#### Description

Updated the `<Tag>` component to add the text of the tag as an HTML `title` attribute so the full text is visible via a native OS tooltip on long hover. The `title` will only be added if each of the shallow children are a string or a number. The user must continue to specify their own `title` attribute for non trivial content.

![image](https://user-images.githubusercontent.com/155164/64054551-b700ac00-cb44-11e9-9fe6-7da5c48d22e8.png)

#### Scope

- [ ] Patch: Bug Fix
- [x] Minor: New Feature
- [ ] Major: Breaking Change
