### PR TITLE
docs: prioritize local storage for theme

### DIFF
--- a/documentation-site/pages/_app.js
+++ b/documentation-site/pages/_app.js
@@ -120,7 +120,8 @@ export default class MyApp extends App {
     if (window.matchMedia) {
       const mmDark = window.matchMedia(DARK_MEDIA_QUERY);
       const mmLight = window.matchMedia(LIGHT_MEDIA_QUERY);
-      if (mmDark.media === DARK_MEDIA_QUERY) {
+      // if no theme is set in localStorage, set theme based on user's OS preference
+      if (!this.getThemeStyle() && mmDark.media === DARK_MEDIA_QUERY) {
         const theme = mmDark.matches ? 'dark' : 'light';
         localStorage.setItem('docs-theme', theme);
       }


### PR DESCRIPTION
I prefer to view doc site in light theme but my OS has dark mode set. Every time I load a page I have to toggle the theme to light because it detects my dark mode preference.

This change makes it so that if a theme preference is already set in localStorage we will use that instead of the OS preference. For folks visiting the first time it will use OS preference. After that it will use whatever they last used.