### PR TITLE
feat(storybook): add dark background for dark mode

### DIFF
--- a/.storybook/load-stories.js
+++ b/.storybook/load-stories.js
@@ -12,7 +12,20 @@ import {storiesOf} from '@storybook/react';
 import scenarios from '../src/**/*.scenario.js';
 
 const light = storiesOf('baseui', module);
-const dark = storiesOf('baseui-dark', module);
+const dark = storiesOf('baseui-dark', module).addDecorator(storyFn => (
+  <div
+    style={{
+      boxSizing: 'border-box',
+      width: 'calc(100vw - 10px)',
+      height: 'calc(100vh - 17px)',
+      overflow: 'scroll',
+      padding: '32px',
+      backgroundColor: 'black',
+    }}
+  >
+    {storyFn()}
+  </div>
+));
 
 scenarios.forEach(scenario => {
   const Component = scenario.component;


### PR DESCRIPTION
Add a dark background to dark mode storybook scenarios. It is a bit difficult to test dark mode components in storybook with a white background.