### PR TITLE
fix(typescript): custom theme type support

### DIFF
--- a/documentation-site/examples/styled/basic.tsx
+++ b/documentation-site/examples/styled/basic.tsx
@@ -1,8 +1,17 @@
 import * as React from 'react';
 import {styled} from 'baseui';
+import {Theme} from 'baseui/theme';
 
-const BlueDiv = styled('div', ({$theme}) => ({
-  color: $theme.colors.primary,
+type CustomTheme = Theme & {extraProp: string};
+
+const BlueDiv = styled<
+  {$color: keyof Theme['colors']},
+  'div',
+  CustomTheme
+>('div', ({$color, $theme}) => ({
+  color: $theme.colors[$color],
 }));
 
-export default () => <BlueDiv>This is a blue div</BlueDiv>;
+export default () => (
+  <BlueDiv $color="primary">This is a blue div</BlueDiv>
+);

--- a/documentation-site/examples/table/cells.tsx
+++ b/documentation-site/examples/table/cells.tsx
@@ -20,21 +20,26 @@ import {
   StyledAction,
 } from 'baseui/table';
 import {Caption1, Caption2, Paragraph3} from 'baseui/typography';
+import {Theme} from 'baseui/theme';
 
 const StyledHeadingCell = withStyle(StyledCell, {
   paddingTop: 0,
   paddingBottom: 0,
 });
 
-const StyledDeltaCell = withStyle(StyledCell, (props: any) => ({
-  ...props.$theme.typography.font550,
+const StyledDeltaCell = withStyle<
+  typeof StyledCell,
+  {$isNegative: boolean},
+  Theme & {customThemeProp: string}
+>(StyledCell, ({$isNegative, $theme}) => ({
+  ...$theme.typography.font550,
   alignItems: 'center',
-  backgroundColor: props.$isNegative
-    ? props.$theme.colors.negative50
-    : props.$theme.colors.positive50,
-  color: props.$isNegative
-    ? props.$theme.colors.negative
-    : props.$theme.colors.positive,
+  backgroundColor: $isNegative
+    ? $theme.colors.negative50
+    : $theme.colors.positive50,
+  color: $isNegative
+    ? $theme.colors.negative
+    : $theme.colors.positive,
 }));
 
 const StyledLargeText = withStyle(StyledCell, {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -8,10 +8,10 @@ type UseStyletronFn<Theme> = () => [(arg: StyleObject) => string, Theme];
 export function createThemedUseStyletron<Theme>(): UseStyletronFn<Theme>;
 export const useStyletron: UseStyletronFn<Theme>;
 
-export function createTheme(
+export function createTheme<P extends object>(
   primitives: ThemePrimitives,
-  overrides?: object,
-): Theme;
+  overrides?: P,
+): Theme & P;
 export function withProps(
   Component: React.ComponentType,
   customProps?: object,
@@ -22,10 +22,11 @@ export function mergeOverrides<T>(
 ): Overrides<T>;
 export function styled<
   P extends object,
-  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>
+  C extends keyof JSX.IntrinsicElements | React.ComponentType<any>,
+  T = Theme
 >(
   component: C,
-  styledFn: StyleObject | ((props: {$theme: Theme} & P) => StyleObject),
+  styledFn: StyleObject | ((props: {$theme: T} & P) => StyleObject),
 ): StyletronComponent<
   Pick<
     React.ComponentProps<C>,
@@ -60,9 +61,9 @@ export interface ThemeProviderProps {
 export const ThemeProvider: React.FC<ThemeProviderProps>;
 
 export interface WithStyleFn {
-  <C extends StyletronComponent<any>, P extends object>(
+  <C extends StyletronComponent<any>, P extends object, T = Theme>(
     component: C,
-    style: (props: P & {$theme: Theme}) => StyleObject,
+    style: (props: P & {$theme: T}) => StyleObject,
   ): StyletronComponent<React.ComponentProps<C> & P>;
   <C extends StyletronComponent<any>>(
     component: C,


### PR DESCRIPTION

#### Description

Allow typescript to use custom theme types when using the `createTheme` and `styled` functions.

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
