### PR TITLE
fix(avatar): reset the error state when src is updated

### DIFF
--- a/src/avatar/__tests__/avatar.test.js
+++ b/src/avatar/__tests__/avatar.test.js
@@ -86,4 +86,19 @@ describe('Avatar', () => {
 
     expect(wrapper.find(StyledInitials).text()).toBe('U');
   });
+
+  it('resets noImageAvailable flag when src is updated', done => {
+    const wrapper = mount(
+      <Avatar name="user name" src="invalid-img-src.png" />,
+    );
+
+    triggerLoadError(wrapper);
+    expect(wrapper.state().noImageAvailable).toBeTruthy();
+    wrapper.setProps({name: 'user name', src: 'valid-img-src.png'}, () => {
+      setTimeout(() => {
+        expect(wrapper.state().noImageAvailable).toBeFalsy();
+        done();
+      }, 0);
+    });
+  });
 });

--- a/src/avatar/avatar.js
+++ b/src/avatar/avatar.js
@@ -37,6 +37,12 @@ export default class Avatar extends React.Component<PropsT, StateT> {
     this.state = {noImageAvailable: !this.props.src};
   }
 
+  componentDidUpdate(prevProps: PropsT, prevState: StateT) {
+    if (prevProps.src !== this.props.src && prevState.noImageAvailable) {
+      this.setState({noImageAvailable: false});
+    }
+  }
+
   handleError = () => {
     this.setState({noImageAvailable: true});
   };


### PR DESCRIPTION
Ad test: I was not able to get the final rendered state through enzyme's `wrapper.find()`, so at least testing the internal state values.
