### PR TITLE
fix(yard): fix theme switching (reset when changed)

### DIFF
--- a/documentation-site/components/yard/code-generator.ts
+++ b/documentation-site/components/yard/code-generator.ts
@@ -54,13 +54,16 @@ export const getCode = (
     }
   });
   const hasChild = children && children.value;
+  const themePrimitives = theme.themeName.startsWith('light-theme')
+    ? 'lightThemePrimitives'
+    : 'darkThemePrimitives';
   const themeImports = isCustomTheme
-    ? `import {ThemeProvider, createTheme, lightThemePrimitives} from 'baseui';\n`
+    ? `import {ThemeProvider, createTheme, ${themePrimitives}} from 'baseui';\n`
     : '';
   const imports = `${themeImports}import {${componentName}${enumImports}} from 'baseui/${componentName.toLowerCase()}';\n\n`;
 
   const themeProviderOpen = isCustomTheme
-    ? `<ThemeProvider theme={createTheme(lightThemePrimitives, { colors: ${JSON.stringify(
+    ? `<ThemeProvider theme={createTheme(${themePrimitives}, { colors: ${JSON.stringify(
         theme.themeValues,
       )} })}>`
     : '';

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ export {LocaleProvider};
 export {
   createTheme,
   lightThemePrimitives,
+  darkThemePrimitives,
   DarkTheme,
   DarkThemeMove,
   LightTheme,


### PR DESCRIPTION
Added an effect that runs when the theme.name (context) is changed. It resets the theme editor so the initial values and imports are correct and user changes are discarded. 
