### PR TITLE
feat(data-table): adds unit and e2e tests

### DIFF
--- a/src/data-table/__tests__/column-boolean.test.js
+++ b/src/data-table/__tests__/column-boolean.test.js
@@ -1,0 +1,105 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+
+import {BooleanColumn} from '../index.js';
+
+let container: HTMLDivElement;
+
+describe('boolean column', () => {
+  beforeEach(() => {
+    if (__BROWSER__) {
+      container = document.createElement('div');
+      if (document.body) {
+        document.body.appendChild(container);
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (__BROWSER__) {
+      if (document.body && container) {
+        document.body.removeChild(container);
+      }
+    }
+  });
+
+  it('is sortable by default', () => {
+    const column = BooleanColumn({title: 'column'});
+    expect(column.sortable).toBe(true);
+  });
+
+  it('is filterable by default', () => {
+    const column = BooleanColumn({title: 'column'});
+    expect(column.filterable).toBe(true);
+  });
+
+  it('applies provided sortable value', () => {
+    const column = BooleanColumn({title: 'column', sortable: false});
+    expect(column.sortable).toBe(false);
+  });
+
+  it('applies provided filterable value', () => {
+    const column = BooleanColumn({title: 'column', filterable: false});
+    expect(column.filterable).toBe(false);
+  });
+
+  it('cell renders T if true value provided', () => {
+    const column = BooleanColumn({title: 'column'});
+    const Cell = column.renderCell;
+
+    act(() => {
+      ReactDOM.render(<Cell value={true} />, container);
+    });
+
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('T');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('cell renders F if false value provided', () => {
+    const column = BooleanColumn({title: 'column'});
+    const Cell = column.renderCell;
+
+    act(() => {
+      ReactDOM.render(<Cell value={false} />, container);
+    });
+
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('F');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  xit('renders expected filter component', () => {
+    // boolean filter component is not implemented yet
+  });
+
+  xit('builds expected filter function', () => {
+    // boolean filter params are not implemented yet
+  });
+
+  it('builds expected sort function', () => {
+    const column = BooleanColumn({title: 'column'});
+    const input = [true, false, true, false, false, true, true, false];
+    input.sort(column.sortFn);
+
+    const output = [true, true, true, true, false, false, false, false];
+    for (let i = 0; i < input.length; i++) {
+      expect(input[i]).toBe(output[i]);
+    }
+  });
+});

--- a/src/data-table/__tests__/column-categorical.test.js
+++ b/src/data-table/__tests__/column-categorical.test.js
@@ -1,0 +1,159 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+
+import {CategoricalColumn} from '../index.js';
+
+let container: HTMLDivElement;
+
+describe('categorical column', () => {
+  beforeEach(() => {
+    if (__BROWSER__) {
+      container = document.createElement('div');
+      if (document.body) {
+        document.body.appendChild(container);
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (__BROWSER__) {
+      if (document.body && container) {
+        document.body.removeChild(container);
+        container.remove();
+      }
+    }
+  });
+
+  it('is sortable by default', () => {
+    const column = CategoricalColumn({title: 'column'});
+    expect(column.sortable).toBe(true);
+  });
+
+  it('is filterable by default', () => {
+    const column = CategoricalColumn({title: 'column'});
+    expect(column.filterable).toBe(true);
+  });
+
+  it('applies provided sortable value', () => {
+    const column = CategoricalColumn({title: 'column', sortable: false});
+    expect(column.sortable).toBe(false);
+  });
+
+  it('applies provided filterable value', () => {
+    const column = CategoricalColumn({title: 'column', filterable: false});
+    expect(column.filterable).toBe(false);
+  });
+
+  it('cell renders provided value', () => {
+    const column = CategoricalColumn({title: 'column'});
+    const Cell = column.renderCell;
+
+    act(() => {
+      ReactDOM.render(<Cell value="A" />, container);
+    });
+
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('A');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('renders expected number of checkboxes in filter component', () => {
+    const column = CategoricalColumn({title: 'column'});
+    const Filter = column.renderFilter;
+
+    const mockSetFilter = jest.fn();
+    const data = ['A', 'B', 'C'];
+    act(() => {
+      ReactDOM.render(
+        <Filter setFilter={mockSetFilter} close={() => {}} data={data} />,
+        container,
+      );
+    });
+
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    // counts an additional checkbox to account for the 'exlude' toggle
+    expect(checkboxes.length).toBe(4);
+  });
+
+  it('can call setFilter with expected selection', () => {
+    const column = CategoricalColumn({title: 'column'});
+    const Filter = column.renderFilter;
+
+    const mockSetFilter = jest.fn();
+    const data = ['A', 'B', 'C'];
+    act(() => {
+      ReactDOM.render(
+        <Filter setFilter={mockSetFilter} close={() => {}} data={data} />,
+        container,
+      );
+    });
+    const checkboxes = container.querySelectorAll('input[type="checkbox"]');
+    act(() => {
+      checkboxes[0].dispatchEvent(new MouseEvent('click', {bubbles: true}));
+    });
+    expect(((checkboxes[0]: any): HTMLInputElement).checked).toBe(true);
+
+    const buttons = container.querySelectorAll('button');
+    buttons.forEach(button => {
+      if (button.textContent === 'Apply') {
+        act(() => {
+          button.dispatchEvent(new MouseEvent('click', {bubbles: true}));
+        });
+      }
+    });
+
+    expect(mockSetFilter.mock.calls.length).toBe(1);
+    const [filterParams, description] = mockSetFilter.mock.calls[0];
+    expect(filterParams.selection.has('A')).toBe(true);
+    expect(filterParams.selection.has('B')).toBe(false);
+    expect(filterParams.selection.has('C')).toBe(false);
+    expect(filterParams.exclude).toBe(false);
+    expect(description).toBe('A');
+  });
+
+  it('builds expected filter function', () => {
+    const column = CategoricalColumn({title: 'column'});
+
+    const filterSelectionEmpty = column.buildFilter({
+      selection: new Set(),
+      exclude: false,
+    });
+    expect(filterSelectionEmpty('A')).toBe(false);
+
+    const filterSelectionSingle = column.buildFilter({
+      selection: new Set(['A']),
+      exclude: false,
+    });
+    expect(filterSelectionSingle('A')).toBe(true);
+
+    const filterSelectionExclude = column.buildFilter({
+      selection: new Set(['A']),
+      exclude: true,
+    });
+    expect(filterSelectionExclude('A')).toBe(false);
+    expect(filterSelectionExclude('B')).toBe(true);
+  });
+
+  it('builds expected sort function', () => {
+    const column = CategoricalColumn({title: 'column'});
+    const input = ['A', 'B', 'C', 'C', 'B', 'A'];
+    input.sort(column.sortFn);
+
+    const output = ['A', 'A', 'B', 'B', 'C', 'C'];
+    for (let i = 0; i < input.length; i++) {
+      expect(input[i]).toBe(output[i]);
+    }
+  });
+});

--- a/src/data-table/__tests__/column-custom.test.js
+++ b/src/data-table/__tests__/column-custom.test.js
@@ -1,0 +1,107 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+
+import {CustomColumn} from '../index.js';
+
+let container: HTMLDivElement;
+
+describe('custom column', () => {
+  beforeEach(() => {
+    if (__BROWSER__) {
+      container = document.createElement('div');
+      if (document.body) {
+        document.body.appendChild(container);
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (__BROWSER__) {
+      if (document.body && container) {
+        document.body.removeChild(container);
+        container.remove();
+      }
+    }
+  });
+
+  it('is not sortable by default', () => {
+    const column = CustomColumn({title: 'column', renderCell: () => null});
+    expect(column.sortable).toBe(false);
+  });
+
+  it('is not filterable by default', () => {
+    const column = CustomColumn({title: 'column', renderCell: () => null});
+    expect(column.filterable).toBe(false);
+  });
+
+  it('is not sortable if no sortFn provided', () => {
+    const column = CustomColumn({
+      title: 'column',
+      sortable: true,
+      renderCell: () => null,
+    });
+    expect(column.sortable).toBe(false);
+  });
+
+  it('applies provided sortable value if sortFn exists', () => {
+    const column = CustomColumn({
+      title: 'column',
+      sortable: true,
+      sortFn: () => {
+        return 0;
+      },
+      renderCell: () => null,
+    });
+    expect(column.sortable).toBe(true);
+  });
+
+  it('is not filterable if neither renderFilter nor buildFilter provided', () => {
+    const column = CustomColumn({
+      title: 'column',
+      filterable: true,
+      renderCell: () => null,
+    });
+    expect(column.filterable).toBe(false);
+  });
+
+  it('applies provided filterable value if renderFilter and buildFilter exist', () => {
+    const column = CustomColumn({
+      title: 'column',
+      filterable: true,
+      renderFilter: () => null,
+      buildFilter: params => value => true,
+      renderCell: () => null,
+    });
+    expect(column.filterable).toBe(true);
+  });
+
+  it('cell renders according to provided renderCell', () => {
+    const column = CustomColumn<{color: string}, {}>({
+      title: 'column',
+      renderCell: props => {
+        return <div>{props.value.color}</div>;
+      },
+    });
+    const Cell = column.renderCell;
+
+    act(() => {
+      ReactDOM.render(<Cell value={{color: 'blue'}} />, container);
+    });
+
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('blue');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+});

--- a/src/data-table/__tests__/column-numerical.test.js
+++ b/src/data-table/__tests__/column-numerical.test.js
@@ -1,0 +1,156 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+
+import {NumericalColumn, NUMERICAL_FORMATS} from '../index.js';
+
+let container: HTMLDivElement;
+
+describe('numerical column', () => {
+  beforeEach(() => {
+    if (__BROWSER__) {
+      container = document.createElement('div');
+      if (document.body) {
+        document.body.appendChild(container);
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (__BROWSER__) {
+      if (document.body && container) {
+        document.body.removeChild(container);
+        container.remove();
+      }
+    }
+  });
+
+  it('is sortable by default', () => {
+    const column = NumericalColumn({title: 'column'});
+    expect(column.sortable).toBe(true);
+  });
+
+  it('is filterable by default', () => {
+    const column = NumericalColumn({title: 'column'});
+    expect(column.filterable).toBe(true);
+  });
+
+  it('applies provided sortable value', () => {
+    const column = NumericalColumn({title: 'column', sortable: false});
+    expect(column.sortable).toBe(false);
+  });
+
+  it('applies provided filterable value', () => {
+    const column = NumericalColumn({title: 'column', filterable: false});
+    expect(column.filterable).toBe(false);
+  });
+
+  it('cell renders provided value with default options', () => {
+    const column = NumericalColumn({title: 'column'});
+    const Cell = column.renderCell;
+    act(() => {
+      ReactDOM.render(<Cell value={1999.888} />, container);
+    });
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('1999.89');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('cell renders positive value according to accounting format', () => {
+    const column = NumericalColumn({
+      title: 'column',
+      format: NUMERICAL_FORMATS.ACCOUNTING,
+    });
+    const Cell = column.renderCell;
+    act(() => {
+      ReactDOM.render(<Cell value={1999.888} />, container);
+    });
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('$1999.89');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('cell renders negative value according to accounting format', () => {
+    const column = NumericalColumn({
+      title: 'column',
+      format: NUMERICAL_FORMATS.ACCOUNTING,
+    });
+    const Cell = column.renderCell;
+    act(() => {
+      ReactDOM.render(<Cell value={-1999.888} />, container);
+    });
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('($1999.89)');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('cell renders value according to percentage format', () => {
+    const column = NumericalColumn({
+      title: 'column',
+      format: NUMERICAL_FORMATS.PERCENTAGE,
+    });
+    const Cell = column.renderCell;
+    act(() => {
+      ReactDOM.render(<Cell value={1999.888} />, container);
+    });
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('1999.89%');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('cell renders value according to provided precision', () => {
+    const column = NumericalColumn({
+      title: 'column',
+      precision: 3,
+    });
+    const Cell = column.renderCell;
+    act(() => {
+      ReactDOM.render(<Cell value={1999.888} />, container);
+    });
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('1999.888');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  xit('can call setFilter with expected selection', () => {
+    // not implemented for numerical column
+  });
+
+  xit('builds expected filter function', () => {
+    // not implemented for numerical column
+  });
+
+  it('builds expected sort function', () => {
+    const column = NumericalColumn({title: 'column'});
+    const input = [2, 1, 3, 4];
+    input.sort(column.sortFn);
+
+    const output = [1, 2, 3, 4];
+    for (let i = 0; i < input.length; i++) {
+      expect(input[i]).toBe(output[i]);
+    }
+  });
+});

--- a/src/data-table/__tests__/column-numerical.test.js
+++ b/src/data-table/__tests__/column-numerical.test.js
@@ -61,7 +61,7 @@ describe('numerical column', () => {
     });
     const cell = container.querySelector('div');
     if (cell) {
-      expect(cell.textContent).toBe('1999.89');
+      expect(cell.textContent).toBe('2000');
     } else {
       expect(cell).not.toBeNull();
     }

--- a/src/data-table/__tests__/column-numerical.test.js
+++ b/src/data-table/__tests__/column-numerical.test.js
@@ -148,7 +148,7 @@ describe('numerical column', () => {
     const input = [2, 1, 3, 4];
     input.sort(column.sortFn);
 
-    const output = [1, 2, 3, 4];
+    const output = [4, 3, 2, 1];
     for (let i = 0; i < input.length; i++) {
       expect(input[i]).toBe(output[i]);
     }

--- a/src/data-table/__tests__/column-string.test.js
+++ b/src/data-table/__tests__/column-string.test.js
@@ -1,0 +1,77 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import {act} from 'react-dom/test-utils';
+
+import {StringColumn} from '../index.js';
+
+let container: HTMLDivElement;
+
+describe('string column', () => {
+  beforeEach(() => {
+    if (__BROWSER__) {
+      container = document.createElement('div');
+      if (document.body) {
+        document.body.appendChild(container);
+      }
+    }
+  });
+
+  afterEach(() => {
+    if (__BROWSER__) {
+      if (document.body && container) {
+        document.body.removeChild(container);
+        container.remove();
+      }
+    }
+  });
+
+  it('is sortable by default', () => {
+    const column = StringColumn({title: 'column'});
+    expect(column.sortable).toBe(true);
+  });
+
+  it('is not filterable by default', () => {
+    const column = StringColumn({title: 'column'});
+    expect(column.filterable).toBe(false);
+  });
+
+  it('applies provided sortable value', () => {
+    const column = StringColumn({title: 'column', sortable: false});
+    expect(column.sortable).toBe(false);
+  });
+
+  it('cell renders provided value', () => {
+    const column = StringColumn({title: 'column'});
+    const Cell = column.renderCell;
+
+    act(() => {
+      ReactDOM.render(<Cell value="hello" />, container);
+    });
+
+    const cell = container.querySelector('div');
+    if (cell) {
+      expect(cell.textContent).toBe('hello');
+    } else {
+      expect(cell).not.toBeNull();
+    }
+  });
+
+  it('builds expected sort function', () => {
+    const column = StringColumn({title: 'column'});
+    const input = ['A', 'B', 'C', 'C', 'B', 'A'];
+    input.sort(column.sortFn);
+
+    const output = ['A', 'A', 'B', 'B', 'C', 'C'];
+    for (let i = 0; i < input.length; i++) {
+      expect(input[i]).toBe(output[i]);
+    }
+  });
+});

--- a/src/data-table/__tests__/data-table-columns.e2e.js
+++ b/src/data-table/__tests__/data-table-columns.e2e.js
@@ -1,0 +1,176 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+/* eslint-env node */
+/* eslint-disable flowtype/require-valid-file-annotation */
+
+const {mount, analyzeAccessibility} = require('../../../e2e/helpers');
+
+function getHeaderCellAtIndex(page, index) {
+  return page.$(
+    // plus one to convert to one indexed item
+    `div[data-baseweb="data-table"] > div > div:nth-child(${index + 1})`,
+  );
+}
+
+function getCellAtIndex(page, index) {
+  // plus two to convert to one indexed item and skips header row
+  return page.$(`div[data-baseweb="data-table"] > div:nth-child(${index + 2})`);
+}
+
+function getCellsAtColumnIndex(page, index) {
+  // hard-coded related column count for now. could be calcuated by number of children if scenario changes.
+  const COLUMN_COUNT = 4;
+  const indices = [];
+  for (let i = 0; i < COLUMN_COUNT; i++) {
+    indices.push(i * COLUMN_COUNT + index);
+  }
+  return Promise.all(indices.map(i => getCellAtIndex(page, i)));
+}
+
+function getTextContentFromElements(page, elements) {
+  return Promise.all(
+    elements.map(element => {
+      return page.evaluate(e => e.textContent, element);
+    }),
+  );
+}
+
+async function getCellContentsAtColumnIndex(page, index) {
+  const elements = await getCellsAtColumnIndex(page, index);
+  return getTextContentFromElements(page, elements);
+}
+
+async function sortColumnAtIndex(page, index) {
+  const headerCell = await getHeaderCellAtIndex(page, index);
+  const sortButton = await headerCell.$('div[role="button"]');
+  return sortButton.click();
+}
+
+function matchArrayElements(a, b) {
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) return false;
+  }
+  return true;
+}
+
+describe('data table columns', () => {
+  jest.setTimeout(30 * 1000);
+  it('passes basic a11y tests', async () => {
+    await mount(page, 'data-table-columns');
+    const accessibilityReport = await analyzeAccessibility(page);
+    expect(accessibilityReport).toHaveNoAccessibilityIssues();
+  });
+
+  it('renders expected number of cells', async () => {
+    await mount(page, 'data-table-columns');
+    await page.waitFor('div[data-baseweb="data-table"]');
+
+    // one extra child to account for header row
+    expect(
+      await page.$eval(
+        'div[data-baseweb="data-table"]',
+        node => node.childNodes.length,
+      ),
+    ).toBe(17);
+  });
+
+  it('sorts boolean column', async () => {
+    const index = 0;
+    await mount(page, 'data-table-columns');
+    await page.waitFor('div[data-baseweb="data-table"]');
+    const initial = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, ['T', 'F', 'T', 'F'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const desc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(desc, ['T', 'T', 'F', 'F'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const asc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(asc, ['F', 'F', 'T', 'T'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const restored = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, restored)).toBe(true);
+  });
+
+  it('sorts categorical column', async () => {
+    const index = 1;
+    await mount(page, 'data-table-columns');
+    await page.waitFor('div[data-baseweb="data-table"]');
+    const initial = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, ['A', 'B', 'A', 'A'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const desc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(desc, ['A', 'A', 'A', 'B'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const asc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(asc, ['B', 'A', 'A', 'A'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const restored = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, restored)).toBe(true);
+  });
+
+  it('sorts numerical column', async () => {
+    const index = 2;
+    await mount(page, 'data-table-columns');
+    await page.waitFor('div[data-baseweb="data-table"]');
+    const initial = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, ['2', '1', '4', '3'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const desc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(desc, ['4', '3', '2', '1'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const asc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(asc, ['1', '2', '3', '4'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const restored = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, restored)).toBe(true);
+  });
+
+  it('sorts string column', async () => {
+    const index = 3;
+    await mount(page, 'data-table-columns');
+    await page.waitFor('div[data-baseweb="data-table"]');
+    const initial = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, ['one', 'two', 'three', 'four'])).toBe(
+      true,
+    );
+
+    await sortColumnAtIndex(page, index);
+    const desc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(desc, ['four', 'one', 'three', 'two'])).toBe(
+      true,
+    );
+
+    await sortColumnAtIndex(page, index);
+    const asc = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(asc, ['two', 'three', 'one', 'four'])).toBe(true);
+
+    await sortColumnAtIndex(page, index);
+    const restored = await getCellContentsAtColumnIndex(page, index);
+    expect(matchArrayElements(initial, restored)).toBe(true);
+  });
+
+  xit('filters boolean column', async () => {
+    // boolean column filter not implemented
+  });
+  xit('filters categorical column', async () => {});
+  xit('filters numerical column', async () => {
+    // numerical column filter not implemented
+  });
+
+  it('renders tag after applying filter', async () => {});
+  it('closing a filter restores filtered rows', async () => {});
+});

--- a/src/data-table/__tests__/data-table-columns.scenario.js
+++ b/src/data-table/__tests__/data-table-columns.scenario.js
@@ -1,0 +1,92 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+// @flow
+
+import * as React from 'react';
+
+import {useStyletron} from '../../styles/index.js';
+
+import {COLUMNS, NUMERICAL_FORMATS} from '../constants.js';
+import {
+  Unstable_DataTable,
+  BooleanColumn,
+  CategoricalColumn,
+  NumericalColumn,
+  StringColumn,
+} from '../index.js';
+
+export const name = 'data-table-columns';
+
+// function Scenario(props) {
+//   return (
+//     <div
+//       id={props.id}
+//       style={{height: '500px', width: '500px', marginBottom: '100px'}}
+//     >
+//       {props.children}
+//     </div>
+//   );
+// }
+
+// function CountChildren() {
+//   const columns = [
+//     BooleanColumn({title: 'boolean-column'}),
+//     NumericalColumn({title: 'numerical-column'}),
+//   ];
+//   const rows = [
+//     {data: [true, 1]},
+//     {data: [false, 2]},
+//     {data: [true, 3]},
+//     {data: [false, 4]},
+//   ];
+
+//   return (
+//     <Scenario id="data-table-count-children">
+//       <Unstable_DataTable columns={columns} rows={rows} />
+//     </Scenario>
+//   );
+// }
+
+// function BooleanScenario() {
+//   const columns = [BooleanColumn({title: 'boolean-column'})];
+//   const rows = [
+//     {data: [true]},
+//     {data: [false]},
+//     {data: [true]},
+//     {data: [false]},
+//   ];
+
+//   return (
+//     <Scenario id="data-table-boolean-column">
+//       <Unstable_DataTable columns={columns} rows={rows} />
+//     </Scenario>
+//   );
+// }
+
+export const component = () => {
+  const columns = [
+    BooleanColumn({title: 'boolean-column'}),
+    CategoricalColumn({title: 'categorical-column'}),
+    NumericalColumn({title: 'numerical-column'}),
+    StringColumn({title: 'string-column'}),
+  ];
+
+  const rows = [
+    {data: [true, 'A', 2, 'one']},
+    {data: [false, 'B', 1, 'two']},
+    {data: [true, 'A', 4, 'three']},
+    {data: [false, 'A', 3, 'four']},
+  ];
+
+  return (
+    <React.Fragment>
+      <div style={{height: '600px', width: '1000px', marginBottom: '100px'}}>
+        <Unstable_DataTable columns={columns} rows={rows} />
+      </div>
+    </React.Fragment>
+  );
+};

--- a/src/data-table/__tests__/data-table-columns.scenario.js
+++ b/src/data-table/__tests__/data-table-columns.scenario.js
@@ -21,52 +21,6 @@ import {
 
 export const name = 'data-table-columns';
 
-// function Scenario(props) {
-//   return (
-//     <div
-//       id={props.id}
-//       style={{height: '500px', width: '500px', marginBottom: '100px'}}
-//     >
-//       {props.children}
-//     </div>
-//   );
-// }
-
-// function CountChildren() {
-//   const columns = [
-//     BooleanColumn({title: 'boolean-column'}),
-//     NumericalColumn({title: 'numerical-column'}),
-//   ];
-//   const rows = [
-//     {data: [true, 1]},
-//     {data: [false, 2]},
-//     {data: [true, 3]},
-//     {data: [false, 4]},
-//   ];
-
-//   return (
-//     <Scenario id="data-table-count-children">
-//       <Unstable_DataTable columns={columns} rows={rows} />
-//     </Scenario>
-//   );
-// }
-
-// function BooleanScenario() {
-//   const columns = [BooleanColumn({title: 'boolean-column'})];
-//   const rows = [
-//     {data: [true]},
-//     {data: [false]},
-//     {data: [true]},
-//     {data: [false]},
-//   ];
-
-//   return (
-//     <Scenario id="data-table-boolean-column">
-//       <Unstable_DataTable columns={columns} rows={rows} />
-//     </Scenario>
-//   );
-// }
-
 export const component = () => {
   const columns = [
     BooleanColumn({title: 'boolean-column'}),

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -90,25 +90,42 @@ const NumericalCell = React.forwardRef<NumericalCellPropsT, HTMLDivElement>(
   },
 );
 
+const defaultOptions = {
+  title: '',
+  sortable: true,
+  filterable: true,
+  format: NUMERICAL_FORMATS.DEFAULT,
+  highlight: () => false,
+  precision: 0,
+};
+
 function NumericalColumn(options: OptionsT): NumericalColumnT {
+  const normalizedOptions = {
+    ...defaultOptions,
+    ...options,
+  };
+
   return {
     kind: COLUMNS.NUMERICAL,
-    title: options.title,
-    sortable: options.sortable === undefined ? true : options.sortable,
-    filterable: options.filterable === undefined ? true : options.filterable,
+    title: normalizedOptions.title,
+    sortable: normalizedOptions.sortable,
+    filterable: normalizedOptions.filterable,
     renderCell: React.forwardRef((props, ref) => {
       return (
         <NumericalCell
           {...props}
           ref={ref}
-          format={options.format || NUMERICAL_FORMATS.DEFAULT}
+          format={normalizedOptions.format}
           highlight={
-            options.highlight ||
-            (options.format === NUMERICAL_FORMATS.ACCOUNTING
+            normalizedOptions.format === NUMERICAL_FORMATS.ACCOUNTING
               ? n => n < 0
-              : () => false)
+              : normalizedOptions.highlight
           }
-          precision={options.precision || 2}
+          precision={
+            normalizedOptions.format === NUMERICAL_FORMATS.DEFAULT
+              ? normalizedOptions.precision
+              : 2
+          }
         />
       );
     }),

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -118,8 +118,9 @@ function NumericalColumn(options: OptionsT): NumericalColumnT {
         return true;
       };
     },
+    // initial sort should display largest values first
     sortFn: function(a, b) {
-      return a - b;
+      return b - a;
     },
   };
 }

--- a/src/data-table/column-numerical.js
+++ b/src/data-table/column-numerical.js
@@ -119,7 +119,7 @@ function NumericalColumn(options: OptionsT): NumericalColumnT {
       };
     },
     sortFn: function(a, b) {
-      return b - a;
+      return a - b;
     },
   };
 }

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -90,7 +90,11 @@ export function Unstable_DataTable(props: Props) {
   const [filters, setFilters] = React.useState(new Map());
   const [widths, setWidths] = React.useState(props.columns.map(() => 0));
   const gridRef = React.useRef<React.Ref<typeof VariableSizeGrid> | null>(null);
+  // indicates which header cell is currently hovered
   const [headerHoverIndex, setHeaderHoverIndex] = React.useState(-1);
+  // filter open state tracked outside of header cell so that mouse-leave from the header
+  // does not cause the popover to close.
+  const [filterOpenIndex, setFilterOpenIndex] = React.useState(-1);
 
   function addFilter(filterParams, title, description) {
     filters.set(title, {filterParams, description});
@@ -185,7 +189,21 @@ export function Unstable_DataTable(props: Props) {
                   filterable={column.filterable}
                   sortable={column.sortable}
                   isHovered={headerHoverIndex === columnIndex}
-                  onMouseEnter={() => setHeaderHoverIndex(columnIndex)}
+                  isFilterOpen={filterOpenIndex === columnIndex}
+                  onFilterOpen={() => {
+                    if (filterOpenIndex === columnIndex) {
+                      setFilterOpenIndex(-1);
+                    } else {
+                      setFilterOpenIndex(columnIndex);
+                    }
+                  }}
+                  onFilterClose={() => setFilterOpenIndex(-1)}
+                  onMouseEnter={() => {
+                    setHeaderHoverIndex(columnIndex);
+                    if (columnIndex !== filterOpenIndex) {
+                      setFilterOpenIndex(-1);
+                    }
+                  }}
                   onMouseLeave={() => setHeaderHoverIndex(-1)}
                   onSort={handleSort}
                   filter={({close}) => {

--- a/src/data-table/data-table.js
+++ b/src/data-table/data-table.js
@@ -152,7 +152,7 @@ export function Unstable_DataTable(props: Props) {
   const InnerTableElement = React.forwardRef(({children, ...rest}, ref) => {
     const [useCss, theme] = useStyletron();
     return (
-      <div ref={ref} {...rest}>
+      <div ref={ref} data-baseweb="data-table" {...rest}>
         <div
           className={useCss({
             position: 'sticky',

--- a/src/data-table/header-cell.js
+++ b/src/data-table/header-cell.js
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 
 import * as React from 'react';
 
-import {StatefulPopover, PLACEMENT} from '../popover/index.js';
+import {Popover, PLACEMENT} from '../popover/index.js';
 import {useStyletron} from '../styles/index.js';
 import ChevronDown from '../icon/chevron-down.js';
 import ChevronUp from '../icon/chevron-up.js';
@@ -21,8 +21,11 @@ type HeaderCellPropsT = {
   filter: React.ComponentType<{close: () => void}>,
   filterable: boolean,
   index: number,
+  isFilterOpen: boolean,
   isHovered: boolean,
   isMeasured?: boolean,
+  onFilterOpen: () => void,
+  onFilterClose: () => void,
   onMouseEnter: number => void,
   onMouseLeave: number => void,
   onSort: number => void,
@@ -84,7 +87,11 @@ const HeaderCell = React.forwardRef<HeaderCellPropsT, HTMLDivElement>(
           whiteSpace: 'nowrap',
         })}
         onMouseEnter={props.onMouseEnter}
-        onMouseLeave={props.onMouseLeave}
+        onMouseLeave={event => {
+          if (!props.isFilterOpen) {
+            props.onMouseLeave(event);
+          }
+        }}
         onKeyUp={event => {
           if (event.key === 'Enter') {
             props.onSort(props.index);
@@ -102,16 +109,23 @@ const HeaderCell = React.forwardRef<HeaderCellPropsT, HTMLDivElement>(
         {props.title}
         <div className={controlStyles}>
           {props.isHovered && props.filterable ? (
-            <StatefulPopover
+            <Popover
               placement={PLACEMENT.bottomLeft}
               ignoreBoundary
-              onClick={e => e.stopPropagation()}
-              content={({close}) => <Filter close={close} />}
+              isOpen={props.isFilterOpen}
+              onClick={e => {
+                e.stopPropagation();
+                props.onFilterOpen();
+              }}
+              onClickOutside={() => {
+                props.onFilterClose();
+              }}
+              content={() => <Filter close={props.onFilterClose} />}
             >
               <button className={filterButtonStyles}>
                 <FilterIcon />
               </button>
-            </StatefulPopover>
+            </Popover>
           ) : (
             <div />
           )}

--- a/src/data-table/measure-column-widths.js
+++ b/src/data-table/measure-column-widths.js
@@ -124,8 +124,11 @@ export default function MeasureColumnWidths(props: MeasureColumnWidthsPropsT) {
               filterable={column.filterable}
               filter={p => null}
               index={columnIndex}
+              isFilterOpen={false}
               isHovered
               isMeasured
+              onFilterOpen={() => {}}
+              onFilterClose={() => {}}
               onMouseEnter={() => {}}
               onMouseLeave={() => {}}
               onSort={i => {}}

--- a/src/styles/__mocks__/styled.js
+++ b/src/styles/__mocks__/styled.js
@@ -25,6 +25,17 @@ type StateT = {styles?: {}};
 const MOCK_THEME = createMockTheme(LightTheme);
 const IDENTITY = x => x;
 
+export function useStyletron() {
+  function useCss(styles: Object) {
+    return {
+      label: 'useStyletron mock describes the applied css properties',
+      ...styles,
+    };
+  }
+
+  return [useCss, MOCK_THEME];
+}
+
 export function styled(ElementName: string, objOrFn?: ObjOrFnT = {}) {
   class MockStyledComponent extends React.Component<PropsT, StateT> {
     static displayName = 'MockStyledComponent';


### PR DESCRIPTION
- adds a `useStyletron` mock so that tests can assert on the css properties rather than the generated class names
- unit tests explore using `act` from `react-dom/test-utils` rather than `enzyme`.
- improves header cell hovering + open filter popover (hovering out of cell will not close the filter)