### PR TITLE
fix(docs): use styledlink in docs

### DIFF
--- a/documentation-site/components/markdown-elements.js
+++ b/documentation-site/components/markdown-elements.js
@@ -11,6 +11,7 @@ import * as React from 'react';
 
 import Head from 'next/head';
 import {Block} from 'baseui/block';
+import {StyledLink} from 'baseui/link';
 import Code from './code';
 import {themedStyled} from '../pages/_app';
 import Link from 'next/link';
@@ -113,9 +114,9 @@ export const DocLink = ({children, href}: {children: string, href: string}) => {
     (parts[0] === '' && parts[1] !== '') || !href.includes('http');
   return (
     <Link href={href}>
-      <a href={href} {...(internal ? {} : {target: '_blank'})}>
+      <StyledLink href={href} {...(internal ? {} : {target: '_blank'})}>
         {children}
-      </a>
+      </StyledLink>
     </Link>
   );
 };


### PR DESCRIPTION
#### Description
Currently the generated documentation at https://baseweb.design appears to have only the default user-agent styles applied to most links ([example](https://baseweb.design/getting-started/setup/)) which make it hard to see the links when the dark theme is used. This change should have the effect of using the `<StyledLink>` from baseui instead of a plain `<a>` and should thus have the appropriate colors applied to it.

![image](https://user-images.githubusercontent.com/358876/64634621-a5809500-d3cb-11e9-917c-d96461e90652.png)

#### Scope
This should not require any version change since the change is only applied to the generated documentation styling.

