### PR TITLE
docs(select): Improve virtualized example

### DIFF
--- a/documentation-site/examples/select/with-many-options.js
+++ b/documentation-site/examples/select/with-many-options.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import {withStyle} from 'baseui';
 import {Select, StyledDropdownListItem} from 'baseui/select';
-import {StyledList} from 'baseui/menu';
+import {StyledList, StyledEmptyState} from 'baseui/menu';
 
 import List from 'react-virtualized/dist/commonjs/List';
 import AutoSizer from 'react-virtualized/dist/commonjs/AutoSizer';
@@ -14,19 +14,30 @@ const ListItem = withStyle(StyledDropdownListItem, {
   alignItems: 'center',
 });
 
-const Container = withStyle(StyledList, {height: '500px'});
+const Container = withStyle(StyledList, ({$height}) => ({
+  height: $height,
+}));
 
 const VirtualList = React.forwardRef((props, ref) => {
   const children = React.Children.toArray(props.children);
+
+  if (!children[0] || !children[0].props.item) {
+    return (
+      <Container $height="72px" ref={ref}>
+        <StyledEmptyState {...children[0].props} />
+      </Container>
+    );
+  }
+
   return (
-    <Container ref={ref}>
+    <Container $height="500px" ref={ref}>
       <AutoSizer>
         {({width}) => (
           <List
             role={props.role}
             height={500}
             width={width}
-            rowCount={props.children.length}
+            rowCount={children.length}
             rowHeight={36}
             rowRenderer={({index, key, style}) => {
               return (
@@ -62,7 +73,7 @@ export default () => {
       options={options}
       labelKey="id"
       valueKey="label"
-      overrides={{Dropdown: {component: VirtualList}}}
+      overrides={{Dropdown: VirtualList}}
       onChange={({value}) => setValue(value)}
       value={value}
     />

--- a/documentation-site/examples/select/with-many-options.tsx
+++ b/documentation-site/examples/select/with-many-options.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {withStyle} from 'baseui';
 import {Select, StyledDropdownListItem, Value} from 'baseui/select';
-import {StyledList} from 'baseui/menu';
+import {StyledList, StyledEmptyState} from 'baseui/menu';
 
 import {List, AutoSizer} from 'react-virtualized';
 
@@ -12,19 +12,30 @@ const ListItem = withStyle(StyledDropdownListItem, {
   alignItems: 'center',
 });
 
-const Container = withStyle(StyledList, {height: '500px'});
+const Container = withStyle(StyledList, ({$height}) => ({
+  height: $height,
+}));
 
 const VirtualList = React.forwardRef((props: any, ref) => {
   const children = React.Children.toArray(props.children);
+
+  if (!children[0] || !children[0].props.item) {
+    return (
+      <Container $height="72px" ref={ref}>
+        <StyledEmptyState {...children[0].props} />
+      </Container>
+    );
+  }
+
   return (
-    <Container ref={ref}>
+    <Container $height="500px" ref={ref}>
       <AutoSizer>
         {({width}) => (
           <List
             role={props.role}
             height={500}
             width={width}
-            rowCount={props.children.length}
+            rowCount={children.length}
             rowHeight={36}
             rowRenderer={({index, key, style}) => {
               return (

--- a/documentation-site/examples/select/with-many-options.tsx
+++ b/documentation-site/examples/select/with-many-options.tsx
@@ -12,9 +12,12 @@ const ListItem = withStyle(StyledDropdownListItem, {
   alignItems: 'center',
 });
 
-const Container = withStyle(StyledList, ({$height}) => ({
-  height: $height,
-}));
+const Container = withStyle(
+  StyledList,
+  (props: {$height: string}) => ({
+    height: props.$height,
+  }),
+);
 
 const VirtualList = React.forwardRef((props: any, ref) => {
   const children = React.Children.toArray(props.children);

--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -47,12 +47,10 @@ export interface RenderItemProps {
   resetMenu?: () => any;
 }
 
-export type OnItemSelect = (
-  args: {
-    item: any;
-    event?: React.SyntheticEvent<HTMLElement> | KeyboardEvent;
-  },
-) => any;
+export type OnItemSelect = (args: {
+  item: any;
+  event?: React.SyntheticEvent<HTMLElement> | KeyboardEvent;
+}) => any;
 
 export type StateReducer = (
   changeType: STATE_CHANGE_TYPES[keyof STATE_CHANGE_TYPES],
@@ -163,6 +161,7 @@ export class NestedMenus extends React.Component<
   getChildMenu(ref: React.Ref<HTMLElement>): React.Ref<HTMLElement>;
 }
 
+export const StyledEmptyState: StyletronComponent<any>;
 export const StyledList: StyletronComponent<any>;
 export const StyledListItem: StyletronComponent<any>;
 export const StyledListItemProfile: StyletronComponent<any>;

--- a/src/menu/index.js
+++ b/src/menu/index.js
@@ -15,6 +15,7 @@ export {default as NestedMenus} from './nested-menus.js';
 export {KEY_STRINGS, STATE_CHANGE_TYPES} from './constants.js';
 // Styled elements
 export {
+  StyledEmptyState,
   StyledList,
   StyledListItem,
   StyledListItemProfile,


### PR DESCRIPTION
Previously, the example we had would not render a 'not found' message when no options are included once filtered by the typed-in query

#### Scope

- [x] Patch: Bug Fix

