### PR TITLE
test(datepicker): multi-month screener test

### DIFF
--- a/src/datepicker/__tests__/calendar-multi-month.scenario.js
+++ b/src/datepicker/__tests__/calendar-multi-month.scenario.js
@@ -16,6 +16,7 @@ export const component = () => (
   <StatefulCalendar
     onChange={({date}) => console.log(date)}
     orientation={ORIENTATION.horizontal}
+    highlightedDate={new Date('March 10, 2019')}
     monthsShown={2}
     range
     quickSelect


### PR DESCRIPTION
we didn't have a date set for the datepicker, so every day, the screener test would fail, because it uses the current day as the default

like this one: https://github.com/uber-web/baseui/pull/1834