### PR TITLE
docs(input): fix alignment in focus example

### DIFF
--- a/documentation-site/examples/input/focus.js
+++ b/documentation-site/examples/input/focus.js
@@ -9,14 +9,18 @@ export default () => {
   const inputRef = React.createRef();
   return (
     <div className={useCss({display: 'flex'})}>
-      <div
-        className={useCss({
-          width: '50%',
-          marginRight: theme.sizing.scale400,
-        })}
-      >
-        <Input inputRef={inputRef} placeholder="With input ref" />
-      </div>
+      <Input
+        inputRef={inputRef}
+        placeholder="With input ref"
+        overrides={{
+          Root: {
+            style: {
+              width: '50%',
+              marginRight: theme.sizing.scale400,
+            },
+          },
+        }}
+      />
       <Button
         onClick={() => inputRef.current && inputRef.current.focus()}
       >

--- a/documentation-site/examples/input/focus.tsx
+++ b/documentation-site/examples/input/focus.tsx
@@ -8,14 +8,18 @@ export default () => {
   const inputRef = React.createRef<HTMLInputElement>();
   return (
     <div className={useCss({display: 'flex'})}>
-      <div
-        className={useCss({
-          width: '50%',
-          marginRight: theme.sizing.scale400,
-        })}
-      >
-        <Input inputRef={inputRef} placeholder="With input ref" />
-      </div>
+      <Input
+        inputRef={inputRef}
+        placeholder="With input ref"
+        overrides={{
+          Root: {
+            style: {
+              width: '50%',
+              marginRight: theme.sizing.scale400,
+            },
+          },
+        }}
+      />
       <Button
         onClick={() => inputRef.current && inputRef.current.focus()}
       >


### PR DESCRIPTION
Small fix to an example on input page which makes buttons and inputs look like they have incorrect sizing.