### PR TITLE
fix(masked-input): fix focus styling

### DIFF
--- a/src/input/__tests__/__snapshots__/masked-input.test.js.snap
+++ b/src/input/__tests__/__snapshots__/masked-input.test.js.snap
@@ -60,7 +60,6 @@ Object {
   "aria-labelledby": null,
   "aria-required": false,
   "autoComplete": "on",
-  "autoFocus": false,
   "disabled": false,
   "id": undefined,
   "inputMode": "text",
@@ -77,7 +76,6 @@ Object {
   "placeholder": "Placeholder",
   "required": false,
   "rows": null,
-  "size": "default",
   "styled-component": "true",
   "test-style": Object {
     "::placeholder": Object {

--- a/src/input/__tests__/input-mask.scenario.js
+++ b/src/input/__tests__/input-mask.scenario.js
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2018-2019 Uber Technologies, Inc.
+
+This source code is licensed under the MIT license found in the
+LICENSE file in the root directory of this source tree.
+*/
+
+// @flow
+
+import React from 'react';
+import {MaskedInput} from '../index.js';
+
+export const name = 'input-mask';
+
+export function component() {
+  const [value, setValue] = React.useState('20000101');
+  return (
+    <MaskedInput
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      autoFocus
+      mask="9999/99/99"
+      value={value}
+      onChange={e => setValue(e.target.value)}
+    />
+  );
+}

--- a/src/input/masked-input.js
+++ b/src/input/masked-input.js
@@ -71,6 +71,5 @@ export default function MaskedInput(props: MaskedInputPropsT) {
 }
 
 MaskedInput.defaultProps = {
-  ...Input.defaultProps,
   maskChar: ' ',
 };


### PR DESCRIPTION
The issue here was that `MaskedInput` had default props that overrides the `onFocus` for `Input`. `Input` then cannot set the focus state to true, and does not style the `InputContainer`.

There is no need for `MaskedInput` to duplicate `Input` default props so I removed the duplicates. 

I also added a visual regression test.