### PR TITLE
bugfix: disable outline for tab

### DIFF
--- a/src/tabs/styled-components.js
+++ b/src/tabs/styled-components.js
@@ -42,6 +42,7 @@ export const Tab = styled<SharedStylePropsArgT>('div', props => {
         ? `2px solid ${colors.primary}`
         : 'none',
     display: 'inline-block',
+    outline: 'none',
   };
   if (!$disabled) {
     style = {


### PR DESCRIPTION
#### Description

I have created two tabs:

![image](https://user-images.githubusercontent.com/327717/65587985-0b058180-df87-11e9-8039-81aadfdabaad.png)

And there's outline when clicked (focus state). So I was thinking to remove it. Or is it intentional?

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
