### PR TITLE
docs(typography): add exports and fix heading example

### DIFF
--- a/documentation-site/pages/components/typography.mdx
+++ b/documentation-site/pages/components/typography.mdx
@@ -8,7 +8,9 @@ LICENSE file in the root directory of this source tree.
 import Example from '../../components/example';
 import API from '../../components/api';
 import Layout from '../../components/layout';
+import Exports from '../../components/exports';
 
+import * as TypographyExports from 'baseui/typography';
 import Display from 'examples/typography/display.js';
 import Heading from 'examples/typography/heading.js';
 import Text from 'examples/typography/text.js';
@@ -33,13 +35,21 @@ You can find the font definitions in the [Theming values](/guides/theming/#themi
 
 At Uber, we use Display components with an alternate font family to create typographic contrast in our UI.
 
-<Example title="Typography Heading Blocks" path="typography/display.js">
+<Example title="Typography Heading Blocks" path="typography/heading.js">
   <Heading />
 </Example>
 
 <Example title="Typography Body Blocks" path="typography/text.js">
   <Text />
 </Example>
+
+## Exports
+
+<Exports
+  component={TypographyExports}
+  title="Typography exports"
+  path="baseui/typography"
+/>
 
 ## API
 


### PR DESCRIPTION
Add exports to typography page and fix the heading example (was showing display again)