### PR TITLE
fix(data-table): ensure width dim exists before setting

### DIFF
--- a/src/data-table/measure-column-widths.js
+++ b/src/data-table/measure-column-widths.js
@@ -96,7 +96,7 @@ export default function MeasureColumnWidths(props: MeasureColumnWidthsPropsT) {
   }, [props.columns, props.rows, props.widths, sampleSize]);
 
   function handleDimensionsChange(columnIndex, rowIndex, dimensions) {
-    if (!dimensions.width) return;
+    if (dimensions.width === undefined) return;
 
     measurementCount.current += 1;
 

--- a/src/data-table/measure-column-widths.js
+++ b/src/data-table/measure-column-widths.js
@@ -44,15 +44,11 @@ type ElementMeasurerPropsT = {
 function ElementMeasurer(props: ElementMeasurerPropsT) {
   const {onDimensionsChange} = props;
   const [ref, dimensions] = useDimensions();
-  const initialized = React.useRef(false);
+
   React.useEffect(() => {
-    // ignores the first callback with empty information
-    if (initialized.current) {
-      onDimensionsChange(dimensions);
-    } else {
-      initialized.current = true;
-    }
+    onDimensionsChange(dimensions);
   }, [dimensions, onDimensionsChange]);
+
   return React.cloneElement(props.item, {ref});
 }
 
@@ -100,6 +96,8 @@ export default function MeasureColumnWidths(props: MeasureColumnWidthsPropsT) {
   }, [props.columns, props.rows, props.widths, sampleSize]);
 
   function handleDimensionsChange(columnIndex, rowIndex, dimensions) {
+    if (!dimensions.width) return;
+
     measurementCount.current += 1;
 
     const nextWidth = Math.max(


### PR DESCRIPTION
#### Description

strangely this bug only occurs in the docs site, not in the scenarios. that's why CI allowed prior diffs to land. to be honest i'm not sure what was causing the width dimensions to be missing in the docs site, but i've updated the code to only update the widths if a value is present

#### Scope

- [x] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
