### PR TITLE
feat(yard): add the Tabs component (nested components support)

### DIFF
--- a/documentation-site/components/yard/__tests__/ast.test.ts
+++ b/documentation-site/components/yard/__tests__/ast.test.ts
@@ -195,18 +195,16 @@ describe('parseCode', () => {
       parsedProps: {
         children: '',
         onChange: 'e => setValue(e.target.value)',
-        overrides: `{
+        overrides: `({
   Root: {
-    style: ({
-      $theme
-    }) => {
+    style: ({ $theme }) => {
       return {
         outline: \`\${$theme.colors.warning200} solid\`,
         backgroundColor: $theme.colors.warning200
       };
     }
   }
-}`,
+})`,
         placeholder: 'Controlled Input',
         value: 'Hello',
       },

--- a/documentation-site/components/yard/__tests__/code-generator.test.ts
+++ b/documentation-site/components/yard/__tests__/code-generator.test.ts
@@ -2,6 +2,7 @@ import {
   getAstPropValue,
   getAstReactHooks,
   getAstImport,
+  getAstImports,
   getEnumsToImport,
   getAstThemeImport,
   getAstThemeWrapper,
@@ -137,23 +138,25 @@ describe('getAstPropValue', () => {
         type: PropTypes.ReactNode,
         description: '',
       }),
-    ).toEqual({
-      children: [],
-      closingElement: null,
-      loc: undefined,
-      openingElement: {
-        attributes: [],
+    ).toEqual([
+      {
+        children: [],
+        closingElement: null,
         loc: undefined,
-        name: {
+        openingElement: {
+          attributes: [],
           loc: undefined,
-          name: 'div',
-          type: 'JSXIdentifier',
+          name: {
+            loc: undefined,
+            name: 'div',
+            type: 'JSXIdentifier',
+          },
+          selfClosing: true,
+          type: 'JSXOpeningElement',
         },
-        selfClosing: true,
-        type: 'JSXOpeningElement',
+        type: 'JSXElement',
       },
-      type: 'JSXElement',
-    });
+    ]);
   });
   test('function', () => {
     expect(
@@ -290,6 +293,25 @@ describe('getAstImport', () => {
   });
 });
 
+describe('getAstImports', () => {
+  test('return multiple named and default imports', () => {
+    expect(
+      generate(t.program(
+        getAstImports('Tabs', ['ORIENTATION'], {
+          'baseui/tabs': {
+            named: ['Tab'],
+            default: 'Root',
+          },
+          'react-motion': {
+            named: ['Motion'],
+          },
+        }),
+      ) as any).code,
+    ).toBe(`import Root, { Tabs, Tab, ORIENTATION } from "baseui/tabs";
+import { Motion } from "react-motion";`);
+  });
+});
+
 describe('getEnumsToImport', () => {
   test('get enums', () => {
     expect(
@@ -366,7 +388,8 @@ describe('getCode', () => {
         'Input',
         {themeValues: {inputFill: 'yellow'}, themeName: 'light'},
       ),
-    ).toBe(`import { Input } from "baseui/input";
+    ).toBe(`import * as React from "react";
+import { Input } from "baseui/input";
 import {
   ThemeProvider,
   createTheme,

--- a/documentation-site/components/yard/__tests__/utils.test.ts
+++ b/documentation-site/components/yard/__tests__/utils.test.ts
@@ -1,0 +1,24 @@
+import {formatBabelError} from '../utils';
+
+describe('formatBabelError', () => {
+  test('decrease the line number by one', () => {
+    const source = `SyntaxError: Unexpected token, expected "jsxTagEnd" (10:5)`;
+    expect(formatBabelError(source)).toBe(
+      `SyntaxError: Unexpected token, expected "jsxTagEnd" (9:5)`,
+    );
+  });
+
+  test('make all adjustments', () => {
+    const source = `SyntaxError: Unexpected token, expected "jsxTagEnd" (3:17)
+  1 | /* @babel/template */;
+  2 | <><Tab title="Tab Link 1">
+> 3 |   Content 1</Tab /></>
+    |                 ^`;
+    expect(formatBabelError(source))
+      .toBe(`SyntaxError: Unexpected token, expected "jsxTagEnd" (2:17)
+  
+  1 | <Tab title="Tab Link 1">
+> 2 |   Content 1</Tab />
+    |                 ^`);
+  });
+});

--- a/documentation-site/components/yard/ast.ts
+++ b/documentation-site/components/yard/ast.ts
@@ -232,7 +232,7 @@ export function parseCode(code: string, elementName: string) {
                   value = formatAstAndPrint(
                     //@ts-ignore
                     t.program([t.expressionStatement(attr.value.expression)]),
-                    30,
+                    name === 'overrides' ? 70 : 30,
                   );
                 }
               }
@@ -245,7 +245,8 @@ export function parseCode(code: string, elementName: string) {
           )
             .replace(/\n  /g, '\n')
             .replace(/^<YardRoot>\n?/, '')
-            .replace(/<\/YardRoot>$/, '');
+            .replace(/<\/YardRoot>$/, '')
+            .replace(/\s*<YardRoot \/>\s*/, '');
         }
       },
       VariableDeclarator(path) {

--- a/documentation-site/components/yard/ast.ts
+++ b/documentation-site/components/yard/ast.ts
@@ -5,6 +5,7 @@ import * as t from 'babel-types';
 import {TProp, TPropHook} from './types';
 import {PropTypes} from './const';
 import {parse as babelParse} from '@babel/parser';
+import {getAstJsxElement, formatAstAndPrint} from './code-generator';
 
 export const parse = (code: string) =>
   babelParse(code, {
@@ -228,18 +229,23 @@ export function parseCode(code: string, elementName: string) {
                 if (attr.value.expression.type === 'BooleanLiteral') {
                   value = attr.value.expression.value;
                 } else {
-                  value = generate(attr.value.expression).code;
+                  value = formatAstAndPrint(
+                    //@ts-ignore
+                    t.program([t.expressionStatement(attr.value.expression)]),
+                    30,
+                  );
                 }
               }
             }
             propValues[name] = value;
           });
-          propValues['children'] = (path.node as any).children
-            .reduce(
-              (result: string, node: any) => `${result}${generate(node).code}`,
-              '',
-            )
-            .replace(/^\s+|\s+$/g, '');
+          propValues['children'] = formatAstAndPrint(
+            getAstJsxElement('YardRoot', [], path.node.children as any) as any,
+            30,
+          )
+            .replace(/\n  /g, '\n')
+            .replace(/^<YardRoot>\n?/, '')
+            .replace(/<\/YardRoot>$/, '');
         }
       },
       VariableDeclarator(path) {

--- a/documentation-site/components/yard/code-generator.ts
+++ b/documentation-site/components/yard/code-generator.ts
@@ -275,11 +275,11 @@ export const getAst = (
   );
 };
 
-export const formatAstAndPrint = (ast: t.Program) => {
+export const formatAstAndPrint = (ast: t.Program, printWidth?: number) => {
   const result = (prettier as any).__debug.formatAST(ast, {
     originalText: '',
     parser: 'babel',
-    printWidth: 70,
+    printWidth: printWidth ? printWidth : 70,
     plugins: [parsers],
   });
   return (

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -3,6 +3,11 @@ import {Button} from 'baseui/button';
 import {PropTypes} from '../const';
 
 export default {
+  extraImports: {
+    named: {
+      'baseui/button': ['Button'],
+    },
+  },
   scopeConfig: {
     Button,
     ButtonGroup,
@@ -36,9 +41,6 @@ export default {
         '<Button>One</Button>\n<Button>Two</Button>\n<Button>Three</Button>',
       type: PropTypes.ReactNode,
       description: 'Buttons within the group',
-      meta: {
-        imports: ['Button'],
-      },
     },
     onClick: {
       value: '(event, index) => {\n  setSelected([index]);\n}',

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -32,10 +32,12 @@ export default {
   ],
   propsConfig: {
     children: {
-      value:
-        '<Button>Label</Button><Button>Label</Button><Button>Label</Button>',
+      value: '<Button>One</Button><Button>Two</Button><Button>Three</Button>',
       type: PropTypes.ReactNode,
       description: 'Buttons within the group',
+      meta: {
+        imports: ['Button'],
+      },
     },
     onClick: {
       value: '(event, index) => {\n  setSelected([index]);\n}',

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -32,7 +32,8 @@ export default {
   ],
   propsConfig: {
     children: {
-      value: '<Button>One</Button><Button>Two</Button><Button>Three</Button>',
+      value:
+        '<Button>One</Button>\n<Button>Two</Button>\n<Button>Three</Button>',
       type: PropTypes.ReactNode,
       description: 'Buttons within the group',
       meta: {

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -4,8 +4,8 @@ import {PropTypes} from '../const';
 
 export default {
   extraImports: {
-    named: {
-      'baseui/button': ['Button'],
+    'baseui/button': {
+      named: ['Button'],
     },
   },
   scopeConfig: {

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -1,0 +1,78 @@
+import {Tabs, Tab, ORIENTATION} from 'baseui/tabs';
+import {PropTypes} from '../const';
+
+export default {
+  scopeConfig: {
+    Tabs,
+    Tab,
+    ORIENTATION,
+  },
+  themeConfig: ['tabBarFill', 'tabColor'],
+  propsConfig: {
+    children: {
+      value: `<Tab title="Tab Link 1">
+  Content 1
+</Tab>
+<Tab title="Tab Link 2">
+  Content 2
+</Tab>
+<Tab title="Tab Link 3">
+  Content 3
+</Tab>`,
+      type: PropTypes.ReactNode,
+      description: `An array of Tab components.`,
+    },
+    onChange: {
+      value: '({ activeKey }) => {\n  setActiveKey(activeKey);\n}',
+      type: PropTypes.Function,
+      description: `Change handler that is called every time a new tab is selected.`,
+      meta: {
+        propHook: {
+          what: 'activeKey',
+          into: 'activeKey',
+        },
+      },
+    },
+    orientation: {
+      value: false,
+      type: PropTypes.Enum,
+      options: ORIENTATION,
+      description: 'The orientation of the tab component.',
+    },
+    activeKey: {
+      value: '0',
+      type: PropTypes.String,
+      description: 'Key of the the tab to be selected.',
+      meta: {
+        stateful: true,
+      },
+    },
+    disabled: {
+      value: false,
+      type: PropTypes.Boolean,
+      description: 'True when all tabs are disabled.',
+    },
+    renderAll: {
+      value: false,
+      type: PropTypes.Boolean,
+      description:
+        'Renders all tab content for SEO purposes regardless of tab active state.',
+    },
+    overrides: {
+      value: undefined,
+      type: PropTypes.Overrides,
+      description: 'Lets you customize all aspects of the component.',
+      meta: {
+        names: ['Root', 'Tab', 'TabBar', 'TabContent'],
+        sharedProps: {
+          $disabled: 'disabled',
+          $active: {
+            type: PropTypes.Boolean,
+            description: 'True when the tab is active.',
+          },
+          $orientation: 'orientation',
+        },
+      },
+    },
+  },
+};

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -3,9 +3,7 @@ import {PropTypes} from '../const';
 
 export default {
   extraImports: {
-    named: {
-      'baseui/tabs': ['Tab'],
-    },
+    'baseui/tabs': {named: ['Tab']},
   },
   scopeConfig: {
     Tabs,

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -2,6 +2,11 @@ import {Tabs, Tab, ORIENTATION} from 'baseui/tabs';
 import {PropTypes} from '../const';
 
 export default {
+  extraImports: {
+    named: {
+      'baseui/tabs': ['Tab'],
+    },
+  },
   scopeConfig: {
     Tabs,
     Tab,

--- a/documentation-site/components/yard/editor.tsx
+++ b/documentation-site/components/yard/editor.tsx
@@ -23,8 +23,10 @@ const highlightCode = (code: string, theme: any) => (
 
 const Editor: React.FC<{
   code: string;
+  placeholder?: string;
   onChange: (code: string) => void;
-}> = ({code, onChange}) => {
+  small?: boolean;
+}> = ({code, onChange, placeholder, small}) => {
   const [css, theme] = useStyletron();
   const [focused, setFocused] = React.useState(false);
   const plainStyles = theme.name.startsWith('light-theme')
@@ -34,6 +36,7 @@ const Editor: React.FC<{
     ...plainStyles,
     plain: {
       ...plainStyles.plain,
+      fontSize: small ? '13px' : '14px',
       backgroundColor: focused
         ? theme.colors.inputFillActive
         : theme.colors.inputFill,
@@ -44,6 +47,11 @@ const Editor: React.FC<{
     <div
       className={css({
         boxSizing: 'border-box',
+        backgroundColor: editorTheme.plain.backgroundColor,
+        paddingLeft: '4px',
+        paddingRight: '4px',
+        height: small && !focused ? '40px' : 'auto',
+        overflow: 'hidden',
         border: focused
           ? `2px solid ${theme.colors.borderFocus}`
           : `2px solid ${theme.colors.inputFill}`,
@@ -55,12 +63,13 @@ const Editor: React.FC<{
         }}
       />
       <SimpleEditor
-        value={code}
+        value={code || ''}
+        placeholder={placeholder}
         highlight={code => highlightCode(code, editorTheme)}
         onValueChange={code => onChange(code)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
-        padding={10}
+        padding={small ? 6 : 12}
         style={editorTheme.plain}
       />
     </div>

--- a/documentation-site/components/yard/index.tsx
+++ b/documentation-site/components/yard/index.tsx
@@ -11,6 +11,7 @@ const YardWrapper: React.FC<TYardProps & {placeholderHeight: number}> = ({
   propsConfig,
   themeConfig,
   placeholderHeight,
+  extraImports,
 }) => {
   const [useCss] = useStyletron();
   const placeholderCx = useCss({
@@ -27,6 +28,7 @@ const YardWrapper: React.FC<TYardProps & {placeholderHeight: number}> = ({
         scopeConfig={scopeConfig}
         propsConfig={propsConfig}
         themeConfig={themeConfig}
+        extraImports={extraImports}
         minHeight={placeholderHeight}
         placeholderElement={() => (
           <div className={placeholderCx}>

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -9,6 +9,7 @@ import {Radio, RadioGroup} from 'baseui/radio';
 import {Checkbox} from 'baseui/checkbox';
 import {StatefulTooltip} from 'baseui/tooltip';
 import PopupError from './popup-error';
+import Editor from './editor';
 
 const getTooltip = (description: string, type: string, name: string) => (
   <span>
@@ -87,6 +88,13 @@ const Knob: React.SFC<{
             error={Boolean(error)}
             onChange={event => set((event.target as any).value)}
             placeholder={placeholder}
+            overrides={{
+              Input: {
+                style: {
+                  height: '36px',
+                },
+              },
+            }}
             size="compact"
             value={val}
           />
@@ -157,24 +165,11 @@ const Knob: React.SFC<{
       return (
         <Spacing>
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
-          <Textarea
-            //@ts-ignore
-            onChange={event => set(event.target.value)}
-            value={val}
-            error={Boolean(error)}
-            size="compact"
+          <Editor
+            onChange={code => set(code)}
+            code={val}
             placeholder={placeholder}
-            overrides={{
-              Input: {
-                style: ({$isFocused}) => ({
-                  height: $isFocused ? 'auto' : '32px',
-                  fontSize: '12px',
-                  fontFamily:
-                    "Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace",
-                  resize: $isFocused ? 'vertical' : 'none',
-                }),
-              },
-            }}
+            small
           />
           <PopupError error={error} />
         </Spacing>

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -4,7 +4,6 @@ import {StyledLink} from 'baseui/link';
 import {assertUnreachable} from './utils';
 import {PropTypes} from './const';
 import {Input} from 'baseui/input';
-import {Textarea} from 'baseui/textarea';
 import {Radio, RadioGroup} from 'baseui/radio';
 import {Checkbox} from 'baseui/checkbox';
 import {StatefulTooltip} from 'baseui/tooltip';

--- a/documentation-site/components/yard/popup-error.tsx
+++ b/documentation-site/components/yard/popup-error.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {Popover, PLACEMENT} from 'baseui/popover';
 import {useStyletron} from 'baseui';
+import {formatBabelError} from './utils';
 
 const PopupError: React.FC<{error: string | null}> = ({error}) => {
   const [css, theme] = useStyletron();
@@ -19,15 +20,12 @@ const PopupError: React.FC<{error: string | null}> = ({error}) => {
   if (error === null) {
     return null;
   }
-  const formatError = error
-    .replace('1 | /* @babel/template */;', '')
-    .replace(/(\d+ \|)/g, num => `${parseInt(num, 10) - 1} |`);
   return (
     <Popover
       isOpen
       accessibilityType="tooltip"
       placement={PLACEMENT.bottom}
-      content={<div className={errorCx}>{formatError}</div>}
+      content={<div className={errorCx}>{formatBabelError(error)}</div>}
     >
       <div />
     </Popover>

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -6,8 +6,10 @@ export type TPropHook = {
 } | null;
 
 export type TExtraImports = {
-  named?: {[key: string]: string[]};
-  default?: {[key: string]: string[]};
+  [key: string]: {
+    named?: string[];
+    default?: string;
+  };
 };
 
 export type TYardProps = {

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -5,9 +5,15 @@ export type TPropHook = {
   into: string;
 } | null;
 
+export type TExtraImports = {
+  named?: {[key: string]: string[]};
+  default?: {[key: string]: string[]};
+};
+
 export type TYardProps = {
   componentName: string;
   minHeight: number;
+  extraImports?: TExtraImports;
   scopeConfig: {[key: string]: any};
   propsConfig: {[key: string]: TProp};
   themeConfig: string[];

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -25,6 +25,7 @@ export type TProp = {
     sharedKeys?: any;
     stateful?: boolean;
     propHook?: TPropHook;
+    imports?: string[];
   };
 };
 

--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -1,3 +1,20 @@
 export function assertUnreachable(): never {
   throw new Error("Didn't expect to get here");
 }
+
+export const formatBabelError = (error: string) => {
+  return error
+    .replace('1 | /* @babel/template */;', '')
+    .replace(
+      /\((\d+):(\d+)\)/,
+      (_, line, col) => `(${parseInt(line, 10) - 1}:${col})`,
+    )
+    .replace('<>', '')
+    .replace('</>', '')
+    .replace(/(\d+) \|/g, (_, line) => {
+      const lineNum = parseInt(line, 10);
+      const newLineNum = lineNum - 1;
+      const lenDiff = line.length - `${newLineNum}`.length;
+      return `${' '.repeat(lenDiff)}${newLineNum} |`;
+    });
+};

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -337,6 +337,7 @@ export default withRouter(
               set={(value: any, name: string) => {
                 try {
                   trackEvent('yard', `${componentName}:knob_change_${name}`);
+                  !hydrated && setHydrated(true);
                   const newCode = getCode(
                     buildPropsObj(state.props, {[name]: value}),
                     componentName,

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -127,6 +127,7 @@ export default withRouter(
     propsConfig,
     themeConfig,
     scopeConfig,
+    extraImports,
     minHeight,
     placeholderElement,
   }: TYardProps & {
@@ -143,10 +144,15 @@ export default withRouter(
     const [state, dispatch] = React.useReducer(reducer, {
       code:
         router.query.code ||
-        getCode(propsConfig, componentName, {
-          themeValues: {},
-          themeName: theme.name,
-        }),
+        getCode(
+          propsConfig,
+          componentName,
+          {
+            themeValues: {},
+            themeName: theme.name,
+          },
+          extraImports,
+        ),
       codeNoRecompile: '',
       props: propsConfig,
       theme: componentThemeObj,
@@ -200,10 +206,15 @@ export default withRouter(
         key => componentThemeObj[key] === state.theme[key],
       );
       if (!isIdentical) {
-        const newCode = getCode(state.props, componentName, {
-          themeValues: {},
-          themeName: theme.name,
-        });
+        const newCode = getCode(
+          state.props,
+          componentName,
+          {
+            themeValues: {},
+            themeName: theme.name,
+          },
+          extraImports,
+        );
         dispatch({
           type: Action.UpdateThemeAndCode,
           payload: {
@@ -233,6 +244,7 @@ export default withRouter(
           themeValues: {},
           themeName: '',
         },
+        extraImports,
       );
       dispatch({
         type: Action.UpdatePropsAndCodeNoRecompile,
@@ -342,6 +354,7 @@ export default withRouter(
                     buildPropsObj(state.props, {[name]: value}),
                     componentName,
                     componentThemeDiff,
+                    extraImports,
                   );
                   if (error.msg !== null) setError({where: '', msg: null});
                   dispatch({
@@ -388,6 +401,7 @@ export default withRouter(
                     buildPropsObj(state.props, {overrides: value}),
                     componentName,
                     componentThemeDiff,
+                    extraImports,
                   );
                   if (error.msg !== null) {
                     setError({where: '', msg: null});
@@ -451,6 +465,7 @@ export default withRouter(
                   state.props,
                   componentName,
                   componentThemeDiff,
+                  extraImports,
                 );
                 dispatch({
                   type: Action.UpdateThemeAndCode,
@@ -566,10 +581,15 @@ export default withRouter(
               dispatch({
                 type: Action.Reset,
                 payload: {
-                  code: getCode(propsConfig, componentName, {
-                    themeValues: {},
-                    themeName: '',
-                  } as any),
+                  code: getCode(
+                    propsConfig,
+                    componentName,
+                    {
+                      themeValues: {},
+                      themeName: '',
+                    } as any,
+                    extraImports,
+                  ),
                   props: propsConfig,
                   theme: componentThemeObj,
                 },

--- a/documentation-site/pages/components/tabs.mdx
+++ b/documentation-site/pages/components/tabs.mdx
@@ -16,15 +16,19 @@ import TabsVertical from 'examples/tabs/vertical.js';
 import TabsRenderAll from 'examples/tabs/renderall.js';
 import TabsOverrides from 'examples/tabs/overrides.js';
 
-import Overrides from '../../components/overrides';
 import {StatefulTabs, Tab} from 'baseui/tabs';
 import * as TabsExports from 'baseui/tabs';
+
+import Yard from '../../components/yard/index';
+import tabsYardConfig from '../../components/yard/config/tabs';
 
 export default Layout;
 
 # Tabs
 
-The Tabs component is used for navigating frequently accessed, but distinct categories.
+<Yard componentName="Tabs" placeholderHeight={102} {...tabsYardConfig} />
+
+The Tabs component is used for navigating frequently accesssed, but distinct categories.
 
 ## Accessibility
 
@@ -54,42 +58,5 @@ The Tabs component is used for navigating frequently accessed, but distinct cate
 <Example title="Tabs Overrides" path="tabs/overrides.js">
   <TabsOverrides />
 </Example>
-
-## Overrides
-
-<Overrides
-  name="Tabs"
-  component={TabsExports}
-  renderExample={props => (
-    <StatefulTabs initialState={{activeKey: '0'}} overrides={props.overrides}>
-      <Tab overrides={props.overrides} title="Tab Link 1">
-        Tab 1 content
-      </Tab>
-      <Tab overrides={props.overrides} title="Tab Link 2">
-        Tab 2 content
-      </Tab>
-      <Tab overrides={props.overrides} title="Tab Link 3">
-        Tab 3 content
-      </Tab>
-    </StatefulTabs>
-  )}
-/>
-
-## API
-
-<API
-  heading="Tabs API"
-  api={require('!!extract-react-types-loader!../../../src/tabs/tabs.js')}
-/>
-
-<API
-  heading="StatefulTabs API"
-  api={require('!!extract-react-types-loader!../../../src/tabs/stateful-tabs.js')}
-/>
-
-<API
-  heading="Tab API"
-  api={require('!!extract-react-types-loader!../../../src/tabs/tab.js')}
-/>
 
 <Exports component={TabsExports} title="Tabs exports" path="baseui/tabs" />


### PR DESCRIPTION
- **added the Tabs component**
- `PropTypes.ReactNode` is now properly parsed and formatted (works great for nested components). There is no need inventing some complicated cross-reference mechanism at this point. Nested components can be just edited through the code (they usually don't have many options anyway).
- all knob textareas switched to the `Editor` component to get that nice highlighting
- better popup babel parse errors (LoC numbers were off)
- added an API for extra imports and supporting default imports as well

<img width="633" alt="Screen Shot 2019-09-26 at 6 02 35 PM" src="https://user-images.githubusercontent.com/1387913/65734514-1ee4dc80-e088-11e9-8add-7798d17200ce.png">
