### PR TITLE
feat(menu): removes smoothscroll-polyfill

### DIFF
--- a/component-sizes.json
+++ b/component-sizes.json
@@ -294,10 +294,6 @@
         "approximateSize": 243
       },
       {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
         "name": "polished",
         "approximateSize": 28614
       },
@@ -823,10 +819,6 @@
         "approximateSize": 5008
       },
       {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
-      },
-      {
         "name": "popper.js",
         "approximateSize": 16380
       },
@@ -923,10 +915,6 @@
       {
         "name": "polished",
         "approximateSize": 28614
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
       },
       {
         "name": "popper.js",
@@ -1172,10 +1160,6 @@
       {
         "name": "object-assign",
         "approximateSize": 1085
-      },
-      {
-        "name": "smoothscroll-polyfill",
-        "approximateSize": 2903
       },
       {
         "name": "popper.js",

--- a/flow-typed/npm/smoothscroll-polyfill_v0.x.x.js
+++ b/flow-typed/npm/smoothscroll-polyfill_v0.x.x.js
@@ -1,8 +1,0 @@
-// flow-typed signature: f5d1cd32fd86e3c7b132d220e88b3454
-// flow-typed version: 463c76ef0c/smoothscroll-polyfill_v0.x.x/flow_>=v0.47.x
-
-declare module 'smoothscroll-polyfill' {
-  declare module.exports: {
-    polyfill: () => void,
-  };
-}

--- a/package.json
+++ b/package.json
@@ -188,7 +188,6 @@
     "react-virtualized": "^9.21.1",
     "react-virtualized-auto-sizer": "^1.0.2",
     "react-window": "^1.8.5",
-    "smoothscroll-polyfill": "^0.4.3",
     "timezone-support": "^2.0.0"
   },
   "peerDependencies": {

--- a/src/menu/utils.js
+++ b/src/menu/utils.js
@@ -6,11 +6,6 @@ LICENSE file in the root directory of this source tree.
 */
 // @flow
 /* eslint-disable import/prefer-default-export */
-import smoothscroll from 'smoothscroll-polyfill';
-
-if (__BROWSER__) {
-  smoothscroll.polyfill();
-}
 
 // Helps scroll a list item into view when cycling through list via
 // keybindings and highlighted item is not in view.

--- a/yarn.lock
+++ b/yarn.lock
@@ -15709,11 +15709,6 @@ slice-ansi@^2.1.0:
     astral-regex "^1.0.0"
     is-fullwidth-code-point "^2.0.0"
 
-smoothscroll-polyfill@^0.4.3:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/smoothscroll-polyfill/-/smoothscroll-polyfill-0.4.3.tgz#94e5f2d604efcceb53f23ff0380d7ea7280d4bff"
-  integrity sha512-aUg0sY8XlWw9reC3VGlVdmC9W4K565alN4t8Cm50kULz53NB4GvsZbrinWPLqYqLolY60NBdqHDyh89MqDUc/Q==
-
 snake-case@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"


### PR DESCRIPTION
#### Description

Removes the smoothscroll-polyfill. It was never needed it in the first place because we did not specify the `Node.scrollIntoView` 'smooth' [behavior](https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView).

#### Scope

- [x] Patch: Bug Fix