### PR TITLE
feat(yard): cleaning up the code, config shape changes, better types

### DIFF
--- a/documentation-site/components/yard/__tests__/ast.test.ts
+++ b/documentation-site/components/yard/__tests__/ast.test.ts
@@ -38,11 +38,9 @@ describe('transformBeforeCompilation', () => {
             value: '',
             type: PropTypes.Function,
             description: '',
-            meta: {
-              propHook: {
-                what: 'e.target.value',
-                into: 'value',
-              },
+            propHook: {
+              what: 'e.target.value',
+              into: 'value',
             },
           },
         }),
@@ -64,11 +62,9 @@ describe('transformBeforeCompilation', () => {
             value: '',
             type: PropTypes.Function,
             description: '',
-            meta: {
-              propHook: {
-                what: 'e.target.value',
-                into: 'value',
-              },
+            propHook: {
+              what: 'e.target.value',
+              into: 'value',
             },
           },
         }),

--- a/documentation-site/components/yard/__tests__/code-generator.test.ts
+++ b/documentation-site/components/yard/__tests__/code-generator.test.ts
@@ -269,9 +269,7 @@ describe('getAstReactHooks', () => {
               value: 'Hey',
               type: PropTypes.String,
               description: '',
-              meta: {
-                stateful: true,
-              },
+              stateful: true,
             },
             foo: {
               value: 'Not stateful',
@@ -362,13 +360,13 @@ describe('getCode', () => {
             value: 'Hello',
             type: PropTypes.String,
             description: 'Input value attribute.',
-            meta: {stateful: true},
+            stateful: true,
           },
           onChange: {
             value: 'e => setValue(e.target.value)',
             type: PropTypes.Function,
             description: '',
-            meta: {propHook: {what: 'e.target.value', into: 'value'}},
+            propHook: {what: 'e.target.value', into: 'value'},
           },
           overrides: {
             value: {
@@ -380,9 +378,7 @@ describe('getCode', () => {
             },
             type: PropTypes.Overrides,
             description: '',
-            meta: {
-              names: ['Root'],
-            },
+            names: ['Root'],
           },
         },
         'Input',

--- a/documentation-site/components/yard/actions.ts
+++ b/documentation-site/components/yard/actions.ts
@@ -1,7 +1,7 @@
 import Router from 'next/router';
 import {parseCode, parseOverrides} from './ast';
 import {Action} from './const';
-import {TProp, TDispatch} from './types';
+import {TProp, TDispatch, TPropValue} from './types';
 
 export const updateCode = (dispatch: TDispatch, newCode: string) => {
   dispatch({
@@ -16,7 +16,7 @@ export const updateAll = (
   componentName: string,
   propsConfig: {[key: string]: TProp},
 ) => {
-  const propValues: any = {};
+  const propValues: {[key: string]: TPropValue} = {};
   const {parsedProps, parsedTheme} = parseCode(newCode, componentName);
   Object.keys(propsConfig).forEach(name => {
     propValues[name] = propsConfig[name].value;
@@ -25,9 +25,7 @@ export const updateAll = (
       // be further analyzed and parsed
       propValues[name] = parseOverrides(
         parsedProps[name],
-        propsConfig.overrides && propsConfig.overrides.meta
-          ? propsConfig.overrides.meta.names || []
-          : [],
+        propsConfig.overrides ? propsConfig.overrides.names || [] : [],
       );
     } else {
       propValues[name] = parsedProps[name];
@@ -60,7 +58,7 @@ export const updatePropsAndCodeNoRecompile = (
   dispatch: TDispatch,
   newCode: string,
   propName: string,
-  propValue: any,
+  propValue: TPropValue,
 ) => {
   dispatch({
     type: Action.UpdatePropsAndCodeNoRecompile,
@@ -75,7 +73,7 @@ export const updatePropsAndCode = (
   dispatch: TDispatch,
   newCode: string,
   propName: string,
-  propValue: any,
+  propValue: TPropValue,
 ) => {
   dispatch({
     type: Action.UpdatePropsAndCode,
@@ -89,7 +87,7 @@ export const updatePropsAndCode = (
 export const updateProps = (
   dispatch: TDispatch,
   propName: string,
-  propValue: any,
+  propValue: TPropValue,
 ) => {
   dispatch({
     type: Action.UpdateProps,

--- a/documentation-site/components/yard/actions.ts
+++ b/documentation-site/components/yard/actions.ts
@@ -1,0 +1,128 @@
+import Router from 'next/router';
+import {parseCode, parseOverrides} from './ast';
+import {Action} from './const';
+import {TProp, TDispatch} from './types';
+
+export const updateCode = (dispatch: TDispatch, newCode: string) => {
+  dispatch({
+    type: Action.UpdateCode,
+    payload: newCode,
+  });
+};
+
+export const updateAll = (
+  dispatch: TDispatch,
+  newCode: string,
+  componentName: string,
+  propsConfig: {[key: string]: TProp},
+) => {
+  const propValues: any = {};
+  const {parsedProps, parsedTheme} = parseCode(newCode, componentName);
+  Object.keys(propsConfig).forEach(name => {
+    propValues[name] = propsConfig[name].value;
+    if (name === 'overrides') {
+      // overrides need a special treatment since the value needs to
+      // be further analyzed and parsed
+      propValues[name] = parseOverrides(
+        parsedProps[name],
+        propsConfig.overrides && propsConfig.overrides.meta
+          ? propsConfig.overrides.meta.names || []
+          : [],
+      );
+    } else {
+      propValues[name] = parsedProps[name];
+    }
+  });
+  dispatch({
+    type: Action.Update,
+    payload: {
+      code: newCode,
+      updatedPropValues: propValues,
+      theme: parsedTheme,
+    },
+  });
+};
+
+export const updateUrl = (pathname: string, code?: string) => {
+  Router.push(
+    code
+      ? {
+          pathname: pathname,
+          query: {code},
+        }
+      : {
+          pathname: pathname,
+        },
+  );
+};
+
+export const updatePropsAndCodeNoRecompile = (
+  dispatch: TDispatch,
+  newCode: string,
+  propName: string,
+  propValue: any,
+) => {
+  dispatch({
+    type: Action.UpdatePropsAndCodeNoRecompile,
+    payload: {
+      codeNoRecompile: newCode,
+      updatedPropValues: {[propName]: propValue},
+    },
+  });
+};
+
+export const updatePropsAndCode = (
+  dispatch: TDispatch,
+  newCode: string,
+  propName: string,
+  propValue: any,
+) => {
+  dispatch({
+    type: Action.UpdatePropsAndCode,
+    payload: {
+      code: newCode,
+      updatedPropValues: {[propName]: propValue},
+    },
+  });
+};
+
+export const updateProps = (
+  dispatch: TDispatch,
+  propName: string,
+  propValue: any,
+) => {
+  dispatch({
+    type: Action.UpdateProps,
+    payload: {[propName]: propValue},
+  });
+};
+
+export const updateThemeAndCode = (
+  dispatch: TDispatch,
+  newCode: string,
+  updatedThemeValues: {[key: string]: string},
+) => {
+  dispatch({
+    type: Action.UpdateThemeAndCode,
+    payload: {
+      code: newCode,
+      theme: updatedThemeValues,
+    },
+  });
+};
+
+export const reset = (
+  dispatch: TDispatch,
+  initialCode: string,
+  propsConfig: {[key: string]: string},
+  initialThemeObj: {[key: string]: string},
+) => {
+  dispatch({
+    type: Action.Reset,
+    payload: {
+      code: initialCode,
+      props: propsConfig,
+      theme: initialThemeObj,
+    },
+  });
+};

--- a/documentation-site/components/yard/actions.ts
+++ b/documentation-site/components/yard/actions.ts
@@ -114,7 +114,7 @@ export const updateThemeAndCode = (
 export const reset = (
   dispatch: TDispatch,
   initialCode: string,
-  propsConfig: {[key: string]: string},
+  propsConfig: {[key: string]: TProp},
   initialThemeObj: {[key: string]: string},
 ) => {
   dispatch({

--- a/documentation-site/components/yard/ast.ts
+++ b/documentation-site/components/yard/ast.ts
@@ -91,9 +91,7 @@ export const transformBeforeCompilation = (
         }
       },
     });
-  } catch (e) {
-    console.warn(e);
-  }
+  } catch (e) {}
   return ast;
 };
 
@@ -269,7 +267,6 @@ export function parseCode(code: string, elementName: string) {
       },
     });
   } catch (e) {
-    console.warn(e);
     throw new Error("Code is not valid and can't be parsed.");
   }
 

--- a/documentation-site/components/yard/ast.ts
+++ b/documentation-site/components/yard/ast.ts
@@ -2,7 +2,7 @@ import traverse from '@babel/traverse';
 import generate from '@babel/generator';
 import {formatCode} from './code-generator';
 import * as t from 'babel-types';
-import {TProp, TPropHook} from './types';
+import {TProp} from './types';
 import {PropTypes} from './const';
 import {parse as babelParse} from '@babel/parser';
 import {getAstJsxElement, formatAstAndPrint} from './code-generator';
@@ -54,9 +54,7 @@ export const transformBeforeCompilation = (
             .forEach(attr => {
               const name = (attr.get('name') as any).node.name;
               if (propsConfig[name].type === PropTypes.Function) {
-                const propHook: TPropHook = propsConfig[name].meta
-                  ? (propsConfig[name].meta as any).propHook
-                  : null;
+                const propHook = propsConfig[name].propHook;
                 if (propHook) {
                   const yardOnChageCallExpression = t.callExpression(
                     t.identifier('__yard_onChange'),

--- a/documentation-site/components/yard/ast.ts
+++ b/documentation-site/components/yard/ast.ts
@@ -94,7 +94,7 @@ export const transformBeforeCompilation = (
       },
     });
   } catch (e) {
-    console.log(e);
+    console.warn(e);
   }
   return ast;
 };
@@ -271,7 +271,7 @@ export function parseCode(code: string, elementName: string) {
       },
     });
   } catch (e) {
-    console.log(e);
+    console.warn(e);
     throw new Error("Code is not valid and can't be parsed.");
   }
 

--- a/documentation-site/components/yard/code-generator.ts
+++ b/documentation-site/components/yard/code-generator.ts
@@ -1,4 +1,4 @@
-import {TProp, TExtraImports} from './types';
+import {TProp, TImportsConfig} from './types';
 import {PropTypes} from './const';
 import {parse} from './ast';
 import template from '@babel/template';
@@ -204,24 +204,24 @@ const nameToImportSource = (name: string) =>
 export const getAstImports = (
   componentName: string,
   enums: string[],
-  extraImports?: TExtraImports,
+  importsConfig?: TImportsConfig,
 ) => {
   const defaultFrom = nameToImportSource(componentName);
   const importList = {
-    ...(extraImports ? extraImports : {}),
+    ...(importsConfig ? importsConfig : {}),
     [defaultFrom]: {
       named: [
         componentName,
-        ...(extraImports &&
-        extraImports[defaultFrom] &&
-        extraImports[defaultFrom].named
-          ? (extraImports[defaultFrom].named as string[])
+        ...(importsConfig &&
+        importsConfig[defaultFrom] &&
+        importsConfig[defaultFrom].named
+          ? (importsConfig[defaultFrom].named as string[])
           : []),
         ...enums,
       ],
       default:
-        extraImports && extraImports[defaultFrom]
-          ? extraImports[defaultFrom].default
+        importsConfig && importsConfig[defaultFrom]
+          ? importsConfig[defaultFrom].default
           : undefined,
     },
   };
@@ -234,7 +234,7 @@ export const getAst = (
   props: {[key: string]: TProp},
   componentName: string,
   theme: any,
-  extraImports?: TExtraImports,
+  importsConfig?: TImportsConfig,
 ) => {
   const {children, ...restProps} = props;
   const isCustomTheme =
@@ -251,7 +251,7 @@ export const getAst = (
       ...getAstImports(
         componentName,
         getEnumsToImport(restProps),
-        extraImports,
+        importsConfig,
       ),
       ...getAstThemeImport(isCustomTheme, themePrimitives),
       buildExport({
@@ -302,8 +302,8 @@ export const getCode = (
   props: {[key: string]: TProp},
   componentName: string,
   theme: {themeValues: {[key: string]: string}; themeName: string},
-  extraImports?: TExtraImports,
+  importsConfig?: TImportsConfig,
 ) => {
-  const ast = getAst(props, componentName, theme, extraImports);
+  const ast = getAst(props, componentName, theme, importsConfig);
   return formatAstAndPrint(ast as any);
 };

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -1,8 +1,9 @@
 import {ButtonGroup, MODE} from 'baseui/button-group';
 import {Button} from 'baseui/button';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
 
-export default {
+const ButtonGroupConfig: TConfig = {
   importsConfig: {
     'baseui/button': {
       named: ['Button'],
@@ -46,20 +47,16 @@ export default {
       value: '(event, index) => {\n  setSelected([index]);\n}',
       type: PropTypes.Function,
       description: `Function called when any button is clicked.`,
-      meta: {
-        propHook: {
-          what: '`[${index}]`',
-          into: 'selected',
-        },
+      propHook: {
+        what: '`[${index}]`',
+        into: 'selected',
       },
     },
     selected: {
       value: '[0]',
       type: PropTypes.Array,
       description: 'Defines which buttons are selected',
-      meta: {
-        stateful: true,
-      },
+      stateful: true,
     },
     disabled: {
       value: false,
@@ -70,10 +67,10 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: ['Root'],
-        sharedProps: {},
-      },
+      names: ['Root'],
+      sharedProps: {},
     },
   },
 };
+
+export default ButtonGroupConfig;

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -3,7 +3,7 @@ import {Button} from 'baseui/button';
 import {PropTypes} from '../const';
 
 export default {
-  extraImports: {
+  importsConfig: {
     'baseui/button': {
       named: ['Button'],
     },

--- a/documentation-site/components/yard/config/button-group.ts
+++ b/documentation-site/components/yard/config/button-group.ts
@@ -4,17 +4,17 @@ import {PropTypes} from '../const';
 import {TConfig} from '../types';
 
 const ButtonGroupConfig: TConfig = {
-  importsConfig: {
+  imports: {
     'baseui/button': {
       named: ['Button'],
     },
   },
-  scopeConfig: {
+  scope: {
     Button,
     ButtonGroup,
     MODE,
   },
-  themeConfig: [
+  theme: [
     'buttonPrimaryFill',
     'buttonPrimaryText',
     'buttonPrimaryHover',
@@ -36,7 +36,7 @@ const ButtonGroupConfig: TConfig = {
     'buttonDisabledFill',
     'buttonDisabledText',
   ],
-  propsConfig: {
+  props: {
     children: {
       value:
         '<Button>One</Button>\n<Button>Two</Button>\n<Button>Three</Button>',

--- a/documentation-site/components/yard/config/button.ts
+++ b/documentation-site/components/yard/config/button.ts
@@ -3,13 +3,13 @@ import {PropTypes} from '../const';
 import {TConfig} from '../types';
 
 const ButtonConfig: TConfig = {
-  scopeConfig: {
+  scope: {
     Button,
     KIND,
     SIZE,
     SHAPE,
   },
-  themeConfig: [
+  theme: [
     'buttonPrimaryFill',
     'buttonPrimaryText',
     'buttonPrimaryHover',
@@ -31,7 +31,7 @@ const ButtonConfig: TConfig = {
     'buttonDisabledFill',
     'buttonDisabledText',
   ],
-  propsConfig: {
+  props: {
     children: {
       value: 'Hello',
       type: PropTypes.ReactNode,

--- a/documentation-site/components/yard/config/button.ts
+++ b/documentation-site/components/yard/config/button.ts
@@ -1,7 +1,8 @@
 import {Button, KIND, SIZE, SHAPE} from 'baseui/button';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
 
-export default {
+const ButtonConfig: TConfig = {
   scopeConfig: {
     Button,
     KIND,
@@ -90,23 +91,23 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: [
-          'BaseButton',
-          'EndEnhancer',
-          'LoadingSpinner',
-          'LoadingSpinnerContainer',
-          'StartEnhancer',
-        ],
-        sharedProps: {
-          $kind: 'kind',
-          $isSelected: 'isSelected',
-          $shape: 'shape',
-          $size: 'size',
-          $isLoading: 'isLoading',
-          $disabled: 'disabled',
-        },
+      names: [
+        'BaseButton',
+        'EndEnhancer',
+        'LoadingSpinner',
+        'LoadingSpinnerContainer',
+        'StartEnhancer',
+      ],
+      sharedProps: {
+        $kind: 'kind',
+        $isSelected: 'isSelected',
+        $shape: 'shape',
+        $size: 'size',
+        $isLoading: 'isLoading',
+        $disabled: 'disabled',
       },
     },
   },
 };
+
+export default ButtonConfig;

--- a/documentation-site/components/yard/config/checkbox.ts
+++ b/documentation-site/components/yard/config/checkbox.ts
@@ -1,7 +1,8 @@
 import {Checkbox, STYLE_TYPE, LABEL_PLACEMENT} from 'baseui/checkbox';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
 
-export default {
+const CheckboxConfig: TConfig = {
   scopeConfig: {
     Checkbox,
     STYLE_TYPE,
@@ -32,9 +33,7 @@ export default {
       value: false,
       type: PropTypes.Boolean,
       description: 'Renders component in checked state.',
-      meta: {
-        stateful: true,
-      },
+      stateful: true,
     },
     children: {
       value: `Sign up for the newsletter`,
@@ -57,11 +56,9 @@ export default {
       value: 'e => setChecked(e.target.checked)',
       type: PropTypes.Function,
       description: 'Called when checkbox value is changed.',
-      meta: {
-        propHook: {
-          what: 'e.target.checked',
-          into: 'checked',
-        },
+      propHook: {
+        what: 'e.target.checked',
+        into: 'checked',
       },
     },
     isError: {
@@ -83,9 +80,6 @@ export default {
       description:
         'Determines how to position the label relative to the checkbox.',
     },
-    //////////////////
-    // Hidden props //
-    //////////////////
     required: {
       value: false,
       type: PropTypes.Boolean,
@@ -144,37 +138,37 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: [
-          'Root',
-          'Checkmark',
-          'Label',
-          'Toggle',
-          'ToggleInner',
-          'ToggleTrack',
-        ],
-        sharedProps: {
-          $isFocused: {
-            type: PropTypes.Boolean,
-            description: 'True when the component is focused.',
-          },
-          $isHovered: {
-            type: PropTypes.Boolean,
-            description: 'True when the component is hovered.',
-          },
-          $isActive: {
-            type: PropTypes.Boolean,
-            description: 'True when the component is active.',
-          },
-          $isError: 'isError',
-          $checked: 'checked',
-          $isIndeterminate: 'isIndeterminate',
-          $required: 'required',
-          $disabled: 'disabled',
-          $checkmarkType: 'checkmarkType',
-          $labelPlacement: 'labelPlacement',
+      names: [
+        'Root',
+        'Checkmark',
+        'Label',
+        'Toggle',
+        'ToggleInner',
+        'ToggleTrack',
+      ],
+      sharedProps: {
+        $isFocused: {
+          type: PropTypes.Boolean,
+          description: 'True when the component is focused.',
         },
+        $isHovered: {
+          type: PropTypes.Boolean,
+          description: 'True when the component is hovered.',
+        },
+        $isActive: {
+          type: PropTypes.Boolean,
+          description: 'True when the component is active.',
+        },
+        $isError: 'isError',
+        $checked: 'checked',
+        $isIndeterminate: 'isIndeterminate',
+        $required: 'required',
+        $disabled: 'disabled',
+        $checkmarkType: 'checkmarkType',
+        $labelPlacement: 'labelPlacement',
       },
     },
   },
 };
+
+export default CheckboxConfig;

--- a/documentation-site/components/yard/config/checkbox.ts
+++ b/documentation-site/components/yard/config/checkbox.ts
@@ -3,12 +3,12 @@ import {PropTypes} from '../const';
 import {TConfig} from '../types';
 
 const CheckboxConfig: TConfig = {
-  scopeConfig: {
+  scope: {
     Checkbox,
     STYLE_TYPE,
     LABEL_PLACEMENT,
   },
-  themeConfig: [
+  theme: [
     'tickFill',
     'tickFillHover',
     'tickFillActive',
@@ -28,7 +28,7 @@ const CheckboxConfig: TConfig = {
     'tickMarkFillError',
     'tickMarkFillDisabled',
   ],
-  propsConfig: {
+  props: {
     checked: {
       value: false,
       type: PropTypes.Boolean,

--- a/documentation-site/components/yard/config/input.ts
+++ b/documentation-site/components/yard/config/input.ts
@@ -2,7 +2,7 @@ import {Input, ADJOINED, SIZE} from 'baseui/input';
 import {PropTypes} from '../const';
 import {TConfig} from '../types';
 
-export const themeConfig = [
+export const theme = [
   'inputFill',
   'inputFillError',
   'inputFillDisabled',
@@ -193,13 +193,13 @@ export const inputProps = {
 };
 
 const InputConfig: TConfig = {
-  scopeConfig: {
+  scope: {
     Input,
     SIZE,
     ADJOINED,
   },
-  themeConfig,
-  propsConfig: {
+  theme,
+  props: {
     ...inputProps,
     overrides: {
       value: undefined,

--- a/documentation-site/components/yard/config/input.ts
+++ b/documentation-site/components/yard/config/input.ts
@@ -1,5 +1,6 @@
 import {Input, ADJOINED, SIZE} from 'baseui/input';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
 
 export const themeConfig = [
   'inputFill',
@@ -20,19 +21,16 @@ export const inputProps = {
     value: 'Hello',
     type: PropTypes.String,
     description: 'Input value attribute.',
-    meta: {
-      stateful: true,
-    },
+    stateful: true,
   },
   onChange: {
     value: 'e => setValue(e.target.value)',
     type: PropTypes.Function,
     description: 'Called when input value is changed.',
-    meta: {
-      propHook: {
-        what: 'e.target.value',
-        into: 'value',
-      },
+
+    propHook: {
+      what: 'e.target.value',
+      into: 'value',
     },
   },
   disabled: {
@@ -162,7 +160,6 @@ export const inputProps = {
     description: 'Called when input loses focus.',
     hidden: true,
   },
-
   onKeyDown: {
     value: undefined,
     type: PropTypes.Function,
@@ -196,7 +193,7 @@ export const inputProps = {
   },
 };
 
-export default {
+const InputConfig: TConfig = {
   scopeConfig: {
     Input,
     SIZE,
@@ -209,39 +206,39 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: [
-          'Root',
-          'Input',
-          'InputContainer',
-          'After',
-          'Before',
-          'ClearIcon',
-          'ClearIconContainer',
-          'EndEnhancer',
-          'MaskToggleButton',
-          'MaskToggleHideIcon',
-          'MaskToggleShowIcon',
-          'StartEnhancer',
-        ],
-        sharedProps: {
-          $isFocused: {
-            type: PropTypes.Boolean,
-            description: 'True when the component is focused.',
-          },
-          $disabled: 'disabled',
-          $error: 'error',
-          $positive: 'positive',
-          $adjoined: 'adjoined',
-          $size: 'size',
-          $required: 'required',
-          $position: {
-            type: PropTypes.Enum,
-            description:
-              'ADJOINED state. How is the input grouped with other controls.',
-          },
+      names: [
+        'Root',
+        'Input',
+        'InputContainer',
+        'After',
+        'Before',
+        'ClearIcon',
+        'ClearIconContainer',
+        'EndEnhancer',
+        'MaskToggleButton',
+        'MaskToggleHideIcon',
+        'MaskToggleShowIcon',
+        'StartEnhancer',
+      ],
+      sharedProps: {
+        $isFocused: {
+          type: PropTypes.Boolean,
+          description: 'True when the component is focused.',
+        },
+        $disabled: 'disabled',
+        $error: 'error',
+        $positive: 'positive',
+        $adjoined: 'adjoined',
+        $size: 'size',
+        $required: 'required',
+        $position: {
+          type: PropTypes.Enum,
+          description:
+            'ADJOINED state. How is the input grouped with other controls.',
         },
       },
     },
   },
 };
+
+export default InputConfig;

--- a/documentation-site/components/yard/config/input.ts
+++ b/documentation-site/components/yard/config/input.ts
@@ -27,7 +27,6 @@ export const inputProps = {
     value: 'e => setValue(e.target.value)',
     type: PropTypes.Function,
     description: 'Called when input value is changed.',
-
     propHook: {
       what: 'e.target.value',
       into: 'value',

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -3,16 +3,16 @@ import {PropTypes} from '../const';
 import {TConfig} from '../types';
 
 const TabsConfig: TConfig = {
-  importsConfig: {
+  imports: {
     'baseui/tabs': {named: ['Tab']},
   },
-  scopeConfig: {
+  scope: {
     Tabs,
     Tab,
     ORIENTATION,
   },
-  themeConfig: ['tabBarFill', 'tabColor'],
-  propsConfig: {
+  theme: ['tabBarFill', 'tabColor'],
+  props: {
     children: {
       value: `<Tab title="Tab Link 1">
   Content 1

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -2,7 +2,7 @@ import {Tabs, Tab, ORIENTATION} from 'baseui/tabs';
 import {PropTypes} from '../const';
 
 export default {
-  extraImports: {
+  importsConfig: {
     'baseui/tabs': {named: ['Tab']},
   },
   scopeConfig: {

--- a/documentation-site/components/yard/config/tabs.ts
+++ b/documentation-site/components/yard/config/tabs.ts
@@ -1,7 +1,8 @@
 import {Tabs, Tab, ORIENTATION} from 'baseui/tabs';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
 
-export default {
+const TabsConfig: TConfig = {
   importsConfig: {
     'baseui/tabs': {named: ['Tab']},
   },
@@ -29,11 +30,9 @@ export default {
       value: '({ activeKey }) => {\n  setActiveKey(activeKey);\n}',
       type: PropTypes.Function,
       description: `Change handler that is called every time a new tab is selected.`,
-      meta: {
-        propHook: {
-          what: 'activeKey',
-          into: 'activeKey',
-        },
+      propHook: {
+        what: 'activeKey',
+        into: 'activeKey',
       },
     },
     orientation: {
@@ -46,9 +45,7 @@ export default {
       value: '0',
       type: PropTypes.String,
       description: 'Key of the the tab to be selected.',
-      meta: {
-        stateful: true,
-      },
+      stateful: true,
     },
     disabled: {
       value: false,
@@ -65,17 +62,17 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: ['Root', 'Tab', 'TabBar', 'TabContent'],
-        sharedProps: {
-          $disabled: 'disabled',
-          $active: {
-            type: PropTypes.Boolean,
-            description: 'True when the tab is active.',
-          },
-          $orientation: 'orientation',
+      names: ['Root', 'Tab', 'TabBar', 'TabContent'],
+      sharedProps: {
+        $disabled: 'disabled',
+        $active: {
+          type: PropTypes.Boolean,
+          description: 'True when the tab is active.',
         },
+        $orientation: 'orientation',
       },
     },
   },
 };
+
+export default TabsConfig;

--- a/documentation-site/components/yard/config/textarea.ts
+++ b/documentation-site/components/yard/config/textarea.ts
@@ -4,16 +4,16 @@ import omit from 'just-omit';
 import {Textarea, SIZE, ADJOINED} from 'baseui/textarea';
 import {PropTypes} from '../const';
 import {TConfig} from '../types';
-import {themeConfig, inputProps} from './input';
+import {theme, inputProps} from './input';
 
 const TextareaConfig: TConfig = {
-  scopeConfig: {
+  scope: {
     Textarea,
     SIZE,
     ADJOINED,
   },
-  themeConfig,
-  propsConfig: {
+  theme,
+  props: {
     ...omit(inputProps, ['type', 'startEnhancer', 'endEnhancer']),
     overrides: {
       value: undefined,

--- a/documentation-site/components/yard/config/textarea.ts
+++ b/documentation-site/components/yard/config/textarea.ts
@@ -3,11 +3,10 @@ import omit from 'just-omit';
 
 import {Textarea, SIZE, ADJOINED} from 'baseui/textarea';
 import {PropTypes} from '../const';
+import {TConfig} from '../types';
+import {themeConfig, inputProps} from './input';
 
-import {themeConfig} from './input';
-import {inputProps} from './input';
-
-export default {
+const TextareaConfig: TConfig = {
   scopeConfig: {
     Textarea,
     SIZE,
@@ -20,21 +19,21 @@ export default {
       value: undefined,
       type: PropTypes.Overrides,
       description: 'Lets you customize all aspects of the component.',
-      meta: {
-        names: ['Input', 'InputContainer'],
-        sharedProps: {
-          $isFocused: {
-            type: PropTypes.Boolean,
-            description: 'True when the component is focused.',
-          },
-          $disabled: 'disabled',
-          $error: 'error',
-          $positive: 'positive',
-          $adjoined: 'adjoined',
-          $size: 'size',
-          $required: 'required',
+      names: ['Input', 'InputContainer'],
+      sharedProps: {
+        $isFocused: {
+          type: PropTypes.Boolean,
+          description: 'True when the component is focused.',
         },
+        $disabled: 'disabled',
+        $error: 'error',
+        $positive: 'positive',
+        $adjoined: 'adjoined',
+        $size: 'size',
+        $required: 'required',
       },
     },
   },
 };
+
+export default TextareaConfig;

--- a/documentation-site/components/yard/editor.tsx
+++ b/documentation-site/components/yard/editor.tsx
@@ -5,7 +5,7 @@ import lightTheme from './light-theme';
 import darkTheme from './dark-theme';
 import {useStyletron} from 'baseui';
 
-const highlightCode = (code: string, theme: any) => (
+const highlightCode = (code: string, theme: typeof lightTheme) => (
   <Highlight Prism={Prism} code={code} theme={theme} language="jsx">
     {({tokens, getLineProps, getTokenProps}) => (
       <React.Fragment>

--- a/documentation-site/components/yard/index.tsx
+++ b/documentation-site/components/yard/index.tsx
@@ -3,16 +3,12 @@ import {Card} from 'baseui/card';
 import {Spinner} from 'baseui/spinner';
 import {TYardProps} from './types';
 import Yard from './yard';
+import {withRouter} from 'next/router';
 import {useStyletron} from 'baseui';
 
-const YardWrapper: React.FC<TYardProps & {placeholderHeight: number}> = ({
-  componentName,
-  scopeConfig,
-  propsConfig,
-  themeConfig,
-  placeholderHeight,
-  extraImports,
-}) => {
+const YardWrapper: React.FC<
+  TYardProps & {placeholderHeight: number; router: any}
+> = ({router, placeholderHeight, ...restProps}) => {
   const [useCss] = useStyletron();
   const placeholderCx = useCss({
     height: `${placeholderHeight}px`,
@@ -21,23 +17,22 @@ const YardWrapper: React.FC<TYardProps & {placeholderHeight: number}> = ({
     justifyContent: 'center',
     alignItems: 'center',
   });
+
   return (
     <Card>
       <Yard
-        componentName={componentName}
-        scopeConfig={scopeConfig}
-        propsConfig={propsConfig}
-        themeConfig={themeConfig}
-        extraImports={extraImports}
         minHeight={placeholderHeight}
+        pathname={router.pathname}
+        urlCode={router.query.code}
         placeholderElement={() => (
           <div className={placeholderCx}>
             <Spinner size={placeholderHeight > 50 ? 50 : placeholderHeight} />
           </div>
         )}
+        {...restProps}
       />
     </Card>
   );
 };
 
-export default YardWrapper;
+export default withRouter(YardWrapper);

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -107,7 +107,7 @@ const Knob: React.SFC<{
               },
             }}
             size="compact"
-            value={String(val)}
+            value={val ? String(val) : undefined}
           />
           <PopupError error={error} />
         </Spacing>
@@ -178,7 +178,7 @@ const Knob: React.SFC<{
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
           <Editor
             onChange={code => set(code)}
-            code={String(val)}
+            code={val ? String(val) : ''}
             placeholder={placeholder}
             small
           />

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -9,6 +9,7 @@ import {Checkbox} from 'baseui/checkbox';
 import {StatefulTooltip} from 'baseui/tooltip';
 import PopupError from './popup-error';
 import Editor from './editor';
+import {TPropValue} from './types';
 
 const getTooltip = (description: string, type: string, name: string) => (
   <span>
@@ -36,7 +37,7 @@ const Label: React.FC<{
   return (
     <label
       className={useCss({
-        ...(theme.typography.font250 as any),
+        ...theme.typography.font250,
         color: theme.colors.foreground,
       })}
     >
@@ -51,10 +52,10 @@ const Knob: React.SFC<{
   name: string;
   error: string | null;
   description: string;
-  val: any;
-  set: (val: any) => void;
+  val: TPropValue;
+  set: (val: TPropValue) => void;
   type: PropTypes;
-  options?: any;
+  options?: {[key: string]: string};
   placeholder?: string;
   enumName?: string;
 }> = ({
@@ -106,7 +107,7 @@ const Knob: React.SFC<{
               },
             }}
             size="compact"
-            value={val}
+            value={String(val)}
           />
           <PopupError error={error} />
         </Spacing>
@@ -114,7 +115,7 @@ const Knob: React.SFC<{
     case PropTypes.Boolean:
       return (
         <Spacing>
-          <Checkbox checked={val} onChange={() => set(!val)}>
+          <Checkbox checked={Boolean(val)} onChange={() => set(!val)}>
             <StatefulTooltip
               accessibilityType="tooltip"
               content={getTooltip(description, type, name)}
@@ -144,9 +145,9 @@ const Knob: React.SFC<{
             }}
             //@ts-ignore
             onChange={e => set(e.target.value)}
-            value={val}
+            value={String(val)}
           >
-            {Object.keys(options).map(opt => (
+            {Object.keys(options ? options : {}).map(opt => (
               <Radio
                 key={opt}
                 value={`${enumName || name.toUpperCase()}.${opt}`}
@@ -177,7 +178,7 @@ const Knob: React.SFC<{
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
           <Editor
             onChange={code => set(code)}
-            code={val}
+            code={String(val)}
             placeholder={placeholder}
             small
           />

--- a/documentation-site/components/yard/knobs.tsx
+++ b/documentation-site/components/yard/knobs.tsx
@@ -1,9 +1,21 @@
 import * as React from 'react';
 import {useStyletron} from 'baseui';
 import {Button, KIND, SIZE} from 'baseui/button';
+import {TPropValue, TProp, TError} from './types';
 import Knob from './knob';
 
-const KnobColumn = ({knobProps, knobNames, error, set}: any) => {
+type TKnobsProps = {
+  knobProps: {[key: string]: TProp};
+  set: (propValue: TPropValue, propName: string) => void;
+  error: TError;
+};
+
+const KnobColumn: React.FC<TKnobsProps & {knobNames: string[]}> = ({
+  knobProps,
+  knobNames,
+  error,
+  set,
+}) => {
   const [useCss, theme] = useStyletron();
   return (
     <div
@@ -22,7 +34,7 @@ const KnobColumn = ({knobProps, knobNames, error, set}: any) => {
           val={knobProps[name].value}
           options={knobProps[name].options}
           placeholder={knobProps[name].placeholder}
-          set={(value: any) => set(value, name)}
+          set={(value: TPropValue) => set(value, name)}
           enumName={knobProps[name].enumName}
         />
       ))}
@@ -30,7 +42,7 @@ const KnobColumn = ({knobProps, knobNames, error, set}: any) => {
   );
 };
 
-const Knobs = ({knobProps, set, error}: any) => {
+const Knobs: React.FC<TKnobsProps> = ({knobProps, set, error}) => {
   const [useCss, theme] = useStyletron();
   const [showAllKnobs, setShowAllKnobs] = React.useState(false);
   const allKnobNames = Object.keys(knobProps);

--- a/documentation-site/components/yard/override.tsx
+++ b/documentation-site/components/yard/override.tsx
@@ -39,14 +39,13 @@ const SharedPropsTooltip: React.FC<{
   componentConfig: any;
   children: React.ReactNode;
 }> = ({componentConfig, children}) => {
-  const sharedProps = Object.keys(componentConfig.overrides.meta.sharedProps);
+  const sharedProps = Object.keys(componentConfig.overrides.sharedProps);
   const getDescription = (name: string) => {
     let metaObj: any = {};
-    if (typeof componentConfig.overrides.meta.sharedProps[name] === 'string') {
-      metaObj =
-        componentConfig[componentConfig.overrides.meta.sharedProps[name]];
+    if (typeof componentConfig.overrides.sharedProps[name] === 'string') {
+      metaObj = componentConfig[componentConfig.overrides.sharedProps[name]];
     } else {
-      metaObj = componentConfig.overrides.meta.sharedProps[name];
+      metaObj = componentConfig.overrides.sharedProps[name];
     }
     return (
       <React.Fragment>
@@ -135,7 +134,7 @@ const Override: React.FC<TProps> = ({
             const newCode = formatCode(
               toggleOverrideSharedProps(
                 overrides.value[overrideKey].style,
-                Object.keys(overrides.meta.sharedProps),
+                Object.keys(overrides.sharedProps),
               ),
             );
             set({

--- a/documentation-site/components/yard/overrides.tsx
+++ b/documentation-site/components/yard/overrides.tsx
@@ -23,11 +23,7 @@ const Overrides: React.FC<TOverridesProps> = ({
 }) => {
   const [, theme] = useStyletron();
   const isLightTheme = theme.name.startsWith('light-theme');
-  if (
-    !overrides.meta ||
-    !overrides.meta.names ||
-    overrides.meta.names.length === 0
-  ) {
+  if (!overrides.names || overrides.names.length === 0) {
     return null;
   }
 
@@ -37,7 +33,7 @@ const Overrides: React.FC<TOverridesProps> = ({
     };
   } = {};
 
-  overrides.meta.names.forEach((key: string) => {
+  overrides.names.forEach((key: string) => {
     if (overrides.value && overrides.value[key]) {
       overridesObj[key] = overrides.value[key];
     } else {

--- a/documentation-site/components/yard/reducer.ts
+++ b/documentation-site/components/yard/reducer.ts
@@ -1,0 +1,63 @@
+import {TState} from './types';
+import {Action} from './const';
+import {assertUnreachable, buildPropsObj} from './utils';
+
+export default function reducer(
+  state: TState,
+  action: {type: Action; payload: any},
+): TState {
+  switch (action.type) {
+    case Action.UpdateCode:
+      return {...state, code: action.payload, codeNoRecompile: ''};
+    case Action.Update:
+      const newTheme = {...state.theme};
+      Object.keys(state.theme).forEach(key => {
+        if (action.payload.theme[key]) {
+          newTheme[key] = action.payload.theme[key];
+        }
+      });
+      return {
+        ...state,
+        code: action.payload.code,
+        codeNoRecompile: '',
+        theme: newTheme,
+        props: buildPropsObj(state.props, action.payload.updatedPropValues),
+      };
+    case Action.UpdatePropsAndCodeNoRecompile:
+      return {
+        ...state,
+        codeNoRecompile: action.payload.codeNoRecompile,
+        props: buildPropsObj(state.props, action.payload.updatedPropValues),
+      };
+    case Action.UpdateProps:
+      return {
+        ...state,
+        codeNoRecompile: '',
+        props: buildPropsObj(state.props, action.payload),
+      };
+    case Action.UpdatePropsAndCode:
+      return {
+        ...state,
+        code: action.payload.code,
+        codeNoRecompile: '',
+        props: buildPropsObj(state.props, action.payload.updatedPropValues),
+      };
+    case Action.UpdateThemeAndCode:
+      return {
+        ...state,
+        code: action.payload.code,
+        codeNoRecompile: '',
+        theme: action.payload.theme,
+      };
+    case Action.Reset:
+      return {
+        ...state,
+        code: action.payload.code,
+        codeNoRecompile: '',
+        props: action.payload.props,
+        theme: action.payload.theme,
+      };
+    default:
+      return assertUnreachable();
+  }
+}

--- a/documentation-site/components/yard/styled-components.tsx
+++ b/documentation-site/components/yard/styled-components.tsx
@@ -1,0 +1,61 @@
+import * as React from 'react';
+import {useStyletron} from 'baseui';
+import {StatefulTooltip} from 'baseui/tooltip';
+import {Tag, VARIANT} from 'baseui/tag';
+import {StatefulTabs, Tab} from 'baseui/tabs';
+
+export const Beta = () => {
+  const [css] = useStyletron();
+  return (
+    <div className={css({display: 'flex', justifyContent: 'flex-end'})}>
+      <Tag closeable={false} variant={VARIANT.outlined} kind="warning">
+        <StatefulTooltip
+          accessibilityType="tooltip"
+          placement="bottomLeft"
+          content="This is a new experimental component playground. Please use GitHub issues to report any feedback and bugs. Thank you!"
+        >
+          Beta
+        </StatefulTooltip>
+      </Tag>
+    </div>
+  );
+};
+
+export const YardTabs: React.FC<{children: React.ReactNode}> = ({children}) => {
+  const [, theme] = useStyletron();
+  return (
+    <StatefulTabs
+      initialState={{activeKey: '0'}}
+      overrides={{
+        Root: {
+          style: {
+            marginBottom: theme.sizing.scale400,
+          },
+        },
+        TabBar: {
+          style: {backgroundColor: 'transparent', paddingLeft: 0},
+        },
+        TabContent: {style: {paddingLeft: 0, paddingRight: 0}},
+      }}
+    >
+      {children}
+    </StatefulTabs>
+  );
+};
+
+export const YardTab: React.FC<any> = props => {
+  return (
+    <Tab
+      {...props}
+      overrides={{
+        Tab: {
+          style: ({$theme}) =>
+            ({
+              marginLeft: 0,
+              ...$theme.typography.font450,
+            } as any),
+        },
+      }}
+    />
+  );
+};

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -11,7 +11,7 @@ export type TThemeDiff = {
 export type TPropHook = {
   what: string;
   into: string;
-} | null;
+};
 
 export type TImportsConfig = {
   [key: string]: {
@@ -28,27 +28,42 @@ export type TError = {
 export type TYardProps = {
   componentName: string;
   minHeight: number;
-  importsConfig?: TImportsConfig;
   scopeConfig: {[key: string]: any};
   propsConfig: {[key: string]: TProp};
   themeConfig: string[];
+  importsConfig?: TImportsConfig;
 };
 
+export type TConfig = {
+  scopeConfig: {[key: string]: any};
+  propsConfig: {[key: string]: TProp};
+  themeConfig: string[];
+  importsConfig?: TImportsConfig;
+};
+
+export type TPropValue =
+  | undefined
+  | boolean
+  | string
+  | {
+      [key: string]: {
+        active: boolean;
+        style: string;
+      };
+    };
+
 export type TProp = {
-  value: any;
+  value: TPropValue;
   type: PropTypes;
   description: string;
   options?: any;
   placeholder?: string;
   enumName?: string;
   hidden?: boolean;
-  meta?: {
-    names?: string[];
-    sharedKeys?: any;
-    stateful?: boolean;
-    propHook?: TPropHook;
-    imports?: string[];
-  };
+  names?: string[];
+  sharedProps?: {[key: string]: string | {type: string; description: string}};
+  stateful?: boolean;
+  propHook?: TPropHook;
 };
 
 export type TState = {

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -13,7 +13,7 @@ export type TPropHook = {
   into: string;
 } | null;
 
-export type TExtraImports = {
+export type TImportsConfig = {
   [key: string]: {
     named?: string[];
     default?: string;
@@ -28,7 +28,7 @@ export type TError = {
 export type TYardProps = {
   componentName: string;
   minHeight: number;
-  extraImports?: TExtraImports;
+  importsConfig?: TImportsConfig;
   scopeConfig: {[key: string]: any};
   propsConfig: {[key: string]: TProp};
   themeConfig: string[];

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -12,6 +12,11 @@ export type TExtraImports = {
   };
 };
 
+export type TError = {
+  where: string;
+  msg: string | null;
+};
+
 export type TYardProps = {
   componentName: string;
   minHeight: number;

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -1,4 +1,12 @@
 import {PropTypes} from './const';
+import {Action} from './const';
+
+export type TDispatch = (value: {type: Action; payload: any}) => void;
+
+export type TThemeDiff = {
+  themeValues: {[key: string]: string};
+  themeName: string;
+};
 
 export type TPropHook = {
   what: string;

--- a/documentation-site/components/yard/types.ts
+++ b/documentation-site/components/yard/types.ts
@@ -28,29 +28,27 @@ export type TError = {
 export type TYardProps = {
   componentName: string;
   minHeight: number;
-  scopeConfig: {[key: string]: any};
-  propsConfig: {[key: string]: TProp};
-  themeConfig: string[];
-  importsConfig?: TImportsConfig;
+  scope: {[key: string]: any};
+  props: {[key: string]: TProp};
+  theme: string[];
+  imports?: TImportsConfig;
 };
 
 export type TConfig = {
-  scopeConfig: {[key: string]: any};
-  propsConfig: {[key: string]: TProp};
-  themeConfig: string[];
-  importsConfig?: TImportsConfig;
+  scope: {[key: string]: any};
+  props: {[key: string]: TProp};
+  theme: string[];
+  imports?: TImportsConfig;
 };
 
-export type TPropValue =
-  | undefined
-  | boolean
-  | string
-  | {
-      [key: string]: {
-        active: boolean;
-        style: string;
-      };
-    };
+type TPropValueOverrides = {
+  [key: string]: {
+    active: boolean;
+    style: string;
+  };
+};
+
+export type TPropValue = undefined | boolean | string | TPropValueOverrides;
 
 export type TProp = {
   value: TPropValue;

--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -1,5 +1,5 @@
 import {Theme} from 'baseui/theme';
-import {TProp, TThemeDiff} from './types';
+import {TProp, TThemeDiff, TPropValue} from './types';
 
 export function assertUnreachable(): never {
   throw new Error("Didn't expect to get here");
@@ -24,7 +24,7 @@ export const formatBabelError = (error: string) => {
 
 export const buildPropsObj = (
   stateProps: {[key: string]: TProp},
-  updatedPropValues: {[key: string]: any},
+  updatedPropValues: {[key: string]: TPropValue},
 ) => {
   const newProps: {
     [key: string]: TProp;
@@ -41,7 +41,10 @@ export const buildPropsObj = (
       description: stateProps[name].description,
       placeholder: stateProps[name].placeholder,
       hidden: stateProps[name].hidden,
-      meta: stateProps[name].meta,
+      names: stateProps[name].names,
+      sharedProps: stateProps[name].sharedProps,
+      stateful: stateProps[name].stateful,
+      propHook: stateProps[name].propHook,
     };
   });
   return newProps;

--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -1,6 +1,5 @@
 import {Theme} from 'baseui/theme';
-import Router from 'next/router';
-import {TProp} from './types';
+import {TProp, TThemeDiff} from './types';
 
 export function assertUnreachable(): never {
   throw new Error("Didn't expect to get here");
@@ -59,15 +58,27 @@ export const getComponentThemeFromContext = (
   return componentThemeObj;
 };
 
-export const updateUrl = (pathname: string, code?: string) => {
-  Router.push(
-    code
-      ? {
-          pathname: pathname,
-          query: {code},
-        }
-      : {
-          pathname: pathname,
-        },
-  );
+export const getThemeForCodeGenerator = (
+  themeConfig: string[],
+  updatedThemeValues: {[key: string]: string},
+  theme: Theme,
+) => {
+  const componentThemeValueDiff: {[key: string]: string} = {};
+  themeConfig.forEach(key => {
+    if (
+      updatedThemeValues[key] &&
+      (theme.colors as any)[key] !== updatedThemeValues[key]
+    ) {
+      componentThemeValueDiff[key] = updatedThemeValues[key];
+    }
+  });
+  const componentThemeDiff: TThemeDiff = {
+    themeValues: {},
+    themeName: '',
+  };
+  if (Object.keys(componentThemeValueDiff).length > 0) {
+    componentThemeDiff.themeValues = componentThemeValueDiff;
+    componentThemeDiff.themeName = theme.name;
+  }
+  return componentThemeDiff;
 };

--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -1,3 +1,7 @@
+import {Theme} from 'baseui/theme';
+import Router from 'next/router';
+import {TProp} from './types';
+
 export function assertUnreachable(): never {
   throw new Error("Didn't expect to get here");
 }
@@ -17,4 +21,53 @@ export const formatBabelError = (error: string) => {
       const lenDiff = line.length - `${newLineNum}`.length;
       return `${' '.repeat(lenDiff)}${newLineNum} |`;
     });
+};
+
+export const buildPropsObj = (
+  stateProps: {[key: string]: TProp},
+  updatedPropValues: {[key: string]: any},
+) => {
+  const newProps: {
+    [key: string]: TProp;
+  } = {};
+  Object.keys(stateProps).forEach(name => {
+    newProps[name] = {...stateProps[name]};
+  });
+  Object.keys(updatedPropValues).forEach(name => {
+    newProps[name] = {
+      value: updatedPropValues[name],
+      type: stateProps[name].type,
+      options: stateProps[name].options,
+      enumName: stateProps[name].enumName,
+      description: stateProps[name].description,
+      placeholder: stateProps[name].placeholder,
+      hidden: stateProps[name].hidden,
+      meta: stateProps[name].meta,
+    };
+  });
+  return newProps;
+};
+
+export const getComponentThemeFromContext = (
+  theme: Theme,
+  themeConfig: string[],
+) => {
+  const componentThemeObj: {[key: string]: string} = {};
+  themeConfig.forEach(key => {
+    componentThemeObj[key] = (theme.colors as any)[key];
+  });
+  return componentThemeObj;
+};
+
+export const updateUrl = (pathname: string, code?: string) => {
+  Router.push(
+    code
+      ? {
+          pathname: pathname,
+          query: {code},
+        }
+      : {
+          pathname: pathname,
+        },
+  );
 };

--- a/documentation-site/components/yard/utils.ts
+++ b/documentation-site/components/yard/utils.ts
@@ -82,3 +82,31 @@ export const getThemeForCodeGenerator = (
   }
   return componentThemeDiff;
 };
+
+export const countOverrides = (overrides: any) => {
+  const existingOverrides = overrides.value ? Object.keys(overrides.value) : [];
+  return existingOverrides.filter(key => overrides.value[key].active).length;
+};
+
+export const countProps = (
+  props: {[key: string]: TProp},
+  propsConfig: {[key: string]: TProp},
+) => {
+  let changedProps = 0;
+  Object.keys(props).forEach(prop => {
+    if (
+      prop !== 'overrides' &&
+      props[prop].value !== '' &&
+      typeof props[prop].value !== 'undefined' &&
+      //@ts-ignore
+      props[prop].value !== propsConfig[prop].value
+    ) {
+      changedProps++;
+    }
+  });
+  return changedProps;
+};
+
+export const countThemeValues = (componentThemeDiff: TThemeDiff) => {
+  return Object.keys(componentThemeDiff.themeValues).length;
+};

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -94,9 +94,7 @@ const Yard: React.FC<
       setHydrated(true);
       try {
         updateAll(dispatch, urlCode, componentName, propsConfig);
-      } catch (e) {
-        console.warn(e);
-      }
+      } catch (e) {}
     }
   }, [urlCode]);
 
@@ -195,7 +193,7 @@ const Yard: React.FC<
                 updateUrl(pathname, newCode);
               } catch (e) {
                 updateProps(dispatch, propName, propValue);
-                setError({where: name, msg: e.toString()});
+                setError({where: propName, msg: e.toString()});
               }
             }}
           />

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -6,7 +6,6 @@ import {
   darkThemePrimitives,
   ThemeProvider,
 } from 'baseui';
-import {withRouter} from 'next/router';
 import {Button, KIND, SIZE} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';
 import copy from 'copy-to-clipboard';
@@ -19,6 +18,9 @@ import {
   buildPropsObj,
   getComponentThemeFromContext,
   getThemeForCodeGenerator,
+  countOverrides,
+  countProps,
+  countThemeValues,
 } from './utils';
 import {TYardProps, TError} from './types';
 
@@ -49,305 +51,285 @@ import {
 } from './actions';
 import reducer from './reducer';
 
-export default withRouter(
-  ({
-    router,
-    componentName,
-    propsConfig,
-    themeConfig,
-    scopeConfig,
-    extraImports,
-    minHeight,
-    placeholderElement,
-  }: TYardProps & {
-    router: any;
+const Yard: React.FC<
+  TYardProps & {
     placeholderElement: React.FC;
-  }) => {
-    const [, theme] = useStyletron();
-    const [hydrated, setHydrated] = React.useState(false);
-    const [error, setError] = React.useState<TError>({where: '', msg: null});
-    const initialThemeObj = getComponentThemeFromContext(theme, themeConfig);
-    const [state, dispatch] = React.useReducer(reducer, {
-      code:
-        router.query.code ||
-        getCode(
-          propsConfig,
-          componentName,
-          getThemeForCodeGenerator(themeConfig, {}, theme),
-          extraImports,
-        ),
-      codeNoRecompile: '',
-      props: propsConfig,
-      theme: initialThemeObj,
-    });
+    pathname: string;
+    urlCode?: string;
+  }
+> = ({
+  componentName,
+  propsConfig,
+  themeConfig,
+  scopeConfig,
+  extraImports,
+  minHeight,
+  placeholderElement,
+  pathname,
+  urlCode,
+}) => {
+  const [, theme] = useStyletron();
+  const [hydrated, setHydrated] = React.useState(false);
+  const [error, setError] = React.useState<TError>({where: '', msg: null});
+  const initialThemeObj = getComponentThemeFromContext(theme, themeConfig);
 
-    // initialize from the URL
-    React.useEffect(() => {
-      if (router.query.code && !hydrated) {
-        setHydrated(true);
-        try {
-          updateAll(dispatch, router.query.code, componentName, propsConfig);
-        } catch (e) {
-          console.warn(e);
-        }
+  // initial state
+  const [state, dispatch] = React.useReducer(reducer, {
+    code:
+      urlCode ||
+      getCode(
+        propsConfig,
+        componentName,
+        getThemeForCodeGenerator(themeConfig, {}, theme),
+        extraImports,
+      ),
+    codeNoRecompile: '',
+    props: propsConfig,
+    theme: initialThemeObj,
+  });
+
+  // initialize from the URL
+  React.useEffect(() => {
+    if (urlCode && !hydrated) {
+      setHydrated(true);
+      try {
+        updateAll(dispatch, urlCode, componentName, propsConfig);
+      } catch (e) {
+        console.warn(e);
       }
-    }, [router.query.code]);
+    }
+  }, [urlCode]);
 
-    //when theme (context) is switched, reset the theme state
-    React.useEffect(() => {
-      // don't make the reset if theme values were untouched
-      // prevents the initial re-update
-      const isIdentical = Object.keys(initialThemeObj).every(
-        key => initialThemeObj[key] === state.theme[key],
-      );
-      if (!isIdentical) {
-        const newCode = getCode(
-          state.props,
-          componentName,
-          getThemeForCodeGenerator(themeConfig, {}, theme),
-          extraImports,
-        );
-        updateThemeAndCode(
-          dispatch,
-          newCode,
-          getComponentThemeFromContext(theme, themeConfig),
-        );
-        if (state.code !== newCode) {
-          updateUrl(router.pathname, newCode);
-        }
-      }
-    }, [theme.name]);
-
-    const __yard_onChange = (
-      componentName: string,
-      propName: string,
-      propValue: any,
-    ) => {
-      !hydrated && setHydrated(true);
+  //when theme (context) is switched, reset the theme state
+  React.useEffect(() => {
+    // don't make the reset if theme values were untouched
+    // prevents the initial re-update
+    const isIdentical = Object.keys(initialThemeObj).every(
+      key => initialThemeObj[key] === state.theme[key],
+    );
+    if (!isIdentical) {
       const newCode = getCode(
-        buildPropsObj(state.props, {[propName]: propValue}),
+        state.props,
         componentName,
         getThemeForCodeGenerator(themeConfig, {}, theme),
         extraImports,
       );
-      updatePropsAndCodeNoRecompile(dispatch, newCode, propName, propValue);
-      updateUrl(router.pathname, newCode);
-    };
-
-    let changedProps = 0;
-    Object.keys(state.props).forEach(prop => {
-      if (
-        prop !== 'overrides' &&
-        state.props[prop].value !== '' &&
-        typeof state.props[prop].value !== 'undefined' &&
-        //@ts-ignore
-        state.props[prop].value !== propsConfig[prop].value
-      ) {
-        changedProps++;
+      updateThemeAndCode(
+        dispatch,
+        newCode,
+        getComponentThemeFromContext(theme, themeConfig),
+      );
+      if (state.code !== newCode) {
+        updateUrl(pathname, newCode);
       }
-    });
+    }
+  }, [theme.name]);
 
-    const componentThemeDiff = getThemeForCodeGenerator(
-      themeConfig,
-      state.theme,
-      theme,
+  const __yard_onChange = (
+    componentName: string,
+    propName: string,
+    propValue: any,
+  ) => {
+    !hydrated && setHydrated(true);
+    const newCode = getCode(
+      buildPropsObj(state.props, {[propName]: propValue}),
+      componentName,
+      getThemeForCodeGenerator(themeConfig, {}, theme),
+      extraImports,
     );
+    updatePropsAndCodeNoRecompile(dispatch, newCode, propName, propValue);
+    updateUrl(pathname, newCode);
+  };
 
-    const existingOverrides = state.props.overrides.value
-      ? Object.keys(state.props.overrides.value)
-      : [];
-    const activeOverrides = existingOverrides.filter(
-      key => state.props.overrides.value[key].active,
-    ).length;
+  const componentThemeDiff = getThemeForCodeGenerator(
+    themeConfig,
+    state.theme,
+    theme,
+  );
 
-    return (
-      <React.Fragment>
-        <Compiler
-          code={state.code}
-          setError={msg => setError({where: '__compiler', msg})}
-          minHeight={minHeight}
-          transformations={[
-            code =>
-              transformBeforeCompilation(code, componentName, propsConfig),
-          ]}
-          scope={{
-            ...scopeConfig,
-            ThemeProvider,
-            lightThemePrimitives,
-            darkThemePrimitives,
-            createTheme,
-            __yard_onChange,
-          }}
-          PlaceholderElement={placeholderElement}
-        />
-        {(error.where === '__compiler' || error.where === 'overrides') &&
-          error.msg && <PopupError error={error.msg} />}
-        <YardTabs>
-          <YardTab
-            title={`Props${changedProps > 0 ? ` (${changedProps})` : ''}`}
-          >
-            <Knobs
-              knobProps={state.props}
-              error={error}
-              set={(propValue: any, propName: string) => {
-                try {
-                  trackEvent(
-                    'yard',
-                    `${componentName}:knob_change_${propName}`,
-                  );
-                  !hydrated && setHydrated(true);
-                  const newCode = getCode(
-                    buildPropsObj(state.props, {[propName]: propValue}),
-                    componentName,
-                    componentThemeDiff,
-                    extraImports,
-                  );
-                  if (error.msg !== null) setError({where: '', msg: null});
-                  updatePropsAndCode(dispatch, newCode, propName, propValue);
-                  updateUrl(router.pathname, newCode);
-                } catch (e) {
-                  updateProps(dispatch, propName, propValue);
-                  setError({where: name, msg: e.toString()});
-                }
-              }}
-            />
-          </YardTab>
-          <YardTab
-            title={`Style Overrides${
-              activeOverrides > 0 ? ` (${activeOverrides})` : ''
-            }`}
-          >
-            <Overrides
-              componentName={componentName}
-              componentConfig={propsConfig}
-              overrides={state.props.overrides}
-              set={(propValue: any) => {
-                const propName = 'overrides';
-                try {
-                  const newCode = getCode(
-                    buildPropsObj(state.props, {[propName]: propValue}),
-                    componentName,
-                    componentThemeDiff,
-                    extraImports,
-                  );
-                  if (error.msg !== null) {
-                    setError({where: '', msg: null});
-                  }
-                  updatePropsAndCode(dispatch, newCode, propName, propValue);
-                  updateUrl(router.pathname, newCode);
-                } catch (e) {
-                  updateProps(dispatch, propName, propValue);
-                  setError({where: propName, msg: e.toString()});
-                }
-              }}
-            />
-          </YardTab>
-          <YardTab
-            title={`Theme ${
-              Object.keys(componentThemeDiff.themeValues).length > 0
-                ? `(${Object.keys(componentThemeDiff.themeValues).length})`
-                : ''
-            }`}
-          >
-            <ThemeEditor
-              themeInit={initialThemeObj}
-              theme={state.theme}
-              componentName={componentName}
-              set={(updatedThemeValues: {[key: string]: string}) => {
-                const componentThemeDiff = getThemeForCodeGenerator(
-                  themeConfig,
-                  updatedThemeValues,
-                  theme,
-                );
+  const activeProps = countProps(state.props, propsConfig);
+  const activeOverrides = countOverrides(state.props.overrides);
+  const activeThemeValues = countThemeValues(componentThemeDiff);
+
+  return (
+    <React.Fragment>
+      <Compiler
+        code={state.code}
+        setError={msg => setError({where: '__compiler', msg})}
+        minHeight={minHeight}
+        transformations={[
+          code => transformBeforeCompilation(code, componentName, propsConfig),
+        ]}
+        scope={{
+          ...scopeConfig,
+          ThemeProvider,
+          lightThemePrimitives,
+          darkThemePrimitives,
+          createTheme,
+          __yard_onChange,
+        }}
+        PlaceholderElement={placeholderElement}
+      />
+      {(error.where === '__compiler' || error.where === 'overrides') &&
+        error.msg && <PopupError error={error.msg} />}
+      <YardTabs>
+        <YardTab title={`Props${activeProps > 0 ? ` (${activeProps})` : ''}`}>
+          <Knobs
+            knobProps={state.props}
+            error={error}
+            set={(propValue: any, propName: string) => {
+              try {
+                trackEvent('yard', `${componentName}:knob_change_${propName}`);
+                !hydrated && setHydrated(true);
                 const newCode = getCode(
-                  state.props,
+                  buildPropsObj(state.props, {[propName]: propValue}),
                   componentName,
                   componentThemeDiff,
                   extraImports,
                 );
-                updateThemeAndCode(dispatch, newCode, updatedThemeValues);
-                updateUrl(router.pathname, newCode);
-              }}
-            />
-          </YardTab>
-        </YardTabs>
-        <Editor
-          code={
-            state.codeNoRecompile !== '' ? state.codeNoRecompile : state.code
+                if (error.msg !== null) setError({where: '', msg: null});
+                updatePropsAndCode(dispatch, newCode, propName, propValue);
+                updateUrl(pathname, newCode);
+              } catch (e) {
+                updateProps(dispatch, propName, propValue);
+                setError({where: name, msg: e.toString()});
+              }
+            }}
+          />
+        </YardTab>
+        <YardTab
+          title={`Style Overrides${
+            activeOverrides > 0 ? ` (${activeOverrides})` : ''
+          }`}
+        >
+          <Overrides
+            componentName={componentName}
+            componentConfig={propsConfig}
+            overrides={state.props.overrides}
+            set={(propValue: any) => {
+              const propName = 'overrides';
+              try {
+                const newCode = getCode(
+                  buildPropsObj(state.props, {[propName]: propValue}),
+                  componentName,
+                  componentThemeDiff,
+                  extraImports,
+                );
+                if (error.msg !== null) {
+                  setError({where: '', msg: null});
+                }
+                updatePropsAndCode(dispatch, newCode, propName, propValue);
+                updateUrl(pathname, newCode);
+              } catch (e) {
+                updateProps(dispatch, propName, propValue);
+                setError({where: propName, msg: e.toString()});
+              }
+            }}
+          />
+        </YardTab>
+        <YardTab
+          title={`Theme ${
+            activeThemeValues > 0 ? `(${activeThemeValues})` : ''
+          }`}
+        >
+          <ThemeEditor
+            themeInit={initialThemeObj}
+            theme={state.theme}
+            componentName={componentName}
+            set={(updatedThemeValues: {[key: string]: string}) => {
+              const componentThemeDiff = getThemeForCodeGenerator(
+                themeConfig,
+                updatedThemeValues,
+                theme,
+              );
+              const newCode = getCode(
+                state.props,
+                componentName,
+                componentThemeDiff,
+                extraImports,
+              );
+              updateThemeAndCode(dispatch, newCode, updatedThemeValues);
+              updateUrl(pathname, newCode);
+            }}
+          />
+        </YardTab>
+      </YardTabs>
+      <Editor
+        code={state.codeNoRecompile !== '' ? state.codeNoRecompile : state.code}
+        onChange={newCode => {
+          try {
+            updateAll(dispatch, newCode, componentName, propsConfig);
+            updateUrl(pathname, newCode);
+          } catch (e) {
+            updateCode(dispatch, newCode);
           }
-          onChange={newCode => {
-            try {
-              updateAll(dispatch, newCode, componentName, propsConfig);
-              updateUrl(router.pathname, newCode);
-            } catch (e) {
-              updateCode(dispatch, newCode);
-            }
-          }}
-        />
-        <Error
-          error={error.where === '__compiler' ? error.msg : null}
-          code={state.code}
-        />
-        <ButtonGroup
-          size={SIZE.compact}
-          overrides={{
-            Root: {
-              style: ({$theme}) => ({
-                marginTop: $theme.sizing.scale300,
-              }),
-            },
+        }}
+      />
+      <Error
+        error={error.where === '__compiler' ? error.msg : null}
+        code={state.code}
+      />
+      <ButtonGroup
+        size={SIZE.compact}
+        overrides={{
+          Root: {
+            style: ({$theme}) => ({
+              marginTop: $theme.sizing.scale300,
+            }),
+          },
+        }}
+      >
+        <Button
+          kind={KIND.tertiary}
+          onClick={() => {
+            trackEvent('yard', `${componentName}:format_code`);
+            updateCode(dispatch, formatCode(state.code));
           }}
         >
-          <Button
-            kind={KIND.tertiary}
-            onClick={() => {
-              trackEvent('yard', `${componentName}:format_code`);
-              updateCode(dispatch, formatCode(state.code));
-            }}
-          >
-            Format
-          </Button>
-          <Button
-            kind={KIND.tertiary}
-            onClick={() => {
-              trackEvent('yard', `${componentName}:copy_code`);
-              copy(state.code);
-            }}
-          >
-            Copy code
-          </Button>
-          <Button
-            kind={KIND.tertiary}
-            onClick={() => {
-              trackEvent('yard', `${componentName}:copy_url`);
-              copy(window.location.href);
-            }}
-          >
-            Copy URL
-          </Button>
-          <Button
-            kind={KIND.tertiary}
-            onClick={() => {
-              trackEvent('yard', `${componentName}:reset_code`);
-              reset(
-                dispatch,
-                getCode(
-                  propsConfig,
-                  componentName,
-                  getThemeForCodeGenerator(themeConfig, {}, theme),
-                  extraImports,
-                ),
+          Format
+        </Button>
+        <Button
+          kind={KIND.tertiary}
+          onClick={() => {
+            trackEvent('yard', `${componentName}:copy_code`);
+            copy(state.code);
+          }}
+        >
+          Copy code
+        </Button>
+        <Button
+          kind={KIND.tertiary}
+          onClick={() => {
+            trackEvent('yard', `${componentName}:copy_url`);
+            copy(window.location.href);
+          }}
+        >
+          Copy URL
+        </Button>
+        <Button
+          kind={KIND.tertiary}
+          onClick={() => {
+            trackEvent('yard', `${componentName}:reset_code`);
+            reset(
+              dispatch,
+              getCode(
                 propsConfig,
-                initialThemeObj,
-              );
-              updateUrl(router.pathname);
-            }}
-          >
-            Reset
-          </Button>
-        </ButtonGroup>
-        <Beta />
-      </React.Fragment>
-    );
-  },
-);
+                componentName,
+                getThemeForCodeGenerator(themeConfig, {}, theme),
+                extraImports,
+              ),
+              propsConfig,
+              initialThemeObj,
+            );
+            updateUrl(pathname);
+          }}
+        >
+          Reset
+        </Button>
+      </ButtonGroup>
+      <Beta />
+    </React.Fragment>
+  );
+};
+
+export default Yard;

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -62,7 +62,7 @@ const Yard: React.FC<
   propsConfig,
   themeConfig,
   scopeConfig,
-  extraImports,
+  importsConfig,
   minHeight,
   placeholderElement,
   pathname,
@@ -81,7 +81,7 @@ const Yard: React.FC<
         propsConfig,
         componentName,
         getThemeForCodeGenerator(themeConfig, {}, theme),
-        extraImports,
+        importsConfig,
       ),
     codeNoRecompile: '',
     props: propsConfig,
@@ -112,7 +112,7 @@ const Yard: React.FC<
         state.props,
         componentName,
         getThemeForCodeGenerator(themeConfig, {}, theme),
-        extraImports,
+        importsConfig,
       );
       updateThemeAndCode(
         dispatch,
@@ -138,7 +138,7 @@ const Yard: React.FC<
       buildPropsObj(state.props, {[propName]: propValue}),
       componentName,
       getThemeForCodeGenerator(themeConfig, state.theme, theme),
-      extraImports,
+      importsConfig,
     );
     updatePropsAndCodeNoRecompile(dispatch, newCode, propName, propValue);
     updateUrl(pathname, newCode);
@@ -188,7 +188,7 @@ const Yard: React.FC<
                   buildPropsObj(state.props, {[propName]: propValue}),
                   componentName,
                   componentThemeDiff,
-                  extraImports,
+                  importsConfig,
                 );
                 if (error.msg !== null) setError({where: '', msg: null});
                 updatePropsAndCode(dispatch, newCode, propName, propValue);
@@ -216,7 +216,7 @@ const Yard: React.FC<
                   buildPropsObj(state.props, {[propName]: propValue}),
                   componentName,
                   componentThemeDiff,
-                  extraImports,
+                  importsConfig,
                 );
                 if (error.msg !== null) {
                   setError({where: '', msg: null});
@@ -249,7 +249,7 @@ const Yard: React.FC<
                 state.props,
                 componentName,
                 componentThemeDiff,
-                extraImports,
+                importsConfig,
               );
               updateThemeAndCode(dispatch, newCode, updatedThemeValues);
               updateUrl(pathname, newCode);
@@ -319,7 +319,7 @@ const Yard: React.FC<
                 propsConfig,
                 componentName,
                 getThemeForCodeGenerator(themeConfig, {}, theme),
-                extraImports,
+                importsConfig,
               ),
               propsConfig,
               initialThemeObj,

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -22,7 +22,7 @@ import {
   countProps,
   countThemeValues,
 } from './utils';
-import {TYardProps, TError} from './types';
+import {TYardProps, TPropValue, TError} from './types';
 
 // tabs aka editing UIs
 import Knobs from './knobs';
@@ -131,7 +131,7 @@ const Yard: React.FC<
   const __yard_onChange = (
     componentName: string,
     propName: string,
-    propValue: any,
+    propValue: TPropValue,
   ) => {
     !hydrated && setHydrated(true);
     const newCode = getCode(
@@ -180,7 +180,7 @@ const Yard: React.FC<
           <Knobs
             knobProps={state.props}
             error={error}
-            set={(propValue: any, propName: string) => {
+            set={(propValue: TPropValue, propName: string) => {
               try {
                 trackEvent('yard', `${componentName}:knob_change_${propName}`);
                 !hydrated && setHydrated(true);
@@ -209,7 +209,7 @@ const Yard: React.FC<
             componentName={componentName}
             componentConfig={propsConfig}
             overrides={state.props.overrides}
-            set={(propValue: any) => {
+            set={(propValue: TPropValue) => {
               const propName = 'overrides';
               try {
                 const newCode = getCode(

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -8,11 +8,8 @@ import {
 } from 'baseui';
 import {withRouter} from 'next/router';
 import {Button, KIND, SIZE} from 'baseui/button';
-import {StatefulTabs, Tab} from 'baseui/tabs';
 import {ButtonGroup} from 'baseui/button-group';
 import copy from 'copy-to-clipboard';
-import {StatefulTooltip} from 'baseui/tooltip';
-import {Tag, VARIANT} from 'baseui/tag';
 
 import {Action} from './const';
 import {getCode, formatCode} from './code-generator';
@@ -23,11 +20,12 @@ import {buildPropsObj, getComponentThemeFromContext, updateUrl} from './utils';
 import Overrides from './overrides';
 import ThemeEditor from './theme-editor';
 import PopupError from './popup-error';
-import {TYardProps} from './types';
+import {TYardProps, TError} from './types';
 
 import Compiler from './compiler';
 import Editor from './editor';
 import Error from './error';
+import {Beta, YardTabs, YardTab} from './styled-components';
 
 import {trackEvent} from '../../helpers/ga';
 
@@ -45,12 +43,9 @@ export default withRouter(
     router: any;
     placeholderElement: React.FC;
   }) => {
-    const [css, theme] = useStyletron();
+    const [, theme] = useStyletron();
     const [hydrated, setHydrated] = React.useState(false);
-    const [error, setError] = React.useState<{
-      where: string;
-      msg: string | null;
-    }>({where: '', msg: null});
+    const [error, setError] = React.useState<TError>({where: '', msg: null});
     const initialThemeObj = getComponentThemeFromContext(theme, themeConfig);
     const [state, dispatch] = React.useReducer(reducer, {
       code:
@@ -219,34 +214,9 @@ export default withRouter(
         />
         {(error.where === '__compiler' || error.where === 'overrides') &&
           error.msg && <PopupError error={error.msg} />}
-        <StatefulTabs
-          initialState={{activeKey: '0'}}
-          onChange={({activeKey}) => {
-            trackEvent('yard', `${componentName}:tab_switch_${activeKey}`);
-          }}
-          overrides={{
-            Root: {
-              style: {
-                marginBottom: theme.sizing.scale400,
-              },
-            },
-            TabBar: {
-              style: {backgroundColor: 'transparent', paddingLeft: 0},
-            },
-            TabContent: {style: {paddingLeft: 0, paddingRight: 0}},
-          }}
-        >
-          <Tab
+        <YardTabs>
+          <YardTab
             title={`Props${changedProps > 0 ? ` (${changedProps})` : ''}`}
-            overrides={{
-              Tab: {
-                style: ({$theme}) =>
-                  ({
-                    marginLeft: 0,
-                    ...$theme.typography.font450,
-                  } as any),
-              },
-            }}
           >
             <Knobs
               knobProps={state.props}
@@ -279,19 +249,11 @@ export default withRouter(
                 }
               }}
             />
-          </Tab>
-          <Tab
+          </YardTab>
+          <YardTab
             title={`Style Overrides${
               activeOverrides > 0 ? ` (${activeOverrides})` : ''
             }`}
-            overrides={{
-              Tab: {
-                style: ({$theme}) =>
-                  ({
-                    ...$theme.typography.font450,
-                  } as any),
-              },
-            }}
           >
             <Overrides
               componentName={componentName}
@@ -325,21 +287,13 @@ export default withRouter(
                 }
               }}
             />
-          </Tab>
-          <Tab
+          </YardTab>
+          <YardTab
             title={`Theme ${
               Object.keys(componentThemeValueDiff).length > 0
                 ? `(${Object.keys(componentThemeValueDiff).length})`
                 : ''
             }`}
-            overrides={{
-              Tab: {
-                style: ({$theme}) =>
-                  ({
-                    ...$theme.typography.font450,
-                  } as any),
-              },
-            }}
           >
             <ThemeEditor
               themeInit={initialThemeObj}
@@ -376,8 +330,8 @@ export default withRouter(
                 updateUrl(router.pathname, newCode);
               }}
             />
-          </Tab>
-        </StatefulTabs>
+          </YardTab>
+        </YardTabs>
         <Editor
           code={
             state.codeNoRecompile !== '' ? state.codeNoRecompile : state.code
@@ -494,17 +448,7 @@ export default withRouter(
             Reset
           </Button>
         </ButtonGroup>
-        <div className={css({display: 'flex', justifyContent: 'flex-end'})}>
-          <Tag closeable={false} variant={VARIANT.outlined} kind="warning">
-            <StatefulTooltip
-              accessibilityType="tooltip"
-              placement="bottomLeft"
-              content="This is a new experimental component playground. Please use GitHub issues to report any feedback and bugs. Thank you!"
-            >
-              Beta
-            </StatefulTooltip>
-          </Tag>
-        </div>
+        <Beta />
       </React.Fragment>
     );
   },

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -125,6 +125,9 @@ const Yard: React.FC<
     }
   }, [theme.name]);
 
+  // this callback is secretely inserted into props marked with
+  // "propHook" this way we can get notified when the internal
+  // state of previewed component is changed by user
   const __yard_onChange = (
     componentName: string,
     propName: string,
@@ -134,7 +137,7 @@ const Yard: React.FC<
     const newCode = getCode(
       buildPropsObj(state.props, {[propName]: propValue}),
       componentName,
-      getThemeForCodeGenerator(themeConfig, {}, theme),
+      getThemeForCodeGenerator(themeConfig, state.theme, theme),
       extraImports,
     );
     updatePropsAndCodeNoRecompile(dispatch, newCode, propName, propValue);

--- a/documentation-site/components/yard/yard.tsx
+++ b/documentation-site/components/yard/yard.tsx
@@ -59,10 +59,10 @@ const Yard: React.FC<
   }
 > = ({
   componentName,
-  propsConfig,
-  themeConfig,
-  scopeConfig,
-  importsConfig,
+  props: propsConfig,
+  theme: themeConfig,
+  scope: scopeConfig,
+  imports: importsConfig,
   minHeight,
   placeholderElement,
   pathname,
@@ -94,7 +94,9 @@ const Yard: React.FC<
       setHydrated(true);
       try {
         updateAll(dispatch, urlCode, componentName, propsConfig);
-      } catch (e) {}
+      } catch (e) {
+        console.warn(e);
+      }
     }
   }, [urlCode]);
 
@@ -193,7 +195,7 @@ const Yard: React.FC<
                 updateUrl(pathname, newCode);
               } catch (e) {
                 updateProps(dispatch, propName, propValue);
-                setError({where: propName, msg: e.toString()});
+                setError({where: name, msg: e.toString()});
               }
             }}
           />


### PR DESCRIPTION
- abstracting some code / removing repetition from the main file
- more comments
- `meta` config object is gone, all options are now on the same (first) level
- `extraImports` config option renamed to `importsConfig` to match `propsConfig` etc
- some internal renaming to better describe what is going on
- improving typescript types
- set theme values were not preserved when user typed into the rendered input (changing the internal state)

**I avoided further steps to decompose the whole project for OSS purposes.** Can be done in the future when we are happy with the overall functionality and have time (it will be a significant effort).