### PR TITLE
feat(yard): better knob sizing, editor bug

### DIFF
--- a/documentation-site/components/yard/code-generator.ts
+++ b/documentation-site/components/yard/code-generator.ts
@@ -273,7 +273,7 @@ export const formatAstAndPrint = (ast: t.Program, printWidth?: number) => {
   const result = (prettier as any).__debug.formatAST(ast, {
     originalText: '',
     parser: 'babel',
-    printWidth: printWidth ? printWidth : 70,
+    printWidth: printWidth ? printWidth : 58,
     plugins: [parsers],
   });
   return (

--- a/documentation-site/components/yard/config/radio.ts
+++ b/documentation-site/components/yard/config/radio.ts
@@ -48,8 +48,15 @@ const RadioGroupConfig: TConfig = {
     },
     children: {
       value: `<Radio value="1">One</Radio>
-<Radio value="2" description="This is a radio description">Two</Radio>
-<Radio value="3">Three</Radio>`,
+<Radio
+  value="2"
+  description="This is a radio description"
+>
+  Two
+</Radio>
+<Radio value="3">
+  Three
+</Radio>`,
       type: PropTypes.ReactNode,
       description: 'Radios within the RadioGroup',
       imports: {

--- a/documentation-site/components/yard/editor.tsx
+++ b/documentation-site/components/yard/editor.tsx
@@ -72,7 +72,7 @@ const Editor: React.FC<{
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
         padding={small ? 4 : 12}
-        style={editorTheme.plain}
+        style={editorTheme.plain as any}
       />
     </div>
   );

--- a/documentation-site/components/yard/editor.tsx
+++ b/documentation-site/components/yard/editor.tsx
@@ -37,6 +37,7 @@ const Editor: React.FC<{
     plain: {
       ...plainStyles.plain,
       fontSize: small ? '13px' : '14px',
+      whiteSpace: 'break-spaces',
       backgroundColor: focused
         ? theme.colors.inputFillActive
         : theme.colors.inputFill,
@@ -50,7 +51,8 @@ const Editor: React.FC<{
         backgroundColor: editorTheme.plain.backgroundColor,
         paddingLeft: '4px',
         paddingRight: '4px',
-        height: small && !focused ? '40px' : 'auto',
+        height: small && !focused ? '36px' : 'auto',
+        maxWidth: small ? '255px' : 'auto',
         overflow: 'hidden',
         border: focused
           ? `2px solid ${theme.colors.borderFocus}`
@@ -69,7 +71,7 @@ const Editor: React.FC<{
         onValueChange={code => onChange(code)}
         onFocus={() => setFocused(true)}
         onBlur={() => setFocused(false)}
-        padding={small ? 6 : 12}
+        padding={small ? 4 : 12}
         style={editorTheme.plain}
       />
     </div>

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -6,7 +6,7 @@ import {PropTypes} from './const';
 import {Input} from 'baseui/input';
 import {Radio, RadioGroup} from 'baseui/radio';
 import {Checkbox} from 'baseui/checkbox';
-import {Select} from 'baseui/select';
+import {Select, SIZE} from 'baseui/select';
 import {StatefulTooltip} from 'baseui/tooltip';
 import PopupError from './popup-error';
 import Editor from './editor';
@@ -100,13 +100,6 @@ const Knob: React.SFC<{
             error={Boolean(error)}
             onChange={event => set((event.target as any).value)}
             placeholder={placeholder}
-            overrides={{
-              Input: {
-                style: {
-                  height: '36px',
-                },
-              },
-            }}
             size="compact"
             value={val ? String(val) : undefined}
           />
@@ -182,6 +175,7 @@ const Knob: React.SFC<{
             </RadioGroup>
           ) : (
             <Select
+              size={SIZE.compact}
               options={selectOptions}
               //@ts-ignore
               value={valueKey && options[valueKey]}

--- a/src/select/index.d.ts
+++ b/src/select/index.d.ts
@@ -5,6 +5,8 @@ import {OnItemSelect} from '../menu';
 import {Override} from '../overrides';
 import {Locale} from '../locale';
 
+export {SIZE} from '../input';
+
 export interface TYPE {
   select: 'select';
   search: 'search';


### PR DESCRIPTION
- all knobs use compact inputs / compact select
- some tweaks of the editor sizing so it matches input when not focused
- fixed the editor cursor position bug in Chrome by adding `white-space: break-spaces`
- prettier's printWidth of the main code formatting lowered to 58 to prevent multi-line break