### PR TITLE
docs(yard): cleanup docs, more robust code generation

### DIFF
--- a/documentation-site/components/yard/__tests__/code-generator.test.ts
+++ b/documentation-site/components/yard/__tests__/code-generator.test.ts
@@ -137,25 +137,23 @@ describe('getAstPropValue', () => {
         type: PropTypes.ReactNode,
         description: '',
       }),
-    ).toEqual([
-      {
-        children: [],
-        closingElement: null,
+    ).toEqual({
+      children: [],
+      closingElement: null,
+      loc: undefined,
+      openingElement: {
+        attributes: [],
         loc: undefined,
-        openingElement: {
-          attributes: [],
+        name: {
           loc: undefined,
-          name: {
-            loc: undefined,
-            name: 'div',
-            type: 'JSXIdentifier',
-          },
-          selfClosing: true,
-          type: 'JSXOpeningElement',
+          name: 'div',
+          type: 'JSXIdentifier',
         },
-        type: 'JSXElement',
+        selfClosing: true,
+        type: 'JSXOpeningElement',
       },
-    ]);
+      type: 'JSXElement',
+    });
   });
   test('function', () => {
     expect(

--- a/documentation-site/components/yard/config/card.ts
+++ b/documentation-site/components/yard/config/card.ts
@@ -6,7 +6,6 @@ import {TConfig} from '../types';
 const TabsConfig: TConfig = {
   imports: {
     'baseui/card': {named: ['Card']},
-    'baseui/button': {named: ['Button']},
   },
   scope: {
     Card,
@@ -32,6 +31,7 @@ const TabsConfig: TConfig = {
       description: `An array of Tab components.`,
       imports: {
         'baseui/card': {named: ['StyledBody', 'StyledAction']},
+        'baseui/button': {named: ['Button']},
       },
     },
     title: {

--- a/documentation-site/components/yard/config/side-nav.ts
+++ b/documentation-site/components/yard/config/side-nav.ts
@@ -19,19 +19,7 @@ const items = `[
             title: 'Dark',
             itemId: '#dark',
           },
-          {
-            title: 'Light',
-            itemId: '#light',
-          },
         ]
-      },
-      {
-        title: 'Sizing',
-        itemId: '#sizing',
-      },
-      {
-        title: 'Typography',
-        itemId: '#typography',
       },
     ],
   },

--- a/documentation-site/components/yard/knob.tsx
+++ b/documentation-site/components/yard/knob.tsx
@@ -91,8 +91,6 @@ const Knob: React.SFC<{
       );
     case PropTypes.String:
     case PropTypes.Number:
-    case PropTypes.Array:
-    case PropTypes.Object:
       return (
         <Spacing>
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>
@@ -196,6 +194,8 @@ const Knob: React.SFC<{
       );
     case PropTypes.ReactNode:
     case PropTypes.Function:
+    case PropTypes.Array:
+    case PropTypes.Object:
       return (
         <Spacing>
           <Label tooltip={getTooltip(description, type, name)}>{name}</Label>

--- a/documentation-site/pages/components/accordion.mdx
+++ b/documentation-site/pages/components/accordion.mdx
@@ -6,11 +6,9 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Exports from '../../components/exports';
 import Layout from '../../components/layout';
 import SEO from '../../components/meta-seo';
-import Overrides from '../../components/overrides';
 import BasicAccordion from 'examples/accordion/basic.js';
 import StatefulAccordion from 'examples/accordion/stateful.js';
 import AccordionSEO from 'examples/accordion/renderpanelcontent.js';
@@ -31,13 +29,13 @@ export default Layout;
 
 # Accordion
 
-Accordions display a list of high-level options that can expand/contract to reveal more detailed information.
-
 <Yard
   componentName="Accordion"
   placeholderHeight={180}
   {...accordionYardConfig}
 />
+
+Accordions display a list of high-level options that can expand/contract to reveal more detailed information.
 
 ## Accessibility
 

--- a/documentation-site/pages/components/avatar.mdx
+++ b/documentation-site/pages/components/avatar.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Exports from '../../components/exports';
 import Layout from '../../components/layout';
 
@@ -15,7 +14,6 @@ import Error from 'examples/avatar/error.js';
 import Override from 'examples/avatar/override.js';
 import Initals from 'examples/avatar/initals.js';
 
-import Overrides from '../../components/overrides';
 import {Avatar} from 'baseui/avatar';
 import * as AvatarExports from 'baseui/avatar';
 import {Block} from 'baseui/block';

--- a/documentation-site/pages/components/breadcrumbs.mdx
+++ b/documentation-site/pages/components/breadcrumbs.mdx
@@ -6,14 +6,12 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Exports from '../../components/exports';
 import Layout from '../../components/layout';
 
 import BasicBreadcrumbs from 'examples/breadcrumbs/basic.js';
 import PseudoBreadcrumbs from 'examples/breadcrumbs/pseudo.js';
 
-import Overrides from '../../components/overrides';
 import {Breadcrumbs} from 'baseui/breadcrumbs';
 import * as BreadcrumbsExports from 'baseui/breadcrumbs';
 import {StyledLink as Link} from 'baseui/link';
@@ -27,7 +25,7 @@ export default Layout;
 
 <Yard
   componentName="Breadcrumbs"
-  placeholderHeight={52}
+  placeholderHeight={24}
   {...breadcrumbsYardConfig}
 />
 

--- a/documentation-site/pages/components/button-group.mdx
+++ b/documentation-site/pages/components/button-group.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Exports from '../../components/exports';
 import Layout from '../../components/layout';
 
@@ -21,7 +20,6 @@ import Dropdown from 'examples/button-group/dropdown.js';
 import StatefulRadio from 'examples/button-group/stateful-radio.js';
 import StatefulCheckbox from 'examples/button-group/stateful-checkbox.js';
 
-import Overrides from '../../components/overrides';
 import {Button} from 'baseui/button';
 import {ButtonGroup} from 'baseui/button-group';
 import * as ButtonGroupExports from 'baseui/button-group';
@@ -102,36 +100,7 @@ As with many of our components, there is also an [uncontrolled](https://reactjs.
   <StatefulCheckbox />
 </Example>
 
-## Overrides
-
-<Overrides
-  name="ButtonGroup"
-  component={ButtonGroupExports}
-  renderExample={props => (
-    <ButtonGroup overrides={props.overrides}>
-      <Button>Label</Button>
-      <Button>Label</Button>
-      <Button>Label</Button>
-    </ButtonGroup>
-  )}
-/>
-
 ## API
-
-<API
-  heading="ButtonGroup API"
-  api={require('!!extract-react-types-loader!../../../src/button-group/button-group.js')}
-/>
-
-<API
-  heading="StatefulButtonGroup API"
-  api={require('!!extract-react-types-loader!../../../src/button-group/stateful-button-group.js')}
-/>
-
-<API
-  heading="StatefulContainer API"
-  api={require('!!extract-react-types-loader!../../../src/button-group/stateful-container.js')}
-/>
 
 <Exports
   component={ButtonGroupExports}

--- a/documentation-site/pages/components/button.mdx
+++ b/documentation-site/pages/components/button.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Exports from '../../components/exports';
 import Layout from '../../components/layout';
 

--- a/documentation-site/pages/components/card.mdx
+++ b/documentation-site/pages/components/card.mdx
@@ -24,12 +24,12 @@ export default Layout;
 
 # Card
 
+<Yard componentName="Card" placeholderHeight={178} {...cardYardConfig} />
+
 Cards are a self-contained unit of information, usually as part of a feed or series of similar
 content. Cards have a dynamic range of modifiers that allow text-only, text and illustration,
 and photography. All cards have an option to include text links or buttons as a primary action.
 The entire card can become an active click-target.
-
-<Yard componentName="Card" placeholderHeight={48} {...cardYardConfig} />
 
 ## Examples
 

--- a/documentation-site/pages/components/checkbox.mdx
+++ b/documentation-site/pages/components/checkbox.mdx
@@ -32,13 +32,13 @@ export default Layout;
 
 # Checkbox
 
+<Yard componentName="Checkbox" placeholderHeight={48} {...checkboxYardConfig} />
+
 Checkboxes are used to provide users with multiple options for selection in a series of options.
 
 When used as a toggle they allow the user to make a binary choice usually (but not limited) in
 the form of a yes/no or on/off suggestion. Toggles are often used in product settings or as filter
 options. When engaged (on), Base Web toggles are colored and when disengaged (off) they’re grey.
-
-<Yard componentName="Checkbox" placeholderHeight={48} {...checkboxYardConfig} />
 
 ## When to use
 

--- a/documentation-site/pages/components/file-uploader.mdx
+++ b/documentation-site/pages/components/file-uploader.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
@@ -16,7 +15,6 @@ import FileUploaderIndeterminate from 'examples/file-uploader/indeterminate-prog
 import FileUploaderDisabled from 'examples/file-uploader/disabled.js';
 import FileUploaderOverrides from 'examples/file-uploader/overrides.js';
 
-import Overrides from '../../components/overrides';
 import OverridesExample from 'examples/file-uploader/_overrides_component.js';
 import * as FileUploaderExports from 'baseui/file-uploader';
 
@@ -71,20 +69,7 @@ Creates a dropzone for file uploads.
   <FileUploaderOverrides />
 </Example>
 
-## Overrides
-
-<Overrides
-  name="File Uploader"
-  component={FileUploaderExports}
-  renderExample={props => <OverridesExample overrides={props.overrides} />}
-/>
-
 ## API
-
-<API
-  heading="File Uploader API"
-  api={require('!!extract-react-types-loader!../../../src/file-uploader/file-uploader.js')}
-/>
 
 <Exports
   component={FileUploaderExports}

--- a/documentation-site/pages/components/form-control.mdx
+++ b/documentation-site/pages/components/form-control.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
@@ -17,7 +16,6 @@ import RadioGroupExample from 'examples/form-control/radio-group.js';
 import SelectExample from 'examples/form-control/select.js';
 import Kinds from 'examples/form-control/kinds.js';
 
-import Overrides from '../../components/overrides';
 import {FormControl} from 'baseui/form-control';
 import {StatefulInput} from 'baseui/input';
 import * as FormControlExports from 'baseui/form-control';
@@ -75,28 +73,7 @@ The `positive` and `error` props accept both `boolean` and `string` values.
 If you pass a `string`, it will be used as the `caption` of the form control, overriding any value passed to the `caption` prop.
 The example above showcases this behavior.
 
-## Overrides
-
-<Overrides
-  name="Form Control"
-  component={FormControlExports}
-  renderExample={props => (
-    <FormControl
-      label="Input label"
-      caption="Input caption"
-      overrides={props.overrides}
-    >
-      <StatefulInput />
-    </FormControl>
-  )}
-/>
-
 ## API
-
-<API
-  heading="FormControl API"
-  api={require('!!extract-react-types-loader!../../../src/form-control/form-control.js')}
-/>
 
 <Exports
   component={FormControlExports}

--- a/documentation-site/pages/components/input.mdx
+++ b/documentation-site/pages/components/input.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 

--- a/documentation-site/pages/components/pagination.mdx
+++ b/documentation-site/pages/components/pagination.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
@@ -15,7 +14,6 @@ import Uncontrolled from 'examples/pagination/uncontrolled.js';
 import Labels from 'examples/pagination/labels.js';
 import Customization from 'examples/pagination/overrides.js';
 
-import Overrides from '../../components/overrides';
 import {StatefulPagination} from 'baseui/pagination';
 import * as PaginationExports from 'baseui/pagination';
 

--- a/documentation-site/pages/components/phone-input.mdx
+++ b/documentation-site/pages/components/phone-input.mdx
@@ -6,9 +6,7 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
-import Overrides from '../../components/overrides';
 import {DocLink} from '../../components/markdown-elements';
 import Exports from '../../components/exports';
 
@@ -30,14 +28,14 @@ export default Layout;
 
 # Phone Input
 
-The Phone Input is used to collect phone numbers with international dial codes.
-It contains a dropdown which allows the user to choose from a list of countries and dial codes.
-
 <Yard
   componentName="PhoneInput"
   placeholderHeight={48}
   {...phoneInputYardConfig}
 />
+
+The Phone Input is used to collect phone numbers with international dial codes.
+It contains a dropdown which allows the user to choose from a list of countries and dial codes.
 
 ## Examples
 

--- a/documentation-site/pages/components/pin-code.mdx
+++ b/documentation-site/pages/components/pin-code.mdx
@@ -6,9 +6,7 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
-import Overrides from '../../components/overrides';
 import Exports from '../../components/exports';
 
 import PinCodeBasic from 'examples/pin-code/basic.js';
@@ -34,11 +32,11 @@ export default Layout;
 
 # Pin Code
 
+<Yard componentName="PinCode" placeholderHeight={48} {...pinYardConfig} />
+
 The `PinCode` component is optimized for entering sequences of digits.
 The most common application is for entering single-use security codes.
 It is optimized for entering digits quickly.
-
-<Yard componentName="PinCode" placeholderHeight={48} {...pinYardConfig} />
 
 ## Examples
 

--- a/documentation-site/pages/components/progress-bar.mdx
+++ b/documentation-site/pages/components/progress-bar.mdx
@@ -26,13 +26,13 @@ export default Layout;
 
 # ProgressBar
 
-Indicates a wait time for deterministic actions- either within an experience flow or loading data.
-
 <Yard
   componentName="ProgressBar"
-  placeholderHeight={48}
+  placeholderHeight={28}
   {...progressBarYardConfig}
 />
+
+Indicates a wait time for deterministic actions- either within an experience flow or loading data.
 
 ## Accessibility
 

--- a/documentation-site/pages/components/radio.mdx
+++ b/documentation-site/pages/components/radio.mdx
@@ -26,9 +26,9 @@ export default Layout;
 
 # Radio
 
-Radios are used when only one choice may be selected in a series of options.
-
 <Yard componentName="RadioGroup" placeholderHeight={122} {...radioYardConfig} />
+
+Radios are used when only one choice may be selected in a series of options.
 
 ## When to use
 

--- a/documentation-site/pages/components/rating.mdx
+++ b/documentation-site/pages/components/rating.mdx
@@ -6,14 +6,12 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
 import Star from 'examples/rating/star.js';
 import Emoticon from 'examples/rating/emoticon.js';
 
-import Overrides from '../../components/overrides';
 import {EmoticonRating, StarRating} from 'baseui/rating';
 import {Block} from 'baseui/block';
 import * as RatingExports from 'baseui/rating';
@@ -24,13 +22,13 @@ export default Layout;
 
 # Rating
 
+<Yard componentName="StarRating" placeholderHeight={25} {...ratingYardConfig} />
+
 **Emoji ratings** are to be used to collect a user’s experience in the form of an emotional ranking.
 Like star ratings, there five options.
 
 **Star ratings** are to be used to collect feedback from a user’s experience with a product. The
 stars indicate a performance rating from one to five.
-
-<Yard componentName="StarRating" placeholderHeight={25} {...ratingYardConfig} />
 
 ## Accessibility
 

--- a/documentation-site/pages/components/side-nav.mdx
+++ b/documentation-site/pages/components/side-nav.mdx
@@ -26,7 +26,7 @@ export default Layout;
 
 <Yard
   componentName="Navigation"
-  placeholderHeight={336}
+  placeholderHeight={192}
   {...sideNavYardConfig}
 />
 

--- a/documentation-site/pages/components/side-nav.mdx
+++ b/documentation-site/pages/components/side-nav.mdx
@@ -6,14 +6,12 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
 import SideNavBasic from 'examples/side-navigation/basic.js';
 import NavOverrides from 'examples/side-navigation/nav-overrides.js';
 
-import Overrides from '../../components/overrides';
 import {Navigation} from 'baseui/side-navigation';
 import * as NavExports from 'baseui/side-navigation';
 

--- a/documentation-site/pages/components/slider.mdx
+++ b/documentation-site/pages/components/slider.mdx
@@ -85,16 +85,6 @@ The component is also **optimized for iOS and Android devices**.
 
 As with many of our components, there is also an [uncontrolled](https://reactjs.org/docs/uncontrolled-components.html) version, `StatefulSlider`, which manages its own state.
 
-## Overrides
-
-<Overrides
-  name="Slider"
-  component={SliderExports}
-  renderExample={props => (
-    <Slider initialState={{value: [25, 75]}} overrides={props.overrides} />
-  )}
-/>
-
 ## API
 
 <Exports

--- a/documentation-site/pages/components/slider.mdx
+++ b/documentation-site/pages/components/slider.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
@@ -18,7 +17,6 @@ import StepMinMax from 'examples/slider/step-min-max.js';
 import CustomTicks from 'examples/slider/custom-ticks.js';
 import Customization from 'examples/slider/overrides.js';
 
-import Overrides from '../../components/overrides';
 import {StatefulSlider as Slider} from 'baseui/slider';
 import * as SliderExports from 'baseui/slider';
 
@@ -29,12 +27,12 @@ export default Layout;
 
 # Slider
 
+<Yard componentName="Slider" placeholderHeight={90} {...sliderYardConfig} />
+
 Control input with sliding axis to choose a single value or range between min and max values.
 
 There are two slider options in Base that allow users to select a single value or a range.
 Each slider has a primary control handle that cues user interaction.
-
-<Yard componentName="Slider" placeholderHeight={90} {...sliderYardConfig} />
 
 ## Accessibility
 
@@ -98,21 +96,6 @@ As with many of our components, there is also an [uncontrolled](https://reactjs.
 />
 
 ## API
-
-<API
-  heading="Slider API"
-  api={require('!!extract-react-types-loader!../../../src/slider/slider.js')}
-/>
-
-<API
-  heading="Stateful Slider API"
-  api={require('!!extract-react-types-loader!../../../src/slider/stateful-slider.js')}
-/>
-
-<API
-  heading="Stateful Slider Container API"
-  api={require('!!extract-react-types-loader!../../../src/slider/stateful-slider-container.js')}
-/>
 
 <Exports
   component={SliderExports}

--- a/documentation-site/pages/components/spinner.mdx
+++ b/documentation-site/pages/components/spinner.mdx
@@ -24,9 +24,9 @@ export default Layout;
 
 # Spinner
 
-Spinners provide a visual cue that an action is processing awaiting a course of change or a result.
+<Yard componentName="Spinner" placeholderHeight={44} {...spinnerYardConfig} />
 
-<Yard componentName="Spinner" placeholderHeight={48} {...spinnerYardConfig} />
+Spinners provide a visual cue that an action is processing awaiting a course of change or a result.
 
 ## Accessibility
 

--- a/documentation-site/pages/components/tabs.mdx
+++ b/documentation-site/pages/components/tabs.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 

--- a/documentation-site/pages/components/textarea.mdx
+++ b/documentation-site/pages/components/textarea.mdx
@@ -6,7 +6,6 @@ LICENSE file in the root directory of this source tree.
 -->
 
 import Example from '../../components/example';
-import API from '../../components/api';
 import Layout from '../../components/layout';
 import Exports from '../../components/exports';
 
@@ -17,7 +16,6 @@ import TextareaRef from 'examples/textarea/ref.js';
 import TextareaResizable from 'examples/textarea/resizable.js';
 import TextareaStateful from 'examples/textarea/stateful.js';
 
-import Overrides from '../../components/overrides';
 import {StatefulTextarea as Textarea, SIZE} from 'baseui/textarea';
 import * as TextareaExports from 'baseui/textarea';
 


### PR DESCRIPTION
- fixes side-nav `items` knob formatting
- `PropTypes.ReactNode` works for non-`children` cases, `children` treated as a snowflake
- assume that user never means to use a variable (identifier) as the knob value and translate it into string

It allows this

```
$
```

->

```jsx
<Input startEnhancer="$" />
```

vs previously

```
'$'
```

->

```jsx
<Input startEnhancer={"$"} />
```

where

```
$
```

would just throw a reference error.

- cleanup examples, remove unused imports, fix minHeights


