### PR TITLE
fix(modal): update close button colors

### DIFF
--- a/src/themes/creator.js
+++ b/src/themes/creator.js
@@ -291,9 +291,9 @@ export default function createTheme(
       menuFontSelected: primitives.mono1000,
 
       // Modal
-      modalCloseColor: primitives.mono700,
-      modalCloseColorHover: primitives.mono800,
-      modalCloseColorFocus: primitives.mono800,
+      modalCloseColor: primitives.primary,
+      modalCloseColorHover: primitives.primary600,
+      modalCloseColorFocus: primitives.primary600,
 
       // Pagination
       paginationTriangleDown: primitives.mono800,


### PR DESCRIPTION
#### Description

Update Modal's close button to black per discussion with the design team.

Because the X icon is so thin, I followed the link colors for hover so there is enough contrast to be perceived. It is still pretty close colors but that's a more general system issue.

#### Scope

- [X] Patch: Bug Fix
- [ ] Minor: New Feature
- [ ] Major: Breaking Change
