### PR TITLE
fix(docs): don't preload move fonts and move the link to the body end so it's not blocking

### DIFF
--- a/documentation-site/pages/_document.js
+++ b/documentation-site/pages/_document.js
@@ -70,7 +70,19 @@ export default class MyDocument extends Document {
             rel="stylesheet"
             href="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.css"
           />
-          <link rel="prefetch" as="style" href="/static/fonts.css" />
+          <link
+            rel="preload"
+            href="https://d1a3f4spazzrp4.cloudfront.net/dotcom-assets/fonts/UberMoveText-Regular.woff2"
+            as="font"
+            crossOrigin="anonymous"
+          />
+          <link
+            rel="preload"
+            href="https://d1a3f4spazzrp4.cloudfront.net/dotcom-assets/fonts/UberMoveText-Medium.woff2"
+            as="font"
+            crossOrigin="anonymous"
+          />
+          <link rel="stylesheet" href="/static/fonts.css" />
           <style>{`
             body {
               margin: 0;


### PR DESCRIPTION
**Background story** 
We prefetched `fonts.css` but that css with font-faces was never applied and so the fonts were never downloaded.

**Solution**
In order to reduce/eliminate the flash of the system fonts, first, we need to link `fonts.css` in a regular way and not just `prefetch` (also it doesn't make sense to prefetch that small css file), second, we need to preload font files that are used on the page. There are trade-offs in this approach like potential increase in the page load time, also preloaded resources get prioritizes that may not be what one wants for font files. Despite the above mentioned, in our specific case, I did not notice any significant load time difference while testing it on a slower network.