### PR TITLE
docs: add a note about themeprovider vs baseprovider div

### DIFF
--- a/documentation-site/pages/components/base-provider.mdx
+++ b/documentation-site/pages/components/base-provider.mdx
@@ -42,7 +42,7 @@ export default function App() {
   }}
 >
   Your application might be wrapping the root only with ThemeProvider. You
-  should use BaseProvider instead to support correct layering. Plase note that
+  should use BaseProvider instead to support correct layering. Please note that
   this component adds an <b>additional div</b> that could impact your layout.
 </Notification>
 

--- a/documentation-site/pages/getting-started/setup.mdx
+++ b/documentation-site/pages/getting-started/setup.mdx
@@ -132,7 +132,7 @@ export default function Hello() {
   }}
 >
   Your application might be wrapping the root only with ThemeProvider. You
-  should use BaseProvider instead to support correct layering. Plase note that
+  should use BaseProvider instead to support correct layering. Please note that
   this component adds an <b>additional div</b> that could impact your layout.
 </Notification>
 


### PR DESCRIPTION
Older apps using ThemeProvider switching to BaseProvider can run into a problem with styling since it adds a wrapping div. There was an internal incident because of that - let's add a note into docs.
