### PR TITLE
fix(menu): add onMouseDown prop to OptionListProps

### DIFF
--- a/src/menu/index.d.ts
+++ b/src/menu/index.d.ts
@@ -123,6 +123,7 @@ export interface OptionListProps extends BaseMenuPropsT {
   item: any;
   getItemLabel: (item: any) => React.ReactNode;
   getChildMenu?: (item: any) => React.ReactNode;
+  onMouseDown?: (event: MouseEvent) => any;
   onMouseEnter?: (event: MouseEvent) => any;
   size?: OPTION_LIST_SIZE[keyof OPTION_LIST_SIZE];
   overrides?: {

--- a/src/menu/types.js
+++ b/src/menu/types.js
@@ -234,6 +234,8 @@ export type OptionListPropsT = {
   getChildMenu?: (item: ItemT) => React.Node,
   onClick?: (event: MouseEvent) => mixed,
   /** Callback used to change highlighted index in stateful menu. */
+  onMouseDown?: (event: MouseEvent) => mixed,
+  /** Callback used to change highlighted index in stateful menu. */
   onMouseEnter?: (event: MouseEvent) => mixed,
   /** Renders UI in defined scale. */
   size?: $Keys<typeof OPTION_LIST_SIZE>,


### PR DESCRIPTION
Add onMouseDown prop to OptionListProps, as this is present in dropdown.js:
https://github.com/uber/baseweb/blob/master/src/select/dropdown.js#L188
